### PR TITLE
Fix analysis findings and prep local Sonar runs

### DIFF
--- a/ASFWDriver/ASFWDriver.cpp
+++ b/ASFWDriver/ASFWDriver.cpp
@@ -39,6 +39,7 @@
 #include "Async/ResponseCode.hpp"
 #include "Audio/AudioCoordinator.hpp"
 #include "Bus/SelfIDCapture.hpp"
+#include "Common/DriverKitOwnership.hpp"
 #include "ConfigROM/ConfigROMStager.hpp"
 #include "ConfigROM/ROMReader.hpp"
 #include "ConfigROM/ROMScanner.hpp"
@@ -396,6 +397,8 @@ kern_return_t ASFWDriver::CopyControllerStatus(OSDictionary** status) {
     return kIOReturnSuccess;
 }
 
+// Positional out-parameters are part of the existing driver/user-client contract.
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 kern_return_t ASFWDriver::CopyControllerSnapshot(OSDictionary** status, uint64_t* sequence,
                                                  uint64_t* timestamp) {
     if (status) {
@@ -699,14 +702,15 @@ kern_return_t ASFWDriver::StartIsochReceive(uint8_t channel) {
 
     nub->EnsureRxQueueCreated();
 
-    OSSharedPtr<IOBufferMemoryDescriptor> rxMem{};
+    IOBufferMemoryDescriptor* rxMemRaw = nullptr;
     uint64_t rxBytes = 0;
-    const kern_return_t rxCopy = nub->CopyRxQueueMemory(rxMem.attach(), &rxBytes);
+    const kern_return_t rxCopy = nub->CopyRxQueueMemory(&rxMemRaw, &rxBytes);
+    auto rxMem = ASFW::Common::AdoptRetained(rxMemRaw);
     if (rxCopy != kIOReturnSuccess || !rxMem || rxBytes == 0) {
         return (rxCopy == kIOReturnSuccess) ? kIOReturnNoMemory : rxCopy;
     }
 
-    return ctx.isoch.StartReceive(channel, *ctx.deps.hardware, rxMem.detach(), rxBytes);
+    return ctx.isoch.StartReceive(channel, *ctx.deps.hardware, rxMem, rxBytes);
 }
 
 kern_return_t ASFWDriver::StopIsochReceive() {
@@ -751,9 +755,10 @@ kern_return_t ASFWDriver::StartIsochTransmit(uint8_t channel) {
         return kIOReturnNotReady;
     }
 
-    OSSharedPtr<IOBufferMemoryDescriptor> txMem{};
+    IOBufferMemoryDescriptor* txMemRaw = nullptr;
     uint64_t txBytes = 0;
-    const kern_return_t txCopy = nub->CopyTransmitQueueMemory(txMem.attach(), &txBytes);
+    const kern_return_t txCopy = nub->CopyTransmitQueueMemory(&txMemRaw, &txBytes);
+    auto txMem = ASFW::Common::AdoptRetained(txMemRaw);
     if (txCopy != kIOReturnSuccess || !txMem || txBytes == 0) {
         return (txCopy == kIOReturnSuccess) ? kIOReturnNoMemory : txCopy;
     }
@@ -772,7 +777,7 @@ kern_return_t ASFWDriver::StartIsochTransmit(uint8_t channel) {
     const uint32_t streamModeRaw = nub->GetStreamMode();
 
     return ctx.isoch.StartTransmit(channel, *ctx.deps.hardware, sid, streamModeRaw, pcmChannels,
-                                   am824Slots, txMem.detach(), txBytes, nullptr, 0, 0);
+                                   am824Slots, txMem, txBytes, nullptr, 0, 0);
 }
 
 kern_return_t ASFWDriver::StopIsochTransmit() {

--- a/ASFWDriver/Async/AsyncSubsystem.hpp
+++ b/ASFWDriver/Async/AsyncSubsystem.hpp
@@ -86,7 +86,7 @@ class AsyncSubsystem : public IAsyncControllerPort {
 
     kern_return_t Start(Driver::HardwareInterface& hw, OSObject* owner,
                         ::IODispatchQueue* workloopQueue, ::OSAction* completionAction,
-                        size_t completionQueueCapacityBytes = 64 * 1024);
+                        size_t completionQueueCapacityBytes = size_t{64} * 1024u);
 
     kern_return_t ArmDMAContexts();
 
@@ -250,6 +250,12 @@ class AsyncSubsystem : public IAsyncControllerPort {
 
     void HandleSyntheticBusResetPacket(const uint32_t* quadlets, uint8_t newGeneration);
     void Teardown(bool disableHardware);
+    [[nodiscard]] kern_return_t InitializeCoreStartState(size_t completionQueueCapacityBytes,
+                                                         const char*& failureStage);
+    [[nodiscard]] kern_return_t ProvisionAsyncDataPath(const char*& failureStage);
+    void FinalizeStart();
+    [[nodiscard]] kern_return_t FailStart(const char* failureStage, kern_return_t kr);
+    void ResetWatchdogCounters() noexcept;
 
     [[nodiscard]] bool EnsureATContextsRunning(const char* reason);
 

--- a/ASFWDriver/Async/AsyncSubsystemDiagnostics.cpp
+++ b/ASFWDriver/Async/AsyncSubsystemDiagnostics.cpp
@@ -18,8 +18,10 @@ std::optional<AsyncStatusSnapshot> AsyncSubsystem::GetStatusSnapshot() const {
         }
     }
 
+    // Positional arguments mirror the snapshot fields being copied.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     auto populateDescriptor = [](AsyncDescriptorStatus& out, const DescriptorRing* ring,
-                                 const uint8_t* virt, uint64_t iova, uint32_t commandPtr,
+                                 const uint8_t* virt, uint64_t iova, uint32_t commandPtr, // NOLINT(bugprone-easily-swappable-parameters)
                                  uint32_t count, uint32_t stride, uint32_t strideFallback) {
         out.descriptorVirt = reinterpret_cast<uint64_t>(virt);
         out.descriptorIOVA = iova;

--- a/ASFWDriver/Async/AsyncSubsystemLifecycle.cpp
+++ b/ASFWDriver/Async/AsyncSubsystemLifecycle.cpp
@@ -71,7 +71,7 @@ constexpr uint32_t kLinkControlRcvPhyPktBit = 1u << 12;
 //   - See packet trace: 060:3279:1136 (s400) → 060:3291:0385 (s100)
 // FIXED: Speed encoding bug corrected in PacketBuilder.cpp (shift 16→24 per OHCI spec)
 constexpr uint8_t kDefaultAsyncSpeed = 0; // S100 (98.304 Mbps)
-constexpr size_t kDefaultCompletionQueueCapacity = 64 * 1024;
+constexpr size_t kDefaultCompletionQueueCapacity = size_t{64} * 1024u;
 
 bool ShouldEnableCoherencyTrace(OSObject* owner) {
     bool enabled = false;
@@ -286,6 +286,157 @@ struct PayloadContext {
 
 } // namespace
 
+kern_return_t AsyncSubsystem::InitializeCoreStartState(size_t completionQueueCapacityBytes,
+                                                       const char*& failureStage) {
+    if (!labelAllocator_) {
+        labelAllocator_ = std::make_unique<LabelAllocator>();
+    }
+    labelAllocator_->Reset();
+
+    sharedLock_ = ::IOLockAlloc();
+    if (!sharedLock_) {
+        failureStage = "AllocSharedLock";
+        return kIOReturnNoMemory;
+    }
+
+    commandQueue_ = std::make_unique<std::deque<PendingCommandPtr>>();
+    commandQueueLock_ = ::IOLockAlloc();
+    if (!commandQueueLock_) {
+        failureStage = "AllocCommandQueueLock";
+        return kIOReturnNoMemory;
+    }
+    commandInFlight_.store(false, std::memory_order_release);
+
+    txnMgr_ = std::make_unique<TransactionManager>();
+    Result<void> txnMgrResult = txnMgr_->Initialize();
+    if (!txnMgrResult) {
+        txnMgrResult.error().Log();
+        failureStage = "TransactionManager";
+        return txnMgrResult.error().BoundaryStatus();
+    }
+
+    if (!generationTracker_) {
+        generationTracker_ = std::make_unique<ASFW::Async::Bus::GenerationTracker>(*labelAllocator_);
+    }
+    generationTracker_->Reset();
+
+    packetBuilder_ = std::make_unique<PacketBuilder>();
+
+    std::unique_ptr<CompletionQueue> completionQueue;
+    const kern_return_t kr = CompletionQueue::Create(workloopQueue_, completionQueueCapacityBytes,
+                                                     completionAction_.get(), completionQueue);
+    if (kr != kIOReturnSuccess || !completionQueue) {
+        ASFW_LOG(Async, "FAILED: CompletionQueue::Create returned 0x%08x", kr);
+        failureStage = "CompletionQueue";
+        return kr != kIOReturnSuccess ? kr : kIOReturnNoMemory;
+    }
+
+    completionQueue_ = std::move(completionQueue);
+    completionQueue_->SetClientBound();
+    completionQueue_->Activate();
+
+    tracking_ = std::make_unique<Track_Tracking<CompletionQueue>>(
+        labelAllocator_.get(), txnMgr_.get(), *completionQueue_, nullptr);
+    return kIOReturnSuccess;
+}
+
+kern_return_t AsyncSubsystem::ProvisionAsyncDataPath(const char*& failureStage) {
+    constexpr size_t kATReqDescCount = 256;
+    constexpr size_t kATRespDescCount = 64;
+    constexpr size_t kARReqBufferCount = 128;
+    constexpr size_t kARReqBufferSize = 4096 + 64;
+    constexpr size_t kARRespBufferCount = 256;
+    constexpr size_t kARRespBufferSize = 4096 + 64;
+
+    contextManager_ = std::make_unique<Engine::ContextManager>();
+
+    Engine::ProvisionSpec spec{};
+    spec.atReqDescCount = kATReqDescCount;
+    spec.atRespDescCount = kATRespDescCount;
+    spec.arReqBufCount = kARReqBufferCount;
+    spec.arReqBufSize = kARReqBufferSize;
+    spec.arRespBufCount = kARRespBufferCount;
+    spec.arRespBufSize = kARRespBufferSize;
+
+    const kern_return_t provisionKr = contextManager_->provision(*hardware_, spec);
+    if (provisionKr != kIOReturnSuccess) {
+        ASFW_LOG(Async, "FAILED: ContextManager::provision (kr=0x%08x)", provisionKr);
+        failureStage = "ContextManagerProvision";
+        return provisionKr;
+    }
+
+    DMAMemoryManager::SetTracingEnabled(ShouldEnableCoherencyTrace(owner_));
+    if (DMAMemoryManager::IsTracingEnabled()) {
+        ASFW_LOG(Async, "AsyncSubsystem: coherency tracing enabled (ASFWTraceDMACoherency)");
+    }
+
+    descriptorBuilder_ = contextManager_->GetDescriptorBuilderRequest();
+    descriptorBuilderResponse_ = contextManager_->GetDescriptorBuilderResponse();
+
+    if (!descriptorBuilder_) {
+        ASFW_LOG_ERROR(Async, "AsyncSubsystem: descriptorBuilder (request) unavailable");
+        failureStage = "DescriptorBuilderReq";
+        return kIOReturnNoResources;
+    }
+    if (!descriptorBuilderResponse_) {
+        ASFW_LOG_ERROR(Async, "AsyncSubsystem: descriptorBuilder (response) unavailable");
+        failureStage = "DescriptorBuilderRsp";
+        return kIOReturnNoResources;
+    }
+
+    submitter_ = std::make_unique<Tx::Submitter>(*contextManager_, *descriptorBuilder_);
+    if (tracking_ && contextManager_) {
+        contextManager_->SetPayloads(tracking_->Payloads());
+        if (submitter_) {
+            submitter_->SetPayloads(tracking_->Payloads());
+        }
+
+        tracking_->SetContextManager(contextManager_.get());
+    }
+
+    packetRouter_ = std::make_unique<PacketRouter>();
+    rxPath_ = std::make_unique<Rx::RxPath>(*contextManager_->GetArRequestContext(),
+                                           *contextManager_->GetArResponseContext(), *tracking_,
+                                           *generationTracker_, *packetRouter_);
+
+    responseSender_ = std::make_unique<ResponseSender>(*descriptorBuilderResponse_, *submitter_,
+                                                       *contextManager_, *generationTracker_);
+    packetRouter_->SetResponseSender(responseSender_.get());
+
+    ASFW_LOG(Async, "✓ ContextManager provisioned");
+    return kIOReturnSuccess;
+}
+
+void AsyncSubsystem::ResetWatchdogCounters() noexcept {
+    watchdogTickCount_.store(0, std::memory_order_relaxed);
+    watchdogExpiredCount_.store(0, std::memory_order_relaxed);
+    watchdogDrainedCompletions_.store(0, std::memory_order_relaxed);
+    watchdogContextsRearmed_.store(0, std::memory_order_relaxed);
+    watchdogLastTickUsec_.store(0, std::memory_order_relaxed);
+}
+
+void AsyncSubsystem::FinalizeStart() {
+    busResetCapture_ = std::make_unique<Debug::BusResetPacketCapture>();
+
+    hardware_->SetInterruptMask(kAsyncInterruptMask, true);
+    hardware_->SetLinkControlBits(kLinkControlRcvPhyPktBit);
+
+    // Report DMA cache mode (always uncached since kIOMemoryMapCacheModeInhibit works reliably)
+    ASFW_LOG_TYPE(Async, OS_LOG_TYPE_INFO, "AsyncSubsystem::Start complete (DMA always uncached)");
+
+    ResetWatchdogCounters();
+    is_bus_reset_in_progress_.store(0, std::memory_order_release);
+    isRunning_ = true;
+}
+
+kern_return_t AsyncSubsystem::FailStart(const char* failureStage, kern_return_t kr) {
+    ASFW_LOG_TYPE(Async, OS_LOG_TYPE_ERROR,
+                  "AsyncSubsystem::Start failed at stage %{public}s (kr=0x%08x)",
+                  failureStage ? failureStage : "unknown", kr);
+    Teardown(false);
+    return kr == kIOReturnSuccess ? kIOReturnError : kr;
+}
+
 kern_return_t AsyncSubsystem::Start(Driver::HardwareInterface& hw, OSObject* owner,
                                     IODispatchQueue* workloopQueue, OSAction* completionAction,
                                     size_t completionQueueCapacityBytes) {
@@ -305,167 +456,25 @@ kern_return_t AsyncSubsystem::Start(Driver::HardwareInterface& hw, OSObject* own
     }
 
     // Initial bus state is managed by GenerationTracker. Reset tracker state now.
-
     hardware_ = &hw;
     owner_ = owner;
     workloopQueue_ = workloopQueue;
     completionAction_ = OSSharedPtr(completionAction, OSRetain);
 
-    kern_return_t kr = kIOReturnSuccess;
     const char* failureStage = nullptr;
-
-    if (!labelAllocator_) {
-        labelAllocator_ = std::make_unique<LabelAllocator>();
-    }
-    labelAllocator_->Reset();
-
-    Result<void> txnMgrResult = {};
-    std::unique_ptr<CompletionQueue> completionQueue;
-
-    sharedLock_ = ::IOLockAlloc();
-    if (!sharedLock_) {
-        kr = kIOReturnNoMemory;
-        failureStage = "AllocSharedLock";
-        goto fail;
+    const kern_return_t coreKr =
+        InitializeCoreStartState(completionQueueCapacityBytes, failureStage);
+    if (coreKr != kIOReturnSuccess) {
+        return FailStart(failureStage, coreKr);
     }
 
-    commandQueue_ = std::make_unique<std::deque<PendingCommandPtr>>();
-    commandQueueLock_ = ::IOLockAlloc();
-    if (!commandQueueLock_) {
-        kr = kIOReturnNoMemory;
-        failureStage = "AllocCommandQueueLock";
-        goto fail;
-    }
-    commandInFlight_.store(false, std::memory_order_release);
-
-    txnMgr_ = std::make_unique<TransactionManager>();
-    txnMgrResult = txnMgr_->Initialize();
-    if (!txnMgrResult) {
-        txnMgrResult.error().Log();
-        kr = txnMgrResult.error().BoundaryStatus();
-        failureStage = "TransactionManager";
-        goto fail;
+    const kern_return_t provisionKr = ProvisionAsyncDataPath(failureStage);
+    if (provisionKr != kIOReturnSuccess) {
+        return FailStart(failureStage, provisionKr);
     }
 
-    if (!generationTracker_) {
-        generationTracker_ =
-            std::make_unique<ASFW::Async::Bus::GenerationTracker>(*labelAllocator_);
-    }
-    generationTracker_->Reset();
-
-    packetBuilder_ = std::make_unique<PacketBuilder>();
-
-    {
-        kr = CompletionQueue::Create(workloopQueue_, completionQueueCapacityBytes,
-                                     completionAction_.get(), completionQueue);
-        if (kr != kIOReturnSuccess || !completionQueue) {
-            ASFW_LOG(Async, "FAILED: CompletionQueue::Create returned 0x%08x", kr);
-            failureStage = "CompletionQueue";
-            goto fail;
-        }
-        completionQueue_ = std::move(completionQueue);
-
-        completionQueue_->SetClientBound();
-        completionQueue_->Activate();
-    }
-
-    tracking_ = std::make_unique<Track_Tracking<CompletionQueue>>(
-        labelAllocator_.get(), txnMgr_.get(), *completionQueue_, nullptr);
-
-    {
-        constexpr size_t kATReqDescCount = 256;
-        constexpr size_t kATRespDescCount = 64;
-        constexpr size_t kARReqBufferCount = 128;
-        constexpr size_t kARReqBufferSize = 4096 + 64;
-        constexpr size_t kARRespBufferCount = 256;
-        constexpr size_t kARRespBufferSize = 4096 + 64;
-
-        contextManager_ = std::make_unique<Engine::ContextManager>();
-        Engine::ProvisionSpec spec{};
-        spec.atReqDescCount = kATReqDescCount;
-        spec.atRespDescCount = kATRespDescCount;
-        spec.arReqBufCount = kARReqBufferCount;
-        spec.arReqBufSize = kARReqBufferSize;
-        spec.arRespBufCount = kARRespBufferCount;
-        spec.arRespBufSize = kARRespBufferSize;
-
-        kern_return_t pkr = contextManager_->provision(*hardware_, spec);
-        if (pkr != kIOReturnSuccess) {
-            ASFW_LOG(Async, "FAILED: ContextManager::provision (kr=0x%08x)", pkr);
-            kr = pkr;
-            failureStage = "ContextManagerProvision";
-            goto fail;
-        }
-
-        DMAMemoryManager::SetTracingEnabled(ShouldEnableCoherencyTrace(owner_));
-        if (DMAMemoryManager::IsTracingEnabled()) {
-            ASFW_LOG(Async, "AsyncSubsystem: coherency tracing enabled (ASFWTraceDMACoherency)");
-        }
-
-        descriptorBuilder_ = contextManager_->GetDescriptorBuilderRequest();
-        descriptorBuilderResponse_ = contextManager_->GetDescriptorBuilderResponse();
-
-        if (!descriptorBuilder_) {
-            ASFW_LOG_ERROR(Async, "AsyncSubsystem: descriptorBuilder (request) unavailable");
-            kr = kIOReturnNoResources;
-            failureStage = "DescriptorBuilderReq";
-            goto fail;
-        }
-        if (!descriptorBuilderResponse_) {
-            ASFW_LOG_ERROR(Async, "AsyncSubsystem: descriptorBuilder (response) unavailable");
-            kr = kIOReturnNoResources;
-            failureStage = "DescriptorBuilderRsp";
-            goto fail;
-        }
-
-        submitter_ = std::make_unique<Tx::Submitter>(*contextManager_, *descriptorBuilder_);
-        if (tracking_ && contextManager_) {
-            contextManager_->SetPayloads(tracking_->Payloads());
-            if (submitter_)
-                submitter_->SetPayloads(tracking_->Payloads());
-
-            tracking_->SetContextManager(contextManager_.get());
-        }
-
-        packetRouter_ = std::make_unique<PacketRouter>();
-        rxPath_ = std::make_unique<Rx::RxPath>(*contextManager_->GetArRequestContext(),
-                                               *contextManager_->GetArResponseContext(), *tracking_,
-                                               *generationTracker_, *packetRouter_);
-
-        responseSender_ = std::make_unique<ResponseSender>(*descriptorBuilderResponse_, *submitter_,
-                                                           *contextManager_, *generationTracker_);
-        packetRouter_->SetResponseSender(responseSender_.get());
-
-        ASFW_LOG(Async, "✓ ContextManager provisioned");
-    }
-
-    busResetCapture_ = std::make_unique<Debug::BusResetPacketCapture>();
-
-    hardware_->SetInterruptMask(kAsyncInterruptMask, true);
-    hardware_->SetLinkControlBits(kLinkControlRcvPhyPktBit);
-
-    // Report DMA cache mode (always uncached since kIOMemoryMapCacheModeInhibit works reliably)
-    ASFW_LOG_TYPE(Async, OS_LOG_TYPE_INFO, "AsyncSubsystem::Start complete (DMA always uncached)");
-
-    watchdogTickCount_.store(0, std::memory_order_relaxed);
-    watchdogExpiredCount_.store(0, std::memory_order_relaxed);
-    watchdogDrainedCompletions_.store(0, std::memory_order_relaxed);
-    watchdogContextsRearmed_.store(0, std::memory_order_relaxed);
-    watchdogLastTickUsec_.store(0, std::memory_order_relaxed);
-
-    is_bus_reset_in_progress_.store(0, std::memory_order_release);
-    isRunning_ = true;
+    FinalizeStart();
     return kIOReturnSuccess;
-
-fail:
-    ASFW_LOG_TYPE(Async, OS_LOG_TYPE_ERROR,
-                  "AsyncSubsystem::Start failed at stage %{public}s (kr=0x%08x)",
-                  failureStage ? failureStage : "unknown", kr);
-    Teardown(false);
-    if (kr == kIOReturnSuccess) {
-        kr = kIOReturnError;
-    }
-    return kr;
 }
 
 kern_return_t AsyncSubsystem::ArmDMAContexts() {

--- a/ASFWDriver/Async/AsyncTypes.hpp
+++ b/ASFWDriver/Async/AsyncTypes.hpp
@@ -156,29 +156,46 @@ enum class AsyncStatus : uint8_t {
  * Default constructor creates invalid address (0xdead:0xcafebabe) per Apple convention.
  */
 struct FWAddress {
+    struct AddressParts {
+        uint16_t addressHi{0};
+        uint32_t addressLo{0};
+    };
+
+    struct QualifiedAddressParts {
+        uint16_t addressHi{0};
+        uint32_t addressLo{0};
+        uint16_t nodeID{0};
+    };
+
+    struct PackedAddressSource {
+        uint64_t target{0};
+        uint16_t nodeIDOverride{0};
+    };
+
     uint16_t nodeID{0};      ///< Bus/node identifier (bus[15:10], node[5:0])
     uint16_t addressHi{0};   ///< Top 16 bits of 48-bit address
     uint32_t addressLo{0};   ///< Bottom 32 bits of 48-bit address
 
     /// Default constructor: invalid address (0xdead:0xcafebabe per Apple)
-    FWAddress() : nodeID(0), addressHi(0xdead), addressLo(0xcafebabe) {}
+    constexpr FWAddress() noexcept : nodeID(0), addressHi(0xdead), addressLo(0xcafebabe) {}
 
     /// Constructor with address only (nodeID defaults to 0)
-    FWAddress(uint16_t h, uint32_t l) : nodeID(0), addressHi(h), addressLo(l) {}
+    constexpr explicit FWAddress(AddressParts parts) noexcept
+        : nodeID(0), addressHi(parts.addressHi), addressLo(parts.addressLo) {}
 
     /// Full constructor with nodeID
-    FWAddress(uint16_t h, uint32_t l, uint16_t n) : nodeID(n), addressHi(h), addressLo(l) {}
+    constexpr explicit FWAddress(QualifiedAddressParts parts) noexcept
+        : nodeID(parts.nodeID), addressHi(parts.addressHi), addressLo(parts.addressLo) {}
 
     /// Copy constructor
-    FWAddress(const FWAddress& a) : nodeID(a.nodeID), addressHi(a.addressHi), addressLo(a.addressLo) {}
+    constexpr FWAddress(const FWAddress& a) noexcept = default;
 
-    /// Create FWAddress from 64-bit target (Apple IOFWUserCommand pattern)
-    /// @param target 64-bit address: bits[63:48] = nodeID, bits[47:32] = addressHi, bits[31:0] = addressLo
-    /// @param nodeIDOverride Optional override for nodeID (if provided, overrides target[63:48])
-    static FWAddress FromU64(uint64_t target, uint16_t nodeIDOverride = 0) {
-        FWAddress addr = FW::Unpack(target);
-        if (nodeIDOverride != 0) {
-            addr.nodeID = nodeIDOverride;
+    /// Create FWAddress from packed address source (Apple IOFWUserCommand pattern)
+    /// @param source Packed source where target encodes nodeID/address and nodeIDOverride optionally replaces target[63:48]
+    static FWAddress FromU64(PackedAddressSource source) {
+        FWAddress addr = FW::Unpack(source.target);
+        if (source.nodeIDOverride != 0) {
+            addr.nodeID = source.nodeIDOverride;
         }
         return addr;
     }

--- a/ASFWDriver/Async/Contexts/ARContextBase.hpp
+++ b/ASFWDriver/Async/Contexts/ARContextBase.hpp
@@ -229,14 +229,14 @@ kern_return_t ARContextBase<Derived, Tag>::Initialize(
     lock_ = IOLockAlloc();
     if (!lock_) {
         ASFW_LOG(Async, "%{public}s: failed to allocate lock",
-                 this->ContextName().data());
+                 this->ContextNameCString());
         return kIOReturnNoMemory;
     }
 
     bufferRing_ = &bufferRing;
 
     ASFW_LOG(Async, "%{public}s: initialized with %zu buffers x %zu bytes",
-             this->ContextName().data(),
+             this->ContextNameCString(),
              bufferRing.BufferCount(),
              bufferRing.BufferSize());
 
@@ -247,13 +247,13 @@ template<typename Derived, ContextRole Tag>
 kern_return_t ARContextBase<Derived, Tag>::Arm(uint32_t commandPtr) noexcept {
     if (!this->hw_) {
         ASFW_LOG(Async, "%{public}s: Arm called before Initialize",
-                 this->ContextName().data());
+                 this->ContextNameCString());
         return kIOReturnNotReady;
     }
 
     // Check if already running
     if (this->IsRunning()) {
-        ASFW_LOG(Async, "%{public}s: already running", this->ContextName().data());
+        ASFW_LOG(Async, "%{public}s: already running", this->ContextNameCString());
         return kIOReturnBusy;
     }
 
@@ -277,14 +277,14 @@ kern_return_t ARContextBase<Derived, Tag>::Arm(uint32_t commandPtr) noexcept {
     for (int i = 0; i < 50; ++i) {
         if (this->IsActive()) {
             ASFW_LOG(Async, "%{public}s: armed and active (CommandPtr=0x%08x)",
-                     this->ContextName().data(), commandPtr);
+                     this->ContextNameCString(), commandPtr);
             return kIOReturnSuccess;
         }
         IOSleep(1);  // 1ms delay
     }
 
     ASFW_LOG(Async, "%{public}s: armed (info: not active yet after 50ms, may activate after reset)",
-             this->ContextName().data());
+             this->ContextNameCString());
     // Not fatal - hardware may start later
     return kIOReturnSuccess;
 }
@@ -312,14 +312,14 @@ kern_return_t ARContextBase<Derived, Tag>::Stop(uint32_t timeoutMs) noexcept {
     for (uint32_t elapsed = 0; elapsed < timeoutMs; elapsed += kPollIntervalMs) {
         if (!this->IsActive()) {
             ASFW_LOG(Async, "%{public}s: stopped after %u ms",
-                     this->ContextName().data(), elapsed);
+                     this->ContextNameCString(), elapsed);
             return kIOReturnSuccess;
         }
         IOSleep(kPollIntervalMs);
     }
 
     ASFW_LOG(Async, "%{public}s: stop timeout after %u ms (still active)",
-             this->ContextName().data(), timeoutMs);
+             this->ContextNameCString(), timeoutMs);
     return kIOReturnTimeout;
 }
 
@@ -387,11 +387,11 @@ kern_return_t ARContextBase<Derived, Tag>::Recycle(size_t index) noexcept {
         // DIAGNOSTIC: Log wake bit write to trace hardware notification
         ASFW_LOG(Async,
                  "♻️  %{public}s: Wrote WAKE bit after recycling buffer[%zu]",
-                 this->ContextName().data(), index);
+                 this->ContextNameCString(), index);
     } else {
         ASFW_LOG(Async,
                  "⚠️  %{public}s: Recycle failed for buffer[%zu], kr=0x%08x (wake NOT written)",
-                 this->ContextName().data(), index, result);
+                 this->ContextNameCString(), index, result);
     }
 
     IOLockUnlock(lock_);

--- a/ASFWDriver/Async/Contexts/ContextBase.hpp
+++ b/ASFWDriver/Async/Contexts/ContextBase.hpp
@@ -25,7 +25,7 @@ namespace ASFW::Async {
  *     static constexpr Driver::Register32 kControlSetReg = ...;
  *     static constexpr Driver::Register32 kControlClearReg = ...;
  *     static constexpr Driver::Register32 kCommandPtrReg = ...;
- *     static constexpr std::string_view kContextName = "My Context";
+ *     static constexpr const char kContextName[] = "My Context";
  * };
  * static_assert(ContextRole<MyContextTag>);
  * \endcode
@@ -56,7 +56,7 @@ struct ATRequestTag {
         static_cast<Driver::Register32>(DMAContextHelpers::AsReqTrContextControlClear);
     static constexpr Driver::Register32 kCommandPtrReg =
         static_cast<Driver::Register32>(DMAContextHelpers::AsReqTrCommandPtr);
-    static constexpr std::string_view kContextName = "AT Request";
+    static constexpr const char kContextName[] = "AT Request";
 };
 
 /**
@@ -77,7 +77,7 @@ struct ATResponseTag {
         static_cast<Driver::Register32>(DMAContextHelpers::AsRspTrContextControlClear);
     static constexpr Driver::Register32 kCommandPtrReg =
         static_cast<Driver::Register32>(DMAContextHelpers::AsRspTrCommandPtr);
-    static constexpr std::string_view kContextName = "AT Response";
+    static constexpr const char kContextName[] = "AT Response";
 };
 
 /**
@@ -102,7 +102,7 @@ struct ARRequestTag {
         static_cast<Driver::Register32>(DMAContextHelpers::AsReqRcvContextControlClear);
     static constexpr Driver::Register32 kCommandPtrReg =
         static_cast<Driver::Register32>(DMAContextHelpers::AsReqRcvCommandPtr);
-    static constexpr std::string_view kContextName = "AR Request";
+    static constexpr const char kContextName[] = "AR Request";
 };
 
 /**
@@ -123,7 +123,7 @@ struct ARResponseTag {
         static_cast<Driver::Register32>(DMAContextHelpers::AsRspRcvContextControlClear);
     static constexpr Driver::Register32 kCommandPtrReg =
         static_cast<Driver::Register32>(DMAContextHelpers::AsRspRcvCommandPtr);
-    static constexpr std::string_view kContextName = "AR Response";
+    static constexpr const char kContextName[] = "AR Response";
 };
 
 // Compile-time validation
@@ -272,6 +272,10 @@ public:
      * \return Human-readable context name from role tag
      */
     [[nodiscard]] constexpr std::string_view ContextName() const noexcept {
+        return Tag::kContextName;
+    }
+
+    [[nodiscard]] constexpr const char* ContextNameCString() const noexcept {
         return Tag::kContextName;
     }
 

--- a/ASFWDriver/Async/Core/Error.hpp
+++ b/ASFWDriver/Async/Core/Error.hpp
@@ -10,7 +10,6 @@
 #include "../../Logging/Logging.hpp"
 #include <DriverKit/IOReturn.h>
 #include <expected>
-#include <string_view>
 
 namespace ASFW::Async {
 
@@ -32,11 +31,14 @@ struct SourceLocation {
                              int l = __builtin_LINE()) noexcept
         : file(f), function(fn), line(l) {}
 
-    /// Extract filename from full path (strips directory)
-    [[nodiscard]] constexpr std::string_view FileName() const noexcept {
-        std::string_view path(file);
-        auto pos = path.find_last_of('/');
-        return (pos != std::string_view::npos) ? path.substr(pos + 1) : path;
+    [[nodiscard]] constexpr const char* FileNameCString() const noexcept {
+        const char* name = file;
+        for (const char* cursor = file; *cursor != '\0'; ++cursor) {
+            if (*cursor == '/') {
+                name = cursor + 1;
+            }
+        }
+        return name;
     }
 
     /// Format as "file:line" for compact logging
@@ -178,7 +180,7 @@ struct Error {
         ASFW_LOG_ERROR(Async,
                        "[%{public}s/%{public}s] %{public}s:%d in %{public}s() - status=0x%08x "
                        "(%{public}s)",
-                       ToString(severity), ToString(code), location.FileName().data(),
+                       ToString(severity), ToString(code), location.FileNameCString(),
                        location.line, location.function, boundaryStatus, message);
     }
 
@@ -186,7 +188,7 @@ struct Error {
         ASFW_LOG(Async,
                  "[%{public}s/%{public}s] %{public}s:%d in %{public}s() - status=0x%08x "
                  "(%{public}s)",
-                 ToString(severity), ToString(code), location.FileName().data(), location.line,
+                 ToString(severity), ToString(code), location.FileNameCString(), location.line,
                  location.function, boundaryStatus, message);
     }
 };

--- a/ASFWDriver/Async/Core/Transaction.hpp
+++ b/ASFWDriver/Async/Core/Transaction.hpp
@@ -75,6 +75,7 @@ enum class TransactionState : uint8_t {
 };
 
 // Compile-time state transition validation (encodes IEEE 1394 protocol)
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 constexpr bool IsValidTransition(TransactionState from, TransactionState to) noexcept {
     switch (from) {
         case TransactionState::Created:

--- a/ASFWDriver/Async/Engine/ATManagerImpl.hpp
+++ b/ASFWDriver/Async/Engine/ATManagerImpl.hpp
@@ -36,7 +36,7 @@ inline const char* ToString(ATState s) noexcept {
 template<typename ContextT, typename RingT, typename RoleTag>
 kern_return_t ATManager<ContextT, RingT, RoleTag>::Submit(DescriptorChain&& chain, const AsyncCmdOptions& opts) {
     if (chain.Empty()) {
-        ASFW_LOG_ERROR(Async, "[%{public}s] Submit: Empty chain", RoleTag::kContextName.data());
+        ASFW_LOG_ERROR(Async, "[%{public}s] Submit: Empty chain", RoleTag::kContextName);
         return kIOReturnBadArgument;
     }
 
@@ -72,7 +72,7 @@ kern_return_t ATManager<ContextT, RingT, RoleTag>::Submit(DescriptorChain&& chai
             return kIOReturnSuccess;
         }
         // Fall through to PATH 1 fallback on failure
-        ASFW_LOG_V2(Async, "[%{public}s] PATH 2 failed, falling back to PATH 1", RoleTag::kContextName.data());
+        ASFW_LOG_V2(Async, "[%{public}s] PATH 2 failed, falling back to PATH 1", RoleTag::kContextName);
     }
 
     // V1: Compact AT transmit one-liner for packet flow visibility
@@ -121,7 +121,7 @@ kern_return_t ATManager<ContextT, RingT, RoleTag>::SubmitPath1_(const Descriptor
     ctx().WriteCommandPtr(cmdPtr);
     ctx().WriteControlSet(kContextControlRunBit);
 
-    ASFW_LOG_V3(Async, "ctx=%{public}s txid=%u gen=%u P1_ARM head=%lu tail=%lu z=%u cmdPtr=0x%08x", RoleTag::kContextName.data(), txid, generation_, (unsigned long)ring().Head(), (unsigned long)ring().Tail(), z, cmdPtr);
+    ASFW_LOG_V3(Async, "ctx=%{public}s txid=%u gen=%u P1_ARM head=%lu tail=%lu z=%u cmdPtr=0x%08x", RoleTag::kContextName, txid, generation_, (unsigned long)ring().Head(), (unsigned long)ring().Tail(), z, cmdPtr);
 
     trace_.push({NowNs(), txid, generation_, ATEvent::P1_ARM, cmdPtr, z});
 
@@ -162,7 +162,7 @@ kern_return_t ATManager<ContextT, RingT, RoleTag>::SubmitPath2_(const Descriptor
     if (linkResult != kIOReturnSuccess) {
         ASFW_LOG_V2(Async,
                     "ctx=%{public}s txid=%u gen=%u P2_FALLBACK cause=%{public}s",
-                    RoleTag::kContextName.data(),
+                    RoleTag::kContextName,
                     txid,
                     generation_,
                     "LinkTailTo");
@@ -178,10 +178,10 @@ kern_return_t ATManager<ContextT, RingT, RoleTag>::SubmitPath2_(const Descriptor
     const bool run = (ctrl & kContextControlRunBit) != 0;
     const bool dead = (ctrl & kContextControlDeadBit) != 0;
 
-    ASFW_LOG_V3(Async, "ctx=%{public}s txid=%u gen=%u WAKE_GUARD ctrl=0x%08x run=%d dead=%d", RoleTag::kContextName.data(), txid, generation_, ctrl, run ? 1 : 0, dead ? 1 : 0);
+    ASFW_LOG_V3(Async, "ctx=%{public}s txid=%u gen=%u WAKE_GUARD ctrl=0x%08x run=%d dead=%d", RoleTag::kContextName, txid, generation_, ctrl, run ? 1 : 0, dead ? 1 : 0);
 
     if (!run || dead) {
-        ASFW_LOG_V2(Async, "ctx=%{public}s txid=%u gen=%u P2_FALLBACK cause=%{public}s", RoleTag::kContextName.data(), txid, generation_, !run ? "RUN0" : "DEAD");
+        ASFW_LOG_V2(Async, "ctx=%{public}s txid=%u gen=%u P2_FALLBACK cause=%{public}s", RoleTag::kContextName, txid, generation_, !run ? "RUN0" : "DEAD");
         UnlinkTail_();
         trace_.push({NowNs(), txid, generation_, ATEvent::P2_FALLBACK, ctrl, 0});
         return kIOReturnNotReady;
@@ -192,7 +192,7 @@ kern_return_t ATManager<ContextT, RingT, RoleTag>::SubmitPath2_(const Descriptor
     // NO POLLING - Apple never polls ACTIVE after WAKE in PATH-2!
     ctx().WriteControlSet(kContextControlWakeBit);
 
-    ASFW_LOG_V3(Async, "ctx=%{public}s txid=%u gen=%u P2_WAKE pulsed", RoleTag::kContextName.data(), txid, generation_);
+    ASFW_LOG_V3(Async, "ctx=%{public}s txid=%u gen=%u P2_WAKE pulsed", RoleTag::kContextName, txid, generation_);
     trace_.push({NowNs(), txid, generation_, ATEvent::P2_WAKE, 0, 0});
 
     // Ring update under lock
@@ -223,7 +223,7 @@ void ATManager<ContextT, RingT, RoleTag>::RequestStop(uint32_t txid, const char*
 template<typename ContextT, typename RingT, typename RoleTag>
 void ATManager<ContextT, RingT, RoleTag>::requestStop_(uint32_t txid, const char* why) noexcept {
     if (this->state_ != State::RUNNING) {
-        ASFW_LOG_V2(Async, "ctx=%{public}s txid=%u gen=%u STOP_SKIP state=%{public}s", RoleTag::kContextName.data(), txid, generation_, ToString(this->state_));
+        ASFW_LOG_V2(Async, "ctx=%{public}s txid=%u gen=%u STOP_SKIP state=%{public}s", RoleTag::kContextName, txid, generation_, ToString(this->state_));
         return;
     }
 
@@ -248,14 +248,14 @@ void ATManager<ContextT, RingT, RoleTag>::requestStop_(uint32_t txid, const char
     // Verify ring is empty before rotation
     if (ring().Head() != ring().Tail()) {
         ASFW_LOG_ERROR(Async, "[%{public}s] STOP: Ring not empty (head=%zu tail=%zu)",
-                       RoleTag::kContextName.data(), ring().Head(), ring().Tail());
+                       RoleTag::kContextName, ring().Head(), ring().Tail());
     }
 
     rotateRingBy2_();
     ring().SetPrevLastBlocks(0);
     ++generation_;
 
-    ASFW_LOG_V2(Async, "ctx=%{public}s txid=%u gen=%u STOP_IMM why=%{public}s elapsed_us=%lu gen=%u", RoleTag::kContextName.data(), txid, generation_, why, (unsigned long)elapsed, generation_);
+    ASFW_LOG_V2(Async, "ctx=%{public}s txid=%u gen=%u STOP_IMM why=%{public}s elapsed_us=%lu gen=%u", RoleTag::kContextName, txid, generation_, why, (unsigned long)elapsed, generation_);
     trace_.push({NowNs(), txid, generation_, ATEvent::STOP_IMM, static_cast<uint32_t>(elapsed), generation_});
 
     Base::Transition(State::IDLE, txid, "stopped");

--- a/ASFWDriver/Async/Rx/RxPath.cpp
+++ b/ASFWDriver/Async/Rx/RxPath.cpp
@@ -52,7 +52,6 @@ void RxPath::ProcessARInterrupts(std::atomic<uint32_t>& is_bus_reset_in_progress
     {
         auto* ctx = &arRequestContext_;
         const char* ctxLabel = "AR Request";
-        const ARContextType ctxType = ARContextType::Request;
 
         auto recycle = [&](size_t descriptorIndex) {
             const kern_return_t recycleKr = ctx->Recycle(descriptorIndex);

--- a/ASFWDriver/Async/Track/Tracking.hpp
+++ b/ASFWDriver/Async/Track/Tracking.hpp
@@ -159,7 +159,8 @@ public:
 
         // Set response handler (wraps meta.callback)
         txn->SetResponseHandler([callback = meta.callback, label]
-                                (kern_return_t kr, uint8_t responseCode, std::span<const uint8_t> data) {
+                                (kern_return_t kr, uint8_t responseCode, std::span<const uint8_t> data) // NOLINT(bugprone-easily-swappable-parameters)
+                                {
             ASFW_LOG_V3(Async, "🔍 [Wrapper Lambda] ENTRY: tLabel=%u callback=%p valid=%d kr=0x%x",
                         label, &callback, callback ? 1 : 0, kr);
             if (callback) {

--- a/ASFWDriver/Async/Tx/DescriptorBuilder.cpp
+++ b/ASFWDriver/Async/Tx/DescriptorBuilder.cpp
@@ -126,8 +126,9 @@ size_t DescriptorBuilder::ReserveBlocks(uint8_t blocks) noexcept {
     return kInvalidRingIndex;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 DescriptorBuilder::DescriptorChain DescriptorBuilder::BuildTransactionChain(const void* headerData,
-                                                                            std::size_t headerSize,
+                                                                            std::size_t headerSize, // NOLINT(bugprone-easily-swappable-parameters)
                                                                             uint64_t payloadDeviceAddress,
                                                                             std::size_t payloadSize,
                                                                             bool needsFlush) {
@@ -251,14 +252,13 @@ DescriptorBuilder::DescriptorChain DescriptorBuilder::BuildTransactionChain(cons
         // - EOL is indicated SOLELY by branchWord=0
         // - Using b=BranchNever on OUTPUT_LAST triggers evt_unknown on strict controllers
         // - Apple's control word baseline: 0x123C0010 = cmd=1, key=2, i=3, b=3, reqCount=16
-        immDesc->common.control = OHCIDescriptor::BuildControl(
-            static_cast<uint16_t>(headerSize),    // reqCount
-            OHCIDescriptor::kCmdOutputLast,       // cmd
-            OHCIDescriptor::kKeyImmediate,        // key
-            OHCIDescriptor::kIntAlways,           // i=3: always interrupt
-            OHCIDescriptor::kBranchAlways,        // b=3: ALWAYS for OUTPUT_LAST (EOL via branchWord)
-            false                                 // ping
-        );
+        immDesc->common.control = OHCIDescriptor::BuildControl({
+            .reqCount = static_cast<uint16_t>(headerSize),
+            .command = OHCIDescriptor::kCmdOutputLast,
+            .key = OHCIDescriptor::kKeyImmediate,
+            .interruptBits = OHCIDescriptor::kIntAlways,
+            .branchBits = OHCIDescriptor::kBranchAlways,
+        });
 
         dmaManager_.PublishRange(immDesc, sizeof(OHCIDescriptorImmediate));
 
@@ -492,14 +492,13 @@ DescriptorBuilder::DescriptorChain DescriptorBuilder::BuildTransactionChain(cons
     // Configure header descriptor (OUTPUT_MORE_Immediate, ping=false for standard async)
     // OHCI Table 7-2: OUTPUT_MORE* descriptors MUST have b=00 per spec
     // Hardware links to next descriptor via contiguity, not via branchWord
-    headerImmDesc->common.control = OHCIDescriptor::BuildControl(
-        static_cast<uint16_t>(headerSize),        // reqCount
-        OHCIDescriptor::kCmdOutputMore,           // cmd
-        OHCIDescriptor::kKeyImmediate,            // key
-        OHCIDescriptor::kIntNever,                // i (interrupt control)
-        OHCIDescriptor::kBranchNever,             // b=00: REQUIRED by OHCI spec for OUTPUT_MORE*
-        false                                     // ping
-    );
+    headerImmDesc->common.control = OHCIDescriptor::BuildControl({
+        .reqCount = static_cast<uint16_t>(headerSize),
+        .command = OHCIDescriptor::kCmdOutputMore,
+        .key = OHCIDescriptor::kKeyImmediate,
+        .interruptBits = OHCIDescriptor::kIntNever,
+        .branchBits = OHCIDescriptor::kBranchNever,
+    });
 
     dmaManager_.PublishRange(headerImmDesc, sizeof(OHCIDescriptorImmediate));
 
@@ -512,14 +511,13 @@ DescriptorBuilder::DescriptorChain DescriptorBuilder::BuildTransactionChain(cons
 
     std::atomic_thread_fence(std::memory_order_release);
 
-    payloadDescriptor->control = OHCIDescriptor::BuildControl(
-        static_cast<uint16_t>(payloadSize),       // reqCount
-        OHCIDescriptor::kCmdOutputLast,           // cmd
-        OHCIDescriptor::kKeyStandard,             // key
-        OHCIDescriptor::kIntAlways,               // i=3: always interrupt on OUTPUT_LAST
-        OHCIDescriptor::kBranchAlways,            // b=3: ALWAYS for OUTPUT_LAST (even at EOL)
-        false                                     // ping
-    );
+    payloadDescriptor->control = OHCIDescriptor::BuildControl({
+        .reqCount = static_cast<uint16_t>(payloadSize),
+        .command = OHCIDescriptor::kCmdOutputLast,
+        .key = OHCIDescriptor::kKeyStandard,
+        .interruptBits = OHCIDescriptor::kIntAlways,
+        .branchBits = OHCIDescriptor::kBranchAlways,
+    });
 
     dmaManager_.PublishRange(payloadDescriptor, sizeof(OHCIDescriptor));
 
@@ -771,6 +769,7 @@ void DescriptorBuilder::UnlinkTail(size_t tailIndex) noexcept {
     }
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void DescriptorBuilder::FlushTail(size_t tailIndex, uint8_t blocks) noexcept {
     if (ring_.Capacity() == 0) return;
     HW::OHCIDescriptor* desc = ring_.At(tailIndex);

--- a/ASFWDriver/Async/Tx/PacketBuilder.cpp
+++ b/ASFWDriver/Async/Tx/PacketBuilder.cpp
@@ -119,11 +119,6 @@ static_assert(sizeof(HeaderPhyPacket) == 16);
 
     return true;
 }
-
-[[nodiscard]] uint16_t EncodeSourceNodeID(const PacketContext& context) {
-    return static_cast<uint16_t>(context.sourceNodeID & kNodeIDMask);
-}
-
 } // namespace
 
 std::size_t PacketBuilder::BuildReadQuadlet(const ReadParams& params,
@@ -416,8 +411,9 @@ std::size_t PacketBuilder::BuildWriteBlock(const WriteParams& params,
     return headerSize;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 std::size_t PacketBuilder::BuildLock(const LockParams& params,
-                                     uint8_t label,
+                                     uint8_t label, // NOLINT(bugprone-easily-swappable-parameters)
                                      uint16_t extendedTCode,
                                      const PacketContext& context,
                                      void* headerBuffer,

--- a/ASFWDriver/Audio/Backends/AVCAudioBackend.cpp
+++ b/ASFWDriver/Audio/Backends/AVCAudioBackend.cpp
@@ -3,6 +3,7 @@
 
 #include "AVCAudioBackend.hpp"
 
+#include "../../Common/DriverKitOwnership.hpp"
 #include "../../Logging/Logging.hpp"
 
 #include <DriverKit/IOLib.h>
@@ -126,9 +127,10 @@ IOReturn AVCAudioBackend::StartStreaming(uint64_t guid) noexcept {
 
     // Ensure queues exist before wiring to isoch contexts.
     nub->EnsureRxQueueCreated();
-    OSSharedPtr<IOBufferMemoryDescriptor> rxMem{};
+    IOBufferMemoryDescriptor* rxMemRaw = nullptr;
     uint64_t rxBytes = 0;
-    const kern_return_t rxCopy = nub->CopyRxQueueMemory(rxMem.attach(), &rxBytes);
+    const kern_return_t rxCopy = nub->CopyRxQueueMemory(&rxMemRaw, &rxBytes);
+    auto rxMem = Common::AdoptRetained(rxMemRaw);
     if (rxCopy != kIOReturnSuccess || !rxMem || rxBytes == 0) {
         return (rxCopy == kIOReturnSuccess) ? kIOReturnNoMemory : rxCopy;
     }
@@ -137,7 +139,7 @@ IOReturn AVCAudioBackend::StartStreaming(uint64_t guid) noexcept {
     {
         const kern_return_t krRx = isoch_.StartReceive(kDefaultIrChannel,
                                                        hardware_,
-                                                       rxMem.detach(),
+                                                       rxMem,
                                                        rxBytes);
         if (krRx != kIOReturnSuccess) {
             ASFW_LOG_ERROR(Audio, "AVCAudioBackend: StartReceive failed GUID=0x%016llx kr=0x%x", guid, krRx);
@@ -174,9 +176,10 @@ IOReturn AVCAudioBackend::StartStreaming(uint64_t guid) noexcept {
         // AV/C playback streams normally have PCM-only wire slots.
         const uint32_t am824Slots = config.outputChannelCount;
 
-        OSSharedPtr<IOBufferMemoryDescriptor> txMem{};
+        IOBufferMemoryDescriptor* txMemRaw = nullptr;
         uint64_t txBytes = 0;
-        const kern_return_t txCopy = nub->CopyTransmitQueueMemory(txMem.attach(), &txBytes);
+        const kern_return_t txCopy = nub->CopyTransmitQueueMemory(&txMemRaw, &txBytes);
+        auto txMem = Common::AdoptRetained(txMemRaw);
         if (txCopy != kIOReturnSuccess || !txMem || txBytes == 0) {
             (void)isoch_.StopReceive();
             // Best-effort: disconnect oPCR.
@@ -190,7 +193,7 @@ IOReturn AVCAudioBackend::StartStreaming(uint64_t guid) noexcept {
                                                         streamModeRaw,
                                                         config.outputChannelCount,
                                                         am824Slots,
-                                                        txMem.detach(),
+                                                        txMem,
                                                         txBytes,
                                                         nullptr,
                                                         0,

--- a/ASFWDriver/Audio/Backends/DiceAudioBackend.cpp
+++ b/ASFWDriver/Audio/Backends/DiceAudioBackend.cpp
@@ -3,6 +3,7 @@
 
 #include "DiceAudioBackend.hpp"
 
+#include "../../Common/DriverKitOwnership.hpp"
 #include "../../Logging/Logging.hpp"
 #include "../../Protocols/Audio/DeviceProtocolFactory.hpp"
 
@@ -205,16 +206,18 @@ IOReturn DiceAudioBackend::StartStreaming(uint64_t guid) noexcept {
 
     // Ensure queues exist before wiring to isoch contexts.
     nub->EnsureRxQueueCreated();
-    OSSharedPtr<IOBufferMemoryDescriptor> rxMem{};
+    IOBufferMemoryDescriptor* rxMemRaw = nullptr;
     uint64_t rxBytes = 0;
-    const kern_return_t rxCopy = nub->CopyRxQueueMemory(rxMem.attach(), &rxBytes);
+    const kern_return_t rxCopy = nub->CopyRxQueueMemory(&rxMemRaw, &rxBytes);
+    auto rxMem = Common::AdoptRetained(rxMemRaw);
     if (rxCopy != kIOReturnSuccess || !rxMem || rxBytes == 0) {
         return (rxCopy == kIOReturnSuccess) ? kIOReturnNoMemory : rxCopy;
     }
 
-    OSSharedPtr<IOBufferMemoryDescriptor> txMem{};
+    IOBufferMemoryDescriptor* txMemRaw = nullptr;
     uint64_t txBytes = 0;
-    const kern_return_t txCopy = nub->CopyTransmitQueueMemory(txMem.attach(), &txBytes);
+    const kern_return_t txCopy = nub->CopyTransmitQueueMemory(&txMemRaw, &txBytes);
+    auto txMem = Common::AdoptRetained(txMemRaw);
     if (txCopy != kIOReturnSuccess || !txMem || txBytes == 0) {
         return (txCopy == kIOReturnSuccess) ? kIOReturnNoMemory : txCopy;
     }
@@ -237,9 +240,9 @@ IOReturn DiceAudioBackend::StartStreaming(uint64_t guid) noexcept {
     params.hostToDeviceAm824Slots = caps.hostToDeviceAm824Slots;
     params.streamMode = Model::StreamMode::kBlocking;
 
-    params.rxQueueMemory = rxMem.detach();
+    params.rxQueueMemory = rxMem;
     params.rxQueueBytes = rxBytes;
-    params.txQueueMemory = txMem.detach();
+    params.txQueueMemory = txMem;
     params.txQueueBytes = txBytes;
 
     // DICE playback: no zero-copy for now (explicitly disabled by policy).

--- a/ASFWDriver/Bus/BusResetCoordinator.cpp
+++ b/ASFWDriver/Bus/BusResetCoordinator.cpp
@@ -96,6 +96,7 @@ void BusResetCoordinator::Initialize(HardwareInterface* hw, OSSharedPtr<IODispat
     }
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void BusResetCoordinator::OnIrq(uint32_t intEvent, uint64_t timestamp) {
     bool relevant = false;
 

--- a/ASFWDriver/Bus/GapCountOptimizer.cpp
+++ b/ASFWDriver/Bus/GapCountOptimizer.cpp
@@ -66,8 +66,9 @@ bool GapCountOptimizer::HasInvalidGap(const std::vector<uint8_t>& gaps) {
     return !AreGapsConsistent(gaps);
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 bool GapCountOptimizer::ShouldUpdate(const std::vector<uint8_t>& currentGaps,
-                                     uint8_t newGap,
+                                     uint8_t newGap, // NOLINT(bugprone-easily-swappable-parameters)
                                      uint8_t prevGap) {
     if (currentGaps.empty()) {
         return false;

--- a/ASFWDriver/Bus/TopologyManager.cpp
+++ b/ASFWDriver/Bus/TopologyManager.cpp
@@ -404,6 +404,7 @@ const char* TopologyManager::TopologyBuildErrorCodeString(TopologyBuildErrorCode
 }
 
 std::expected<TopologySnapshot, TopologyManager::TopologyBuildError>
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 TopologyManager::UpdateFromSelfID(const SelfIDCapture::Result& result, uint64_t timestamp,
                                   uint32_t nodeIDReg) {
     if (!result.valid || result.quads.empty()) {

--- a/ASFWDriver/Bus/TopologyTypes.hpp
+++ b/ASFWDriver/Bus/TopologyTypes.hpp
@@ -154,6 +154,8 @@ inline const char* PowerClassToString(PowerClass p) {
 // Extract the 2-bit port status for port index (0..15). Returns PortState.
 // Ports are packed as p0 (bits 7:6), p1 (5:4), p2 (3:2) in the primary quadlet, extended
 // ports appear in subsequent quadlets for extended Self-ID packets.
+// Positional `(quad, portIndex)` mirrors the Self-ID wire layout.
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 inline PortState ExtractPortState(uint32_t quad, unsigned portIndex) {
     // Only supports first 3 ports in the base quadlet; callers should read extended
     // quadlets for p3..p15 as described in Figure 16-11 when IsExtended() is true.

--- a/ASFWDriver/Common/CallbackUtils.hpp
+++ b/ASFWDriver/Common/CallbackUtils.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace ASFW::Common {
+
+template <typename Callback>
+using SharedCallback = std::shared_ptr<std::decay_t<Callback>>;
+
+template <typename Callback>
+[[nodiscard]] auto ShareCallback(Callback&& callback)
+    -> SharedCallback<Callback>
+{
+    return std::make_shared<std::decay_t<Callback>>(std::forward<Callback>(callback));
+}
+
+template <typename Callback, typename... Args>
+void InvokeSharedCallback(const std::shared_ptr<Callback>& callback, Args&&... args)
+{
+    (*callback)(std::forward<Args>(args)...);
+}
+
+} // namespace ASFW::Common

--- a/ASFWDriver/Common/DriverKitOwnership.hpp
+++ b/ASFWDriver/Common/DriverKitOwnership.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#ifdef ASFW_HOST_TEST
+#include "../Testing/HostDriverKitStubs.hpp"
+#else
+#include <DriverKit/IOMemoryMap.h>
+#include <DriverKit/OSSharedPtr.h>
+#endif
+
+#include <type_traits>
+
+namespace ASFW::Common {
+
+template <typename T>
+[[nodiscard]] OSSharedPtr<T> AdoptRetained(T*& rawObject) noexcept
+{
+    static_assert(std::is_base_of_v<OSObject, T>,
+                  "AdoptRetained<T>() requires T to derive from OSObject");
+    if (!rawObject) {
+        return {};
+    }
+
+    OSSharedPtr<T> adopted(rawObject, OSNoRetain);
+    rawObject = nullptr;
+    return adopted;
+}
+
+template <typename T>
+[[nodiscard]] kern_return_t CreateSharedMapping(const OSSharedPtr<T>& memory,
+                                                OSSharedPtr<IOMemoryMap>& outMap,
+                                                uint64_t options = kIOMemoryMapCacheModeDefault) noexcept
+{
+    outMap.reset();
+    if (!memory) {
+        return kIOReturnBadArgument;
+    }
+
+    IOMemoryMap* rawMap = nullptr;
+    const kern_return_t kr = memory->CreateMapping(options, 0, 0, 0, 0, &rawMap);
+    if (kr != kIOReturnSuccess || !rawMap) {
+        if (rawMap) {
+            rawMap->release();
+            rawMap = nullptr;
+        }
+        return (kr == kIOReturnSuccess) ? kIOReturnNoMemory : kr;
+    }
+
+    outMap = AdoptRetained(rawMap);
+    return kIOReturnSuccess;
+}
+
+} // namespace ASFW::Common

--- a/ASFWDriver/Common/FWCommon.hpp
+++ b/ASFWDriver/Common/FWCommon.hpp
@@ -530,10 +530,15 @@ struct BusOptionsDecoded {
 
 // Convenience: update only the generation bits and preserve all other bits (including reserved
 // bits).
-[[nodiscard]] constexpr uint32_t SetGeneration(uint32_t busOptionsHost, uint8_t gen4) noexcept {
-    const uint32_t cleared = (busOptionsHost & ~BusOptionsFields::kGenerationMask);
+struct GenerationUpdate {
+    uint32_t busOptionsHost{0};
+    uint8_t gen4{0};
+};
+
+[[nodiscard]] constexpr uint32_t SetGeneration(GenerationUpdate update) noexcept {
+    const uint32_t cleared = (update.busOptionsHost & ~BusOptionsFields::kGenerationMask);
     const uint32_t genBits =
-        (static_cast<uint32_t>(gen4 & 0x0Fu) << BusOptionsFields::kGenerationShift);
+        (static_cast<uint32_t>(update.gen4 & 0x0Fu) << BusOptionsFields::kGenerationShift);
     return cleared | genBits;
 }
 

--- a/ASFWDriver/ConfigROM/Local/ConfigROMBuilder.cpp
+++ b/ASFWDriver/ConfigROM/Local/ConfigROMBuilder.cpp
@@ -31,6 +31,7 @@ void ConfigROMBuilder::Build(uint32_t busOptions, uint64_t guid, uint32_t nodeCa
     Finalize();
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void ConfigROMBuilder::Begin(uint32_t busOptions, uint64_t guid, uint32_t nodeCapabilities) {
     (void)nodeCapabilities; // value provided later via AddImmediateEntry
     Reset();
@@ -44,7 +45,10 @@ void ConfigROMBuilder::Begin(uint32_t busOptions, uint64_t guid, uint32_t nodeCa
     // Bus information block (5 quadlets)
     Append(0); // header placeholder
     Append(ASFW::FW::kBusNameQuadlet);
-    Append(ASFW::FW::SetGeneration(busOptions, 0));
+    Append(ASFW::FW::SetGeneration({
+        .busOptionsHost = busOptions,
+        .gen4 = 0,
+    }));
     Append(guidHi);
     Append(guidLo);
     FinaliseBIB();
@@ -135,7 +139,10 @@ void ConfigROMBuilder::UpdateGeneration(uint8_t generation) {
     if (quadCount_ < 3) {
         return;
     }
-    words_[2] = ASFW::FW::SetGeneration(lastBusOptions_, generation);
+    words_[2] = ASFW::FW::SetGeneration({
+        .busOptionsHost = lastBusOptions_,
+        .gen4 = generation,
+    });
     FinaliseBIB();
 }
 

--- a/ASFWDriver/ConfigROM/Parse/ConfigROMParser.cpp
+++ b/ASFWDriver/ConfigROM/Parse/ConfigROMParser.cpp
@@ -37,6 +37,7 @@ bool ConfigROMParser::IsLeafOrDirectory(uint8_t keyType) {
     return keyType == EntryType::kLeaf || keyType == EntryType::kDirectory;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 uint32_t ConfigROMParser::ComputeScanLimit(uint16_t dirLength, uint32_t maxQuadlets) {
     auto scanLimit = static_cast<uint32_t>(dirLength);
     if (maxQuadlets > 1 && (maxQuadlets - 1) < scanLimit) {
@@ -47,6 +48,7 @@ uint32_t ConfigROMParser::ComputeScanLimit(uint16_t dirLength, uint32_t maxQuadl
 }
 
 std::optional<uint32_t>
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 ConfigROMParser::ComputeTargetOffsetQuadlets(uint8_t keyType, uint32_t value, uint32_t index) {
     if (!ConfigROMParser::IsLeafOrDirectory(keyType)) {
         return std::nullopt;
@@ -63,6 +65,7 @@ ConfigROMParser::ComputeTargetOffsetQuadlets(uint8_t keyType, uint32_t value, ui
     return static_cast<uint32_t>(rel);
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void ConfigROMParser::AppendRecognizedEntry(std::vector<RomEntry>& entries, uint8_t keyType,
                                             uint8_t keyId, uint32_t value,
                                             uint32_t targetOffsetQuadlets) {

--- a/ASFWDriver/ConfigROM/Remote/ROMReader.cpp
+++ b/ASFWDriver/ConfigROM/Remote/ROMReader.cpp
@@ -35,8 +35,9 @@ constexpr uint32_t BusNameQuadletHostOrder() noexcept {
     return ASFW::FW::kBusNameQuadlet;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 [[nodiscard]] bool CanTreatAsEOF(ROMReader::QuadletReadPolicy policy, Async::AsyncStatus status,
-                                 size_t payloadSizeBytes, uint32_t completedQuadlets) noexcept {
+                                 size_t payloadSizeBytes, uint32_t completedQuadlets) noexcept { // NOLINT(bugprone-easily-swappable-parameters)
     if (policy != ROMReader::QuadletReadPolicy::AllowPartialEOF) {
         return false;
     }
@@ -58,9 +59,10 @@ void ROMReader::ReadQuadletsBE(uint8_t nodeId, Generation generation, FwSpeed sp
                        std::move(callback), policy);
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void ROMReader::ReadQuadletsBEImpl(Async::IFireWireBus& bus,
                                    OSSharedPtr<IODispatchQueue> dispatchQueue, uint8_t nodeId,
-                                   Generation generation, FwSpeed speed, uint32_t offsetBytes,
+                                   Generation generation, FwSpeed speed, uint32_t offsetBytes, // NOLINT(bugprone-easily-swappable-parameters)
                                    uint32_t quadletCount, CompletionCallback callback,
                                    QuadletReadPolicy policy) {
     if (FW::ConfigROMAddr::kAddressHi != 0xFFFF) {
@@ -117,8 +119,11 @@ void ROMReader::ScheduleQuadletReadStep(const std::shared_ptr<QuadletReadContext
 
     const uint32_t addressLo =
         ctx->baseAddress + (ctx->quadletIndex * ASFW::ConfigROM::kQuadletBytes);
-    Async::FWAddress addr{FW::ConfigROMAddr::kAddressHi, addressLo,
-                          static_cast<uint16_t>(ctx->nodeId)};
+    Async::FWAddress addr{Async::FWAddress::QualifiedAddressParts{
+        .addressHi = FW::ConfigROMAddr::kAddressHi,
+        .addressLo = addressLo,
+        .nodeID = static_cast<uint16_t>(ctx->nodeId),
+    }};
 
     Async::InterfaceCompletionCallback completionHandler =
         [ctx](Async::AsyncStatus status, std::span<const uint8_t> payload) mutable {

--- a/ASFWDriver/ConfigROM/Remote/ROMScanSessionIRM.cpp
+++ b/ASFWDriver/ConfigROM/Remote/ROMScanSessionIRM.cpp
@@ -25,8 +25,10 @@ void ROMScanSession::StartIRMRead(ROMScanNodeStateMachine& node) {
 
     ++inflight_;
 
-    Async::FWAddress addr{IRM::IRMRegisters::kAddressHi,
-                          IRM::IRMRegisters::kChannelsAvailable63_32};
+    Async::FWAddress addr{Async::FWAddress::AddressParts{
+        .addressHi = IRM::IRMRegisters::kAddressHi,
+        .addressLo = IRM::IRMRegisters::kChannelsAvailable63_32,
+    }};
 
     const Generation gen = gen_;
     auto weakSelf = weak_from_this();
@@ -103,8 +105,10 @@ void ROMScanSession::StartIRMLock(ROMScanNodeStateMachine& node) {
 
     ++inflight_;
 
-    Async::FWAddress addr{IRM::IRMRegisters::kAddressHi,
-                          IRM::IRMRegisters::kChannelsAvailable63_32};
+    Async::FWAddress addr{Async::FWAddress::AddressParts{
+        .addressHi = IRM::IRMRegisters::kAddressHi,
+        .addressLo = IRM::IRMRegisters::kChannelsAvailable63_32,
+    }};
 
     std::array<uint8_t, 8> casOperand{};
     const uint32_t beCompare = OSSwapHostToBigInt32(0xFFFFFFFFU);

--- a/ASFWDriver/Controller/ControllerCoreLifecycle.cpp
+++ b/ASFWDriver/Controller/ControllerCoreLifecycle.cpp
@@ -672,6 +672,7 @@ kern_return_t ControllerCore::EnableInterruptsAndStartBus() {
     return kIOReturnSuccess;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 kern_return_t ControllerCore::StageConfigROM(uint32_t busOptions, uint32_t guidHi,
                                              uint32_t guidLo) const {
     if (!deps_.configRom || !deps_.configRomStager || !deps_.hardware) {

--- a/ASFWDriver/Diagnostics/Signposts.hpp
+++ b/ASFWDriver/Diagnostics/Signposts.hpp
@@ -20,7 +20,8 @@ inline uint64_t MachTicksToMicroseconds(uint64_t ticks) {
         mach_timebase_info(&timebase);
     }
     // ticks * numer / denom = nanoseconds; divide by 1000 for microseconds
-    return (ticks * timebase.numer) / (timebase.denom * 1000);
+    return (ticks * timebase.numer) /
+           (static_cast<uint64_t>(timebase.denom) * 1000u);
 }
 
 /// RAII timer for measuring code section latency

--- a/ASFWDriver/Diagnostics/StatusPublisher.cpp
+++ b/ASFWDriver/Diagnostics/StatusPublisher.cpp
@@ -177,6 +177,7 @@ void StatusPublisher::SetLastAsyncCompletion(uint64_t machTime) {
     lastAsyncCompletionMach_.store(machTime, std::memory_order_release);
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void StatusPublisher::UpdateAsyncWatchdog(uint32_t asyncTimeoutCount, uint64_t watchdogTickCount,
                                           uint64_t watchdogLastTickUsec) {
     asyncTimeoutCount_.store(asyncTimeoutCount, std::memory_order_release);

--- a/ASFWDriver/Discovery/DiscoveryTypes.hpp
+++ b/ASFWDriver/Discovery/DiscoveryTypes.hpp
@@ -23,11 +23,16 @@ using Generation = ASFW::FW::Generation;
 using Guid64 = uint64_t;
 
 struct FwAddress {
+    struct BusNodeParts {
+        uint16_t bus{0};
+        uint8_t node{0xFF};
+    };
+
     uint16_t bus{0};
     uint16_t node{0xFFFF};
     
     FwAddress() = default;
-    FwAddress(uint16_t b, uint8_t n) : bus(b), node(n) {}
+    constexpr explicit FwAddress(BusNodeParts parts) noexcept : bus(parts.bus), node(parts.node) {}
 };
 
 // ============================================================================

--- a/ASFWDriver/Discovery/IDeviceManager.hpp
+++ b/ASFWDriver/Discovery/IDeviceManager.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <optional>
 #include "DiscoveryTypes.hpp"
+#include "../Logging/Logging.hpp"
 
 namespace ASFW::Discovery {
 
@@ -125,9 +126,8 @@ public:
             try {
                 unregister_();
             } catch (...) {
-                // Unregister must not throw from a destructor.
-                // Virtual Unregister* implementations should be noexcept;
-                // swallow defensively to prevent std::terminate.
+                ASFW_LOG_ERROR(Discovery,
+                               "ObserverGuard: unregister callback threw during destruction");
             }
         }
     }

--- a/ASFWDriver/Hardware/HardwareInterface.cpp
+++ b/ASFWDriver/Hardware/HardwareInterface.cpp
@@ -53,6 +53,7 @@ HardwareInterface::~HardwareInterface() {
     Detach();
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 kern_return_t HardwareInterface::Attach(IOService* owner, IOService* provider) {
     if (device_) {
         return kIOReturnSuccess;
@@ -707,6 +708,7 @@ static bool WaitForRegister(ReadFn&& read32, uint32_t mask, bool expectSet, uint
 
 } // anonymous namespace
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 bool HardwareInterface::WaitHC(uint32_t mask, bool expectSet, uint32_t timeoutUsec,
                                uint32_t pollIntervalUsec) const {
     if (!device_) {
@@ -729,6 +731,7 @@ bool HardwareInterface::WaitHC(uint32_t mask, bool expectSet, uint32_t timeoutUs
         });
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 bool HardwareInterface::WaitLink(uint32_t mask, bool expectSet, uint32_t timeoutUsec,
                                  uint32_t pollIntervalUsec) const {
     if (!device_) {

--- a/ASFWDriver/Hardware/OHCIDescriptors.hpp
+++ b/ASFWDriver/Hardware/OHCIDescriptors.hpp
@@ -58,13 +58,26 @@ struct alignas(16) OHCIDescriptor {
     static constexpr uint8_t kBranchNever = 0b00;
     static constexpr uint8_t kBranchAlways = 0b11;
 
-    [[nodiscard]] static constexpr uint32_t BuildControl(uint16_t reqCount, uint8_t cmd, uint8_t key, uint8_t i, uint8_t b, bool ping = false) noexcept {
-        const uint8_t cmd_masked = cmd & 0xF;
-        const uint8_t key_masked = key & 0x7;
-        const uint8_t i_masked = i & 0x3;
-        const uint8_t b_masked = b & 0x3;
-        const uint32_t high = (static_cast<uint32_t>(cmd_masked) << kCmdShift) | (static_cast<uint32_t>(key_masked) << kKeyShift) | (static_cast<uint32_t>(i_masked) << kIntShift) | (static_cast<uint32_t>(b_masked) << kBranchShift) | (ping ? (1u << kPingShift) : 0);
-        return ((high & 0xFFFFu) << kControlHighShift) | (reqCount & 0xFFFFu);
+    struct ControlFields {
+        uint16_t reqCount{0};
+        uint8_t command{0};
+        uint8_t key{0};
+        uint8_t interruptBits{0};
+        uint8_t branchBits{0};
+        bool ping{false};
+    };
+
+    [[nodiscard]] static constexpr uint32_t BuildControl(const ControlFields& fields) noexcept {
+        const uint8_t cmd_masked = fields.command & 0xF;
+        const uint8_t key_masked = fields.key & 0x7;
+        const uint8_t i_masked = fields.interruptBits & 0x3;
+        const uint8_t b_masked = fields.branchBits & 0x3;
+        const uint32_t high = (static_cast<uint32_t>(cmd_masked) << kCmdShift) |
+                              (static_cast<uint32_t>(key_masked) << kKeyShift) |
+                              (static_cast<uint32_t>(i_masked) << kIntShift) |
+                              (static_cast<uint32_t>(b_masked) << kBranchShift) |
+                              (fields.ping ? (1u << kPingShift) : 0);
+        return ((high & 0xFFFFu) << kControlHighShift) | (fields.reqCount & 0xFFFFu);
     }
 
     static inline void PatchBranch(OHCIDescriptor& desc, uint8_t b) noexcept {
@@ -127,30 +140,42 @@ struct IsochHeader {
 };
 
 struct ITDescriptorBuilder {
+    struct OutputMoreImmediateParams {
+        uint32_t isochHeaderLE{0};
+        uint32_t cipQ0LE{0};
+        uint8_t interruptBits{OHCIDescriptor::kIntNever};
+    };
+
+    struct OutputLastParams {
+        uint32_t dataIOVA{0};
+        uint16_t payloadSize{0};
+        uint32_t branchIOVA{0};
+        uint8_t zValue{0};
+        uint8_t interruptBits{OHCIDescriptor::kIntNever};
+    };
+
     // OUTPUT_MORE-Immediate (32 bytes)
     // - Control: cmd=0, key=2 (Immediate), b=0, i=0/3, reqCount=4 (CIP Q0 only)
     // - Immediate[0]: IsochHeader (Framing - NOT payload) - Mapped to branchWord offset
     // - Immediate[1]: CIP Q0 (First 4 bytes of payload)   - Mapped to statusWord offset
-    static void BuildOutputMoreImmediate(OHCIDescriptorImmediate& desc, 
-                                        uint32_t isochHeaderLE, 
-                                        uint32_t cipQ0LE, 
-                                        uint8_t interruptBits = OHCIDescriptor::kIntNever) {
+    static void BuildOutputMoreImmediate(OHCIDescriptorImmediate& desc,
+                                         const OutputMoreImmediateParams& params) {
         constexpr uint16_t kReqCount = 4; // CIP Q0 only (IsochHeader is not payload)
-        desc.common.control = OHCIDescriptor::BuildControl(
-            kReqCount,
-            OHCIDescriptor::kCmdOutputMore,
-            OHCIDescriptor::kKeyImmediate,
-            interruptBits,
-            OHCIDescriptor::kBranchNever
-        );
+        desc.common.control = OHCIDescriptor::BuildControl({
+            .reqCount = kReqCount,
+            .command = OHCIDescriptor::kCmdOutputMore,
+            .key = OHCIDescriptor::kKeyImmediate,
+            .interruptBits = params.interruptBits,
+            .branchBits = OHCIDescriptor::kBranchNever,
+        });
         
         // CRITICAL FIX: For OUTPUT_MORE-Immediate, the first 16 bytes contain Imm0 and Imm1.
         // In the generic OHCIDescriptor struct, these map to:
         // offset 0x08 (branchWord) -> Imm0 (IsochHeader)
         // offset 0x0C (statusWord) -> Imm1 (CIP Q0)
         desc.common.dataAddress = 0; // Skip (offset 0x04)
-        desc.common.branchWord = isochHeaderLE; 
-        desc.common.statusWord = cipQ0LE; 
+        desc.common.branchWord = params.isochHeaderLE;
+        desc.common.statusWord = params.cipQ0LE;
 
         // Second 16-byte block is unused for this specific format
         desc.immediateData[0] = 0;
@@ -163,25 +188,20 @@ struct ITDescriptorBuilder {
     // - Control: cmd=1, s=1 (update status), key=0, b=3, reqCount=payloadSize
     // - DataAddress: Payload Ptr
     // - Branch: Next Descriptor
-    static void BuildOutputLast(OHCIDescriptor& desc,
-                               uint32_t dataIOVA,
-                               uint16_t payloadSize,
-                               uint32_t branchIOVA,
-                               uint8_t zValue,
-                               uint8_t interruptBits = OHCIDescriptor::kIntNever) {
-        desc.control = OHCIDescriptor::BuildControl(
-            payloadSize,
-            OHCIDescriptor::kCmdOutputLast,
-            OHCIDescriptor::kKeyStandard,
-            interruptBits,
-            OHCIDescriptor::kBranchAlways // Mandatory for ring
-        );
+    static void BuildOutputLast(OHCIDescriptor& desc, const OutputLastParams& params) {
+        desc.control = OHCIDescriptor::BuildControl({
+            .reqCount = params.payloadSize,
+            .command = OHCIDescriptor::kCmdOutputLast,
+            .key = OHCIDescriptor::kKeyStandard,
+            .interruptBits = params.interruptBits,
+            .branchBits = OHCIDescriptor::kBranchAlways,
+        });
         // Set Status Update bit (s=1)
         desc.control |= (1u << (OHCIDescriptor::kStatusShift + OHCIDescriptor::kControlHighShift));
         
-        desc.dataAddress = dataIOVA;
-        desc.branchWord = MakeBranchWordAT(branchIOVA, zValue); // Note: IT uses "Z" too
-        AR_init_status(desc, payloadSize);
+        desc.dataAddress = params.dataIOVA;
+        desc.branchWord = MakeBranchWordAT(params.branchIOVA, params.zValue); // Note: IT uses "Z" too
+        AR_init_status(desc, params.payloadSize);
     }
     
     // OUTPUT_LAST-Immediate removed per expert recommendation.

--- a/ASFWDriver/IRM/IRMAllocationManager.cpp
+++ b/ASFWDriver/IRM/IRMAllocationManager.cpp
@@ -1,4 +1,5 @@
 #include "IRMAllocationManager.hpp"
+#include "../Common/CallbackUtils.hpp"
 #include "../Logging/Logging.hpp"
 #include <os/log.h>
 
@@ -64,9 +65,10 @@ void IRMAllocationManager::Allocate(uint8_t channel,
 void IRMAllocationManager::Release(AllocationCallback callback,
                                     const RetryPolicy& retryPolicy)
 {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     if (!isAllocated_) {
         ASFW_LOG(IRM, "AllocationManager: No allocation to release");
-        callback(AllocationStatus::Success);
+        Common::InvokeSharedCallback(callbackState, AllocationStatus::Success);
         return;
     }
 
@@ -84,8 +86,8 @@ void IRMAllocationManager::Release(AllocationCallback callback,
 
     // Release resources
     irmClient_.ReleaseResources(channelToRelease, bandwidthToRelease,
-        [callback](AllocationStatus status) {
-            callback(status);
+        [callbackState](AllocationStatus status) {
+            Common::InvokeSharedCallback(callbackState, status);
         },
         retryPolicy);
 }

--- a/ASFWDriver/IRM/IRMClient.cpp
+++ b/ASFWDriver/IRM/IRMClient.cpp
@@ -1,4 +1,5 @@
 #include "IRMClient.hpp"
+#include "../Common/CallbackUtils.hpp"
 #include "../Logging/Logging.hpp"
 #include <DriverKit/IOLib.h>
 #include <os/log.h>
@@ -20,32 +21,41 @@ void IRMClient::ReadIRMQuadlet(
     uint32_t addressLo,
     std::function<void(bool success, uint32_t value)> callback)
 {
-    Async::FWAddress addr{IRMRegisters::kAddressHi, addressLo};
+    auto callbackState = Common::ShareCallback(std::move(callback));
+    Async::FWAddress addr{Async::FWAddress::AddressParts{
+        .addressHi = IRMRegisters::kAddressHi,
+        .addressLo = addressLo,
+    }};
 
     FW::FwSpeed speed{0};
     FW::NodeId node{irmNodeId_};
     FW::Generation gen{generation_};
 
     busOps_.ReadQuad(gen, node, addr, speed,
-        [callback](Async::AsyncStatus status, std::span<const uint8_t> payload) {
+        [callbackState](Async::AsyncStatus status, std::span<const uint8_t> payload) {
             if (status == Async::AsyncStatus::kSuccess && payload.size() == 4) {
                 uint32_t raw = 0;
                 std::memcpy(&raw, payload.data(), sizeof(raw));
                 uint32_t hostValue = OSSwapBigToHostInt32(raw);
-                callback(true, hostValue);
+                Common::InvokeSharedCallback(callbackState, true, hostValue);
             } else {
-                callback(false, 0);
+                Common::InvokeSharedCallback(callbackState, false, 0u);
             }
         });
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void IRMClient::CompareSwapIRMQuadlet(
-    uint32_t addressLo,
+    uint32_t addressLo, // NOLINT(bugprone-easily-swappable-parameters)
     uint32_t expected,
     uint32_t desired,
     std::function<void(bool success, uint32_t oldValue)> callback)
 {
-    Async::FWAddress addr{IRMRegisters::kAddressHi, addressLo};
+    auto callbackState = Common::ShareCallback(std::move(callback));
+    Async::FWAddress addr{Async::FWAddress::AddressParts{
+        .addressHi = IRMRegisters::kAddressHi,
+        .addressLo = addressLo,
+    }};
 
     FW::FwSpeed speed{0};
     FW::NodeId node{irmNodeId_};
@@ -59,16 +69,16 @@ void IRMClient::CompareSwapIRMQuadlet(
 
     busOps_.Lock(gen, node, addr, FW::LockOp::kCompareSwap,
         std::span{operand}, 4, speed,
-        [callback, expected](Async::AsyncStatus status, std::span<const uint8_t> payload) {
+        [callbackState, expected](Async::AsyncStatus status, std::span<const uint8_t> payload) {
             if (status == Async::AsyncStatus::kSuccess && payload.size() == 4) {
                 uint32_t raw = 0;
                 std::memcpy(&raw, payload.data(), sizeof(raw));
                 uint32_t oldValue = OSSwapBigToHostInt32(raw);
 
                 bool succeeded = (oldValue == expected);
-                callback(succeeded, oldValue);
+                Common::InvokeSharedCallback(callbackState, succeeded, oldValue);
             } else {
-                callback(false, 0);
+                Common::InvokeSharedCallback(callbackState, false, 0u);
             }
         });
 }
@@ -199,10 +209,11 @@ void IRMClient::AllocateResources(uint8_t channel,
     }, retryPolicy);
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void IRMClient::ReleaseResources(uint8_t channel,
-                                  uint32_t bandwidthUnits,
-                                  AllocationCallback callback,
-                                  const RetryPolicy& retryPolicy)
+                                 uint32_t bandwidthUnits,
+                                 AllocationCallback callback,
+                                 const RetryPolicy& retryPolicy)
 {
     struct ReleaseContext {
         AllocationCallback userCallback;

--- a/ASFWDriver/IRM/IRMTypes.hpp
+++ b/ASFWDriver/IRM/IRMTypes.hpp
@@ -57,15 +57,14 @@ constexpr uint32_t kMaxBandwidthUnitsS400 = 4915;
 constexpr uint32_t kChannelsAvailableInitial = 0xFFFFFFFF;  ///< All channels free
 
 /**
- * Calculate bandwidth units needed for given bitrate and speed.
+ * Inputs for CalculateBandwidthUnits().
  *
  * Formula (from IEEE 1394-1995 Annex C):
  *   units = (bits_per_second * overhead_factor) / speed_mbps * max_units
  *
- * @param bitsPerSecond Required bandwidth in bits per second
- * @param speedMbps Bus speed in Mbps (100, 200, 400, 800)
- * @param overheadPercent Overhead factor (default 10% for CIP headers, retries, etc.)
- * @return Number of bandwidth units to allocate
+ * bitsPerSecond: Required bandwidth in bits per second.
+ * speedMbps: Bus speed in Mbps (100, 200, 400, 800).
+ * overheadPercent: Overhead factor for CIP headers, retries, etc. Defaults to 10%.
  *
  * Example:
  *   Audio: 48kHz * 24-bit * 2ch = 2.304 Mbps
@@ -75,18 +74,27 @@ constexpr uint32_t kChannelsAvailableInitial = 0xFFFFFFFF;  ///< All channels fr
  * Reference: Apple IOFireWireController.cpp bandwidth allocation
  *            IEC 61883 overhead calculations
  */
-inline uint32_t CalculateBandwidthUnits(uint32_t bitsPerSecond,
-                                        uint32_t speedMbps,
-                                        uint32_t overheadPercent = 10)
+struct BandwidthUnitsRequest {
+    uint32_t bitsPerSecond{0};
+    uint32_t speedMbps{0};
+    uint32_t overheadPercent{10};
+};
+
+/**
+ * Calculate the number of bandwidth units to allocate for a stream request.
+ */
+inline uint32_t CalculateBandwidthUnits(const BandwidthUnitsRequest& request)
 {
     // Convert bits/sec to Mbits/sec (round up)
-    uint32_t mbitsPerSec = (bitsPerSecond + 999999) / 1000000;
+    uint32_t mbitsPerSec = (request.bitsPerSecond + 999999) / 1000000;
 
     // Add overhead
-    mbitsPerSec = (mbitsPerSec * (100 + overheadPercent)) / 100;
+    mbitsPerSec = static_cast<uint32_t>(
+        (static_cast<uint64_t>(mbitsPerSec) * (100ULL + request.overheadPercent)) / 100ULL);
 
     // Scale to S400 bandwidth units
-    uint32_t units = (mbitsPerSec * kMaxBandwidthUnitsS400) / speedMbps;
+    uint32_t units = static_cast<uint32_t>(
+        (static_cast<uint64_t>(mbitsPerSec) * kMaxBandwidthUnitsS400) / request.speedMbps);
 
     return units;
 }

--- a/ASFWDriver/Isoch/Audio/ASFWAudioDriver.cpp
+++ b/ASFWDriver/Isoch/Audio/ASFWAudioDriver.cpp
@@ -85,6 +85,8 @@ struct AudioDriverSharedMemoryState {
     bool rxQueueValid{false};
 };
 
+// Runtime layout is intentionally organized around hot-path state ownership, not field packing.
+// NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 struct AudioDriverRuntimeState {
     OSSharedPtr<IOTimerDispatchSource> timestampTimer;
     OSSharedPtr<OSAction> timestampTimerAction;
@@ -475,6 +477,7 @@ kern_return_t IMPL(ASFWAudioDriver, Start)
     uint32_t formatCount = ivars->device.sampleRateCount > 8 ? 8 : ivars->device.sampleRateCount;
     
     for (uint32_t i = 0; i < formatCount; i++) {
+        // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
         auto fillFormat = [](IOUserAudioStreamBasicDescription& fmt, double sampleRate, uint32_t channels) {
             fmt.mSampleRate = sampleRate;
             fmt.mFormatID = IOUserAudioFormatID::LinearPCM;

--- a/ASFWDriver/Isoch/Audio/ASFWAudioNub.cpp
+++ b/ASFWDriver/Isoch/Audio/ASFWAudioNub.cpp
@@ -85,8 +85,9 @@ static uint32_t FallbackOutputChannels(const ASFWAudioNub_IVars* iv) {
     return ClampAudioChannels(iv->outputChannelCount ? iv->outputChannelCount : iv->channelCount);
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 static bool TryResolveRuntimeAudioChannels(ASFWAudioNub_IVars* iv,
-                                           uint32_t& outInputChannels,
+                                           uint32_t& outInputChannels, // NOLINT(bugprone-easily-swappable-parameters)
                                            uint32_t& outOutputChannels)
 {
     if (!iv) {

--- a/ASFWDriver/Isoch/Audio/ASFWProtocolBooleanControl.cpp
+++ b/ASFWDriver/Isoch/Audio/ASFWProtocolBooleanControl.cpp
@@ -19,7 +19,7 @@ OSSharedPtr<ASFWProtocolBooleanControl> ASFWProtocolBooleanControl::Create(
     IOUserAudioObjectPropertyElement controlElement,
     IOUserAudioObjectPropertyScope controlScope,
     IOUserAudioClassID controlClassID,
-    uint32_t classIdFourCC,
+    uint32_t classIdFourCC, // NOLINT(bugprone-easily-swappable-parameters)
     uint32_t routedElement)
 {
     auto* control = OSTypeAlloc(ASFWProtocolBooleanControl);
@@ -42,6 +42,8 @@ OSSharedPtr<ASFWProtocolBooleanControl> ASFWProtocolBooleanControl::Create(
     return OSSharedPtr(control, OSNoRetain);
 }
 
+// The property signature mirrors IOUserAudio property routing inputs.
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 bool ASFWProtocolBooleanControl::init(
     ASFWAudioDriver* ownerDriver,
     bool isSettable,
@@ -49,7 +51,7 @@ bool ASFWProtocolBooleanControl::init(
     IOUserAudioObjectPropertyElement controlElement,
     IOUserAudioObjectPropertyScope controlScope,
     IOUserAudioClassID controlClassID,
-    uint32_t classIdFourCC,
+    uint32_t classIdFourCC, // NOLINT(bugprone-easily-swappable-parameters)
     uint32_t routedElement)
 {
     if (!ownerDriver) {

--- a/ASFWDriver/Isoch/Audio/AudioDriverConfig.cpp
+++ b/ASFWDriver/Isoch/Audio/AudioDriverConfig.cpp
@@ -15,7 +15,7 @@ namespace {
 
 [[nodiscard]] bool ReadOSBoolValue(OSObject* object, bool fallback) {
     auto* booleanObject = OSDynamicCast(OSBoolean, object);
-    if (!booleanObject) {
+    if (booleanObject == nullptr) {
         return fallback;
     }
     return booleanObject == kOSBooleanTrue;
@@ -93,7 +93,7 @@ void ParseAudioDriverConfigFromProperties(OSDictionary* properties,
         const uint32_t cappedCount = std::min(rates->getCount(), kMaxSampleRates);
         for (uint32_t i = 0; i < cappedCount; ++i) {
             auto* rate = OSDynamicCast(OSNumber, rates->getObject(i));
-            if (!rate) {
+            if (rate == nullptr) {
                 continue;
             }
             inOutConfig.sampleRates[inOutConfig.sampleRateCount++] =
@@ -128,7 +128,7 @@ void ParseAudioDriverConfigFromProperties(OSDictionary* properties,
             auto* classNumber = OSDynamicCast(OSNumber, entry->getObject("ClassID"));
             auto* scopeNumber = OSDynamicCast(OSNumber, entry->getObject("Scope"));
             auto* elementNumber = OSDynamicCast(OSNumber, entry->getObject("Element"));
-            if (!classNumber || !scopeNumber || !elementNumber) {
+            if (classNumber == nullptr || scopeNumber == nullptr || elementNumber == nullptr) {
                 continue;
             }
 

--- a/ASFWDriver/Isoch/Audio/AudioDriverConfigPolicy.cpp
+++ b/ASFWDriver/Isoch/Audio/AudioDriverConfigPolicy.cpp
@@ -18,7 +18,7 @@ void AppendBoolControl(ParsedAudioDriverConfig& inOutConfig,
 } // namespace
 
 void InitializeAudioDriverConfigDefaults(ParsedAudioDriverConfig& outConfig) {
-    memset(&outConfig, 0, sizeof(outConfig));
+    outConfig = {};
 
     strlcpy(outConfig.deviceName, "FireWire Audio", sizeof(outConfig.deviceName));
     outConfig.channelCount = kDefaultChannelCount;

--- a/ASFWDriver/Isoch/Audio/AudioIOPath.cpp
+++ b/ASFWDriver/Isoch/Audio/AudioIOPath.cpp
@@ -24,8 +24,9 @@ void MaybeDrainRxStartup(AudioIOPathState& state) {
     *state.rxStartupDrained = true;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 kern_return_t HandleBeginRead(AudioIOPathState& state,
-                              uint32_t ioBufferFrameSize,
+                              uint32_t ioBufferFrameSize, // NOLINT(bugprone-easily-swappable-parameters)
                               uint64_t sampleTime) {
     if (!state.inputBuffer) {
         return kIOReturnNotReady;
@@ -58,20 +59,20 @@ kern_return_t HandleBeginRead(AudioIOPathState& state,
     MaybeDrainRxStartup(state);
 
     if (state.rxQueueValid && state.rxQueueReader) {
-        auto* pcmFirst = reinterpret_cast<int32_t*>(segment.address + offsetBytes);
-        const uint32_t read1 = state.rxQueueReader->Read(pcmFirst, firstFrames);
-        if (read1 < firstFrames) {
-            memset(pcmFirst + read1 * ch,
-                   0,
-                   size_t(firstFrames - read1) * sizeof(int32_t) * ch);
-        }
+            auto* pcmFirst = reinterpret_cast<int32_t*>(segment.address + offsetBytes);
+            const uint32_t read1 = state.rxQueueReader->Read(pcmFirst, firstFrames);
+            if (read1 < firstFrames) {
+                memset(pcmFirst + (static_cast<size_t>(read1) * ch),
+                       0,
+                       size_t(firstFrames - read1) * sizeof(int32_t) * ch);
+            }
 
         if (secondFrames > 0) {
             auto* pcmSecond = reinterpret_cast<int32_t*>(segment.address);
             if (read1 == firstFrames) {
                 const uint32_t read2 = state.rxQueueReader->Read(pcmSecond, secondFrames);
                 if (read2 < secondFrames) {
-                    memset(pcmSecond + read2 * ch,
+                    memset(pcmSecond + (static_cast<size_t>(read2) * ch),
                            0,
                            size_t(secondFrames - read2) * sizeof(int32_t) * ch);
                 }
@@ -230,8 +231,9 @@ kern_return_t HandleWriteEnd(AudioIOPathState& state,
 
 } // namespace detail
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 kern_return_t HandleIOOperation(AudioIOPathState& state,
-                                IOUserAudioIOOperation operation,
+                                IOUserAudioIOOperation operation, // NOLINT(bugprone-easily-swappable-parameters)
                                 uint32_t ioBufferFrameSize,
                                 uint64_t sampleTime) {
     switch (operation) {

--- a/ASFWDriver/Isoch/Audio/AudioSharedMemoryBridge.cpp
+++ b/ASFWDriver/Isoch/Audio/AudioSharedMemoryBridge.cpp
@@ -1,9 +1,13 @@
 #include "AudioSharedMemoryBridge.hpp"
 
+#include "../../Common/DriverKitOwnership.hpp"
+
+#include <utility>
+
 namespace ASFW::Isoch::Audio {
 namespace {
 
-kern_return_t MapSharedQueue(IOBufferMemoryDescriptor* queueMemory,
+kern_return_t MapSharedQueue(OSSharedPtr<IOBufferMemoryDescriptor> queueMemory,
                              uint64_t queueBytes,
                              OSSharedPtr<IOBufferMemoryDescriptor>& outQueueMemory,
                              OSSharedPtr<IOMemoryMap>& outQueueMap,
@@ -19,26 +23,18 @@ kern_return_t MapSharedQueue(IOBufferMemoryDescriptor* queueMemory,
         return kIOReturnBadArgument;
     }
 
-    outQueueMemory.reset(queueMemory, OSNoRetain);
+    outQueueMemory = std::move(queueMemory);
     outQueueBytes = queueBytes;
 
-    IOMemoryMap* queueMapRaw = nullptr;
-    kern_return_t mappingStatus = queueMemory->CreateMapping(
-        kIOMemoryMapCacheModeDefault,
-        0,
-        0,
-        0,
-        0,
-        &queueMapRaw);
-    if (mappingStatus != kIOReturnSuccess || !queueMapRaw) {
+    const kern_return_t mappingStatus =
+        Common::CreateSharedMapping(outQueueMemory, outQueueMap);
+    if (mappingStatus != kIOReturnSuccess) {
         outQueueMemory.reset();
         outQueueBytes = 0;
-        return (mappingStatus == kIOReturnSuccess) ? kIOReturnNoMemory : mappingStatus;
+        return mappingStatus;
     }
 
-    outQueueMap.reset(queueMapRaw, OSNoRetain);
-
-    void* baseAddress = reinterpret_cast<void*>(queueMapRaw->GetAddress());
+    void* baseAddress = reinterpret_cast<void*>(outQueueMap->GetAddress());
     if (!outQueue.Attach(baseAddress, queueBytes)) {
         outQueueMap.reset();
         outQueueMemory.reset();
@@ -58,15 +54,18 @@ kern_return_t MapRxQueueFromNub(ASFWAudioNub& nub,
                                 uint64_t& outQueueBytes,
                                 ASFW::Shared::TxSharedQueueSPSC& outQueueReader,
                                 bool& outQueueValid) {
-    IOBufferMemoryDescriptor* queueMemory = nullptr;
+    IOBufferMemoryDescriptor* queueMemoryRaw = nullptr;
     uint64_t queueBytes = 0;
-    const kern_return_t copyStatus = nub.CopyRxQueueMemory(&queueMemory, &queueBytes);
+    const kern_return_t copyStatus = nub.CopyRxQueueMemory(&queueMemoryRaw, &queueBytes);
     if (copyStatus != kIOReturnSuccess) {
+        if (queueMemoryRaw) {
+            queueMemoryRaw->release();
+        }
         outQueueValid = false;
         return copyStatus;
     }
 
-    return MapSharedQueue(queueMemory,
+    return MapSharedQueue(Common::AdoptRetained(queueMemoryRaw),
                           queueBytes,
                           outQueueMemory,
                           outQueueMap,
@@ -81,15 +80,18 @@ kern_return_t MapTxQueueFromNub(ASFWAudioNub& nub,
                                 uint64_t& outQueueBytes,
                                 ASFW::Shared::TxSharedQueueSPSC& outQueueWriter,
                                 bool& outQueueValid) {
-    IOBufferMemoryDescriptor* queueMemory = nullptr;
+    IOBufferMemoryDescriptor* queueMemoryRaw = nullptr;
     uint64_t queueBytes = 0;
-    const kern_return_t copyStatus = nub.CopyTransmitQueueMemory(&queueMemory, &queueBytes);
+    const kern_return_t copyStatus = nub.CopyTransmitQueueMemory(&queueMemoryRaw, &queueBytes);
     if (copyStatus != kIOReturnSuccess) {
+        if (queueMemoryRaw) {
+            queueMemoryRaw->release();
+        }
         outQueueValid = false;
         return copyStatus;
     }
 
-    return MapSharedQueue(queueMemory,
+    return MapSharedQueue(Common::AdoptRetained(queueMemoryRaw),
                           queueBytes,
                           outQueueMemory,
                           outQueueMap,
@@ -98,13 +100,15 @@ kern_return_t MapTxQueueFromNub(ASFWAudioNub& nub,
                           outQueueValid);
 }
 
+// Positional output parameters mirror the shared-memory mapping state being populated.
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 kern_return_t MapZeroCopyOutputFromNub(bool enableZeroCopy,
                                        ASFWAudioNub& nub,
                                        uint32_t channelCount,
                                        OSSharedPtr<IOBufferMemoryDescriptor>& outStreamOutputBuffer,
                                        OSSharedPtr<IOBufferMemoryDescriptor>& outSharedOutputBuffer,
                                        OSSharedPtr<IOMemoryMap>& outSharedOutputMap,
-                                       uint64_t& outSharedOutputBytes,
+                                       uint64_t& outSharedOutputBytes, // NOLINT(bugprone-easily-swappable-parameters)
                                        uint32_t& outZeroCopyFrameCapacity,
                                        bool& outZeroCopyEnabled) {
     outZeroCopyEnabled = false;
@@ -121,40 +125,37 @@ kern_return_t MapZeroCopyOutputFromNub(bool enableZeroCopy,
     uint64_t sharedOutputBytes = 0;
     kern_return_t copyStatus = nub.CopyOutputAudioMemory(&sharedOutputRaw, &sharedOutputBytes);
     if (copyStatus != kIOReturnSuccess || !sharedOutputRaw || sharedOutputBytes == 0) {
+        if (sharedOutputRaw) {
+            sharedOutputRaw->release();
+        }
         return (copyStatus == kIOReturnSuccess) ? kIOReturnNoMemory : copyStatus;
     }
 
-    outSharedOutputBuffer.reset(sharedOutputRaw, OSNoRetain);
+    outSharedOutputBuffer = Common::AdoptRetained(sharedOutputRaw);
     outSharedOutputBytes = sharedOutputBytes;
 
-    IOMemoryMap* outputMapRaw = nullptr;
-    kern_return_t mappingStatus = sharedOutputRaw->CreateMapping(
-        kIOMemoryMapCacheModeDefault,
-        0,
-        0,
-        0,
-        0,
-        &outputMapRaw);
-    if (mappingStatus != kIOReturnSuccess || !outputMapRaw) {
+    const kern_return_t mappingStatus =
+        Common::CreateSharedMapping(outSharedOutputBuffer, outSharedOutputMap);
+    if (mappingStatus != kIOReturnSuccess) {
         outSharedOutputBuffer.reset();
         outSharedOutputBytes = 0;
-        return (mappingStatus == kIOReturnSuccess) ? kIOReturnNoMemory : mappingStatus;
+        return mappingStatus;
     }
 
-    outSharedOutputMap.reset(outputMapRaw, OSNoRetain);
     outZeroCopyEnabled = true;
     if (channelCount > 0) {
         outZeroCopyFrameCapacity = static_cast<uint32_t>(
             sharedOutputBytes / (sizeof(int32_t) * channelCount));
     }
 
-    outStreamOutputBuffer.reset(sharedOutputRaw, OSRetain);
+    outStreamOutputBuffer = outSharedOutputBuffer;
     return kIOReturnSuccess;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void ResetZeroCopyState(OSSharedPtr<IOBufferMemoryDescriptor>& inOutSharedOutputBuffer,
                         OSSharedPtr<IOMemoryMap>& inOutSharedOutputMap,
-                        uint64_t& inOutSharedOutputBytes,
+                        uint64_t& inOutSharedOutputBytes, // NOLINT(bugprone-easily-swappable-parameters)
                         uint32_t& inOutZeroCopyFrameCapacity,
                         bool& inOutZeroCopyEnabled) {
     inOutZeroCopyEnabled = false;

--- a/ASFWDriver/Isoch/Core/ExternalSyncBridge.hpp
+++ b/ASFWDriver/Isoch/Core/ExternalSyncBridge.hpp
@@ -50,8 +50,10 @@ public:
     // Observe one RX CIP sample and publish it when valid for 48k sync tracking.
     // Returns true when establish threshold is reached and caller should log transition.
     // Caller must set bridge.clockEstablished after emitting transition log.
+    // These arguments are ordered to match the RX packet fields consumed together.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     bool ObserveSample(ExternalSyncBridge& bridge,
-                       uint64_t nowHostTicks,
+                       uint64_t nowHostTicks, // NOLINT(bugprone-easily-swappable-parameters)
                        uint16_t syt,
                        uint8_t fdf,
                        uint8_t dbs,
@@ -84,8 +86,9 @@ public:
                 consecutiveValid_ >= kEstablishValidUpdates);
     }
 
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     bool HandleStale(ExternalSyncBridge& bridge,
-                     uint64_t nowHostTicks,
+                     uint64_t nowHostTicks, // NOLINT(bugprone-easily-swappable-parameters)
                      uint64_t staleThresholdHostTicks) noexcept {
         if (!bridge.active.load(std::memory_order_acquire)) {
             consecutiveValid_ = 0;

--- a/ASFWDriver/Isoch/Encoding/AudioRingBuffer.hpp
+++ b/ASFWDriver/Isoch/Encoding/AudioRingBuffer.hpp
@@ -34,8 +34,10 @@ namespace Encoding {
 /// Channel count is runtime (1..Isoch::Config::kMaxPcmChannels).
 /// FrameCount is compile-time (power of 2 for efficient modulo).
 ///
+// Cacheline separation here is intentional for the SPSC hot path.
+// NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 template <uint32_t FrameCount = Isoch::Config::kAudioRingBufferFrames>
-class AudioRingBuffer {
+class AudioRingBuffer { // NOLINT(clang-analyzer-optin.performance.Padding)
 public:
     static_assert((FrameCount & (FrameCount - 1)) == 0,
                   "FrameCount must be power of 2 for efficient modulo");
@@ -119,7 +121,9 @@ public:
         if (toRead == 0) {
             underrunCount_.fetch_add(1, std::memory_order_relaxed);
             // Fill output with silence
-            std::memset(data, 0, frameCount * channelCount_ * sizeof(int32_t));
+            std::memset(data,
+                        0,
+                        static_cast<size_t>(frameCount) * channelCount_ * sizeof(int32_t));
             return 0;
         }
 

--- a/ASFWDriver/Isoch/Encoding/CIPHeaderBuilder.hpp
+++ b/ASFWDriver/Isoch/Encoding/CIPHeaderBuilder.hpp
@@ -37,6 +37,8 @@ public:
     /// Construct a CIP header builder.
     /// @param sid Source node ID (6 bits, from OHCI NodeID register)
     /// @param dbs Data block size in quadlets (2 for stereo)
+    // Positional `(sid, dbs)` matches the CIP header field order.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     explicit CIPHeaderBuilder(uint8_t sid = 0, uint8_t dbs = 2) noexcept
         : sid_(sid & 0x3F), dbs_(dbs) {}
     
@@ -75,6 +77,7 @@ public:
     ///   [23:16] FDF = Format dependent field (SFC for audio)
     ///   [15:0]  SYT = Presentation timestamp (0xFFFF for NO-DATA)
     ///
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     CIPHeader build(uint8_t dbc, uint16_t syt, bool isNoData = false) const noexcept {
         CIPHeader header;
         

--- a/ASFWDriver/Isoch/Encoding/PacketAssembler.hpp
+++ b/ASFWDriver/Isoch/Encoding/PacketAssembler.hpp
@@ -42,10 +42,11 @@ constexpr uint32_t kSamplesPerDataPacket = 8;
 constexpr uint32_t kCIPHeaderSize = 8;
 
 /// Compile-time max audio payload size (8 frames × max AM824 slots × 4 bytes)
-constexpr uint32_t kMaxAudioDataSize = kSamplesPerDataPacket * Isoch::Config::kMaxAmdtpDbs * sizeof(uint32_t);
+constexpr size_t kMaxAudioDataSize =
+    static_cast<size_t>(kSamplesPerDataPacket) * Isoch::Config::kMaxAmdtpDbs * sizeof(uint32_t);
 
 /// Compile-time max assembled packet size (CIP header + max audio data)
-constexpr uint32_t kMaxAssembledPacketSize = kCIPHeaderSize + kMaxAudioDataSize;
+constexpr size_t kMaxAssembledPacketSize = kCIPHeaderSize + kMaxAudioDataSize;
 
 /// Underrun diagnostic snapshot (1A: detection).
 /// All fields atomically updated in assembleDataPacket() hot path.
@@ -76,6 +77,8 @@ struct AssembledPacket {
 ///   3. Call assembleNext() for each FireWire cycle (8000/sec)
 ///   4. Transmit or validate the assembled packet
 ///
+// Hot-path layout intentionally keeps cadence, DBC, ring-buffer, and diagnostics separate.
+// NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 class PacketAssembler {
 public:
     /// Construct a packet assembler.
@@ -98,7 +101,9 @@ public:
 
     /// Get runtime data packet size in bytes.
     uint32_t dataPacketSize() const noexcept {
-        return kCIPHeaderSize + samplesPerDataPacket() * am824SlotCount_ * sizeof(uint32_t);
+        const size_t payloadBytes =
+            static_cast<size_t>(samplesPerDataPacket()) * am824SlotCount_ * sizeof(uint32_t);
+        return static_cast<uint32_t>(kCIPHeaderSize + payloadBytes);
     }
 
     /// Get DATA packet frame count for the active stream mode (48k paths only).
@@ -121,6 +126,8 @@ public:
     /// Reconfigure PCM channels and wire AM824 slot count (CIP DBS).
     /// `am824Slots` may exceed `channels` when the stream carries non-audio slots
     /// such as MIDI conformant data.
+    // Positional arguments mirror PCM-channels / wire-slots / SID reconfiguration.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     void reconfigureAM824(uint32_t channels, uint32_t am824Slots, uint8_t sid) noexcept {
         channelCount_ = channels;
         am824SlotCount_ = am824Slots;
@@ -310,8 +317,8 @@ private:
             underrunDiag_.lastDbc.store(packet.dbc, std::memory_order_relaxed);
 
             // SAFETY: Zero remaining samples to prevent encoding stale stack data
-            size_t samplesRead = framesRead * channelCount_;
-            size_t totalSamples = framesPerPacket * channelCount_;
+            size_t samplesRead = static_cast<size_t>(framesRead) * channelCount_;
+            size_t totalSamples = static_cast<size_t>(framesPerPacket) * channelCount_;
             std::memset(&samples[samplesRead], 0, (totalSamples - samplesRead) * sizeof(int32_t));
         }
 
@@ -358,8 +365,8 @@ private:
                                         uint32_t frames,
                                         uint32_t* outWireQuadlets) const noexcept {
         for (uint32_t f = 0; f < frames; ++f) {
-            const int32_t* frameIn = pcmInterleaved + (f * channelCount_);
-            uint32_t* frameOut = outWireQuadlets + (f * am824SlotCount_);
+            const int32_t* frameIn = pcmInterleaved + (static_cast<size_t>(f) * channelCount_);
+            uint32_t* frameOut = outWireQuadlets + (static_cast<size_t>(f) * am824SlotCount_);
 
             for (uint32_t ch = 0; ch < channelCount_; ++ch) {
                 frameOut[ch] = AM824Encoder::encode(frameIn[ch]);
@@ -373,7 +380,7 @@ private:
     void fillSilentAm824Frames(uint32_t frames, uint32_t* outWireQuadlets) const noexcept {
         const uint32_t silence = AM824Encoder::encodeSilence();
         for (uint32_t f = 0; f < frames; ++f) {
-            uint32_t* frameOut = outWireQuadlets + (f * am824SlotCount_);
+            uint32_t* frameOut = outWireQuadlets + (static_cast<size_t>(f) * am824SlotCount_);
             for (uint32_t ch = 0; ch < channelCount_; ++ch) {
                 frameOut[ch] = silence;
             }
@@ -429,6 +436,7 @@ private:
     
 public:
     /// Snapshot debug counters for 1Hz logging (resets counters atomically)
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     void snapshotDebug(uint64_t& dataPkts, uint64_t& underruns) noexcept {
         dataPkts = dbgDataPackets_.exchange(0, std::memory_order_relaxed);
         underruns = dbgUnderrunPackets_.exchange(0, std::memory_order_relaxed);
@@ -436,8 +444,9 @@ public:
 
     /// 1A: Record an underrun from external caller (zero-copy path).
     /// Called by IsochTransmitContext when zeroCopyFillBefore < framesPerPacket.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     void recordUnderrun(uint32_t fillLevel, uint32_t requestedFrames,
-                        uint32_t availableFrames, uint64_t cycleNumber,
+                        uint32_t availableFrames, uint64_t cycleNumber, // NOLINT(bugprone-easily-swappable-parameters)
                         uint8_t dbc) noexcept {
         underrunDiag_.underrunCount.fetch_add(1, std::memory_order_relaxed);
         underrunDiag_.lastFillLevel.store(fillLevel, std::memory_order_relaxed);

--- a/ASFWDriver/Isoch/Encoding/SYTGenerator.cpp
+++ b/ASFWDriver/Isoch/Encoding/SYTGenerator.cpp
@@ -36,6 +36,7 @@ void SYTGenerator::reset() noexcept {
     ASFW_LOG(Isoch, "SYTGenerator: Reset (cycle-based mode)");
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 uint16_t SYTGenerator::computeDataSYT(uint32_t transmitCycle, uint32_t samplesInPacket) noexcept {
     if (!initialized_) return kNoInfo;
     if (samplesInPacket == 0 || ticksPerSample_ == 0) return kNoInfo;

--- a/ASFWDriver/Isoch/IsochService.cpp
+++ b/ASFWDriver/Isoch/IsochService.cpp
@@ -2,12 +2,14 @@
 
 #include <DriverKit/IOLib.h>
 #include <atomic>
+#include <utility>
 
 #include "IsochReceiveContext.hpp"
 #include "Transmit/IsochTransmitContext.hpp"
 #include "Memory/IsochDMAMemoryManager.hpp"
 #include "Config/AudioTxProfiles.hpp"
 #include "Encoding/TimingUtils.hpp"
+#include "../Common/DriverKitOwnership.hpp"
 #include "../Hardware/HardwareInterface.hpp"
 #include "../Logging/Logging.hpp"
 
@@ -15,14 +17,11 @@ namespace ASFW::Driver {
 
 kern_return_t IsochService::StartReceive(uint8_t channel,
                                          HardwareInterface& hardware,
-                                         IOBufferMemoryDescriptor* rxQueueMemory,
+                                         OSSharedPtr<IOBufferMemoryDescriptor> rxQueueMemory,
                                          uint64_t rxQueueBytes) {
     if (isochReceiveContext_ &&
         isochReceiveContext_->GetState() == ASFW::Isoch::IRPolicy::State::Running) {
         ASFW_LOG(Controller, "[Isoch] IR already running; StartReceive is idempotent");
-        if (rxQueueMemory) {
-            rxQueueMemory->release();
-        }
         return kIOReturnSuccess;
     }
 
@@ -30,23 +29,15 @@ kern_return_t IsochService::StartReceive(uint8_t channel,
 
     void* rxQueueBase = nullptr;
     if (rxQueueMemory && rxQueueBytes > 0) {
-        rxQueue_.memory.reset(rxQueueMemory, OSNoRetain);
+        rxQueue_.memory = std::move(rxQueueMemory);
         rxQueue_.bytes = rxQueueBytes;
 
-        IOMemoryMap* mapRaw = nullptr;
-        const kern_return_t mappingStatus = rxQueueMemory->CreateMapping(
-            kIOMemoryMapCacheModeDefault,
-            0,
-            0,
-            0,
-            0,
-            &mapRaw);
-        if (mappingStatus != kIOReturnSuccess || !mapRaw) {
+        const kern_return_t mappingStatus =
+            Common::CreateSharedMapping(rxQueue_.memory, rxQueue_.map);
+        if (mappingStatus != kIOReturnSuccess) {
             rxQueue_.Reset();
-            return (mappingStatus == kIOReturnSuccess) ? kIOReturnNoMemory : mappingStatus;
+            return mappingStatus;
         }
-
-        rxQueue_.map.reset(mapRaw, OSNoRetain);
         rxQueueBase = rxQueue_.BaseAddress();
     }
 
@@ -60,11 +51,13 @@ kern_return_t IsochService::StartReceive(uint8_t channel,
         auto isochMem = ASFW::Isoch::Memory::IsochDMAMemoryManager::Create(config);
         if (!isochMem) {
             ASFW_LOG(Controller, "[Isoch] ❌ StartIsochReceive: Failed to create Memory Manager");
+            rxQueue_.Reset();
             return kIOReturnNoMemory;
         }
 
         if (!isochMem->Initialize(hardware)) {
             ASFW_LOG(Controller, "[Isoch] ❌ StartIsochReceive: Failed to initialize DMA slabs");
+            rxQueue_.Reset();
             return kIOReturnNoMemory;
         }
 
@@ -72,6 +65,7 @@ kern_return_t IsochService::StartReceive(uint8_t channel,
 
         if (!isochReceiveContext_) {
             ASFW_LOG(Controller, "[Isoch] ❌ StartIsochReceive: Context creation failed");
+            rxQueue_.Reset();
             return kIOReturnNoMemory;
         }
         ASFW_LOG(Controller, "[Isoch] ✅ provisioned Isoch Context with Dedicated Memory");
@@ -119,7 +113,7 @@ kern_return_t IsochService::StartTransmit(uint8_t channel,
                                           uint32_t streamModeRaw,
                                           uint32_t pcmChannels,
                                           uint32_t am824Slots,
-                                          IOBufferMemoryDescriptor* txQueueMemory,
+                                          OSSharedPtr<IOBufferMemoryDescriptor> txQueueMemory,
                                           uint64_t txQueueBytes,
                                           void* zeroCopyBase,
                                           uint64_t zeroCopyBytes,
@@ -128,9 +122,6 @@ kern_return_t IsochService::StartTransmit(uint8_t channel,
     if (isochTransmitContext_ &&
         isochTransmitContext_->GetState() == ASFW::Isoch::ITState::Running) {
         ASFW_LOG(Controller, "[Isoch] IT already running; StartTransmit is idempotent");
-        if (txQueueMemory) {
-            txQueueMemory->release();
-        }
         return kIOReturnSuccess;
     }
 
@@ -138,23 +129,15 @@ kern_return_t IsochService::StartTransmit(uint8_t channel,
 
     void* txQueueBase = nullptr;
     if (txQueueMemory && txQueueBytes > 0) {
-        txQueue_.memory.reset(txQueueMemory, OSNoRetain);
+        txQueue_.memory = std::move(txQueueMemory);
         txQueue_.bytes = txQueueBytes;
 
-        IOMemoryMap* mapRaw = nullptr;
-        const kern_return_t mappingStatus = txQueueMemory->CreateMapping(
-            kIOMemoryMapCacheModeDefault,
-            0,
-            0,
-            0,
-            0,
-            &mapRaw);
-        if (mappingStatus != kIOReturnSuccess || !mapRaw) {
+        const kern_return_t mappingStatus =
+            Common::CreateSharedMapping(txQueue_.memory, txQueue_.map);
+        if (mappingStatus != kIOReturnSuccess) {
             txQueue_.Reset();
-            return (mappingStatus == kIOReturnSuccess) ? kIOReturnNoMemory : mappingStatus;
+            return mappingStatus;
         }
-
-        txQueue_.map.reset(mapRaw, OSNoRetain);
         txQueueBase = txQueue_.BaseAddress();
     }
 
@@ -342,31 +325,20 @@ kern_return_t IsochService::StopTransmit() {
 
 kern_return_t IsochService::StartDuplex(const IsochDuplexStartParams& params,
                                        HardwareInterface& hardware) {
-    // Ownership: callers pass retained IOBufferMemoryDescriptor* values (from
-    // ASFWAudioNub::Copy*QueueMemory). IsochService consumes them regardless of
-    // outcome, releasing on all early-return paths.
-    IOBufferMemoryDescriptor* rxQueueMemory = params.rxQueueMemory;
-    IOBufferMemoryDescriptor* txQueueMemory = params.txQueueMemory;
-
     if (params.guid == 0) {
-        if (rxQueueMemory) rxQueueMemory->release();
-        if (txQueueMemory) txQueueMemory->release();
         return kIOReturnBadArgument;
     }
 
     if (activeGuid_ != 0 && activeGuid_ != params.guid) {
         // Transport layer is currently global. Control-plane enforces single-device too.
-        if (rxQueueMemory) rxQueueMemory->release();
-        if (txQueueMemory) txQueueMemory->release();
         return kIOReturnBusy;
     }
 
     const kern_return_t krRx = StartReceive(params.irChannel,
                                            hardware,
-                                           rxQueueMemory,
+                                           params.rxQueueMemory,
                                            params.rxQueueBytes);
     if (krRx != kIOReturnSuccess) {
-        if (txQueueMemory) txQueueMemory->release();
         return krRx;
     }
 
@@ -377,7 +349,7 @@ kern_return_t IsochService::StartDuplex(const IsochDuplexStartParams& params,
                                             streamModeRaw,
                                             params.hostOutputPcmChannels,
                                             params.hostToDeviceAm824Slots,
-                                            txQueueMemory,
+                                            params.txQueueMemory,
                                             params.txQueueBytes,
                                             params.zeroCopyBase,
                                             params.zeroCopyBytes,

--- a/ASFWDriver/Isoch/IsochService.hpp
+++ b/ASFWDriver/Isoch/IsochService.hpp
@@ -15,6 +15,7 @@
 #include "Core/ExternalSyncBridge.hpp"
 #include "Transmit/IsochTransmitContext.hpp"
 #include "../Audio/Model/ASFWAudioDevice.hpp"
+#include "../Common/DriverKitOwnership.hpp"
 
 namespace ASFW::Driver {
 
@@ -37,9 +38,9 @@ struct IsochDuplexStartParams {
 
     ASFW::Audio::Model::StreamMode streamMode{ASFW::Audio::Model::StreamMode::kNonBlocking};
 
-    IOBufferMemoryDescriptor* rxQueueMemory{nullptr};
+    OSSharedPtr<IOBufferMemoryDescriptor> rxQueueMemory{};
     uint64_t rxQueueBytes{0};
-    IOBufferMemoryDescriptor* txQueueMemory{nullptr};
+    OSSharedPtr<IOBufferMemoryDescriptor> txQueueMemory{};
     uint64_t txQueueBytes{0};
 
     void* zeroCopyBase{nullptr};
@@ -54,7 +55,7 @@ public:
 
     kern_return_t StartReceive(uint8_t channel,
                                HardwareInterface& hardware,
-                               IOBufferMemoryDescriptor* rxQueueMemory,
+                               OSSharedPtr<IOBufferMemoryDescriptor> rxQueueMemory,
                                uint64_t rxQueueBytes);
 
     kern_return_t StopReceive();
@@ -65,7 +66,7 @@ public:
                                 uint32_t streamModeRaw,
                                 uint32_t pcmChannels,
                                 uint32_t am824Slots,
-                                IOBufferMemoryDescriptor* txQueueMemory,
+                                OSSharedPtr<IOBufferMemoryDescriptor> txQueueMemory,
                                 uint64_t txQueueBytes,
                                 void* zeroCopyBase,
                                 uint64_t zeroCopyBytes,

--- a/ASFWDriver/Isoch/Receive/IsochAudioRxPipeline.cpp
+++ b/ASFWDriver/Isoch/Receive/IsochAudioRxPipeline.cpp
@@ -65,9 +65,10 @@ void IsochAudioRxPipeline::OnPacket(const uint8_t* payload, size_t length) noexc
     }
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void IsochAudioRxPipeline::OnPollEnd(Driver::HardwareInterface& hw,
-                                    uint32_t packetsProcessed,
-                                    uint64_t pollStartMachTicks) noexcept {
+                                     uint32_t packetsProcessed, // NOLINT(bugprone-easily-swappable-parameters)
+                                     uint64_t pollStartMachTicks) noexcept {
     if (packetsProcessed > 0) {
         const uint64_t end = mach_absolute_time();
         const uint64_t deltaTicks = end - pollStartMachTicks;

--- a/ASFWDriver/Isoch/Receive/IsochReceiveContext.cpp
+++ b/ASFWDriver/Isoch/Receive/IsochReceiveContext.cpp
@@ -53,6 +53,7 @@ IsochReceiveContext::Registers IsochReceiveContext::GetRegisters(uint8_t index) 
     };
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 kern_return_t IsochReceiveContext::Configure(uint8_t channel, uint8_t contextIndex) {
     if (!hardware_ || !dmaMemory_) {
         return kIOReturnNotReady;
@@ -198,4 +199,3 @@ void IsochReceiveContext::LogHardwareState() {
 }
 
 } // namespace ASFW::Isoch
-

--- a/ASFWDriver/Isoch/Receive/IsochReceiveContext.hpp
+++ b/ASFWDriver/Isoch/Receive/IsochReceiveContext.hpp
@@ -42,7 +42,7 @@ struct IRPolicy {
 };
 
 struct IRTag {
-    static constexpr std::string_view kContextName = "IsochReceiveContext";
+    static constexpr const char kContextName[] = "IsochReceiveContext";
 };
 
 class IsochReceiveContext : public OSObject,
@@ -109,4 +109,3 @@ private:
 };
 
 } // namespace ASFW::Isoch
-

--- a/ASFWDriver/Isoch/Receive/IsochRxDmaRing.cpp
+++ b/ASFWDriver/Isoch/Receive/IsochRxDmaRing.cpp
@@ -51,12 +51,13 @@ kern_return_t IsochRxDmaRing::SetupRings(Memory::IIsochDMAMemory& dma,
             const uint8_t interruptBits =
                 (i % 8 == 7) ? Async::HW::OHCIDescriptor::kIntAlways : Async::HW::OHCIDescriptor::kIntNever;
 
-            uint32_t control = Async::HW::OHCIDescriptor::BuildControl(
-                reqCount,
-                Async::HW::OHCIDescriptor::kCmdInputLast,
-                Async::HW::OHCIDescriptor::kKeyStandard,
-                interruptBits,
-                Async::HW::OHCIDescriptor::kBranchAlways);
+            uint32_t control = Async::HW::OHCIDescriptor::BuildControl({
+                .reqCount = reqCount,
+                .command = Async::HW::OHCIDescriptor::kCmdInputLast,
+                .key = Async::HW::OHCIDescriptor::kKeyStandard,
+                .interruptBits = interruptBits,
+                .branchBits = Async::HW::OHCIDescriptor::kBranchAlways,
+            });
             control |= (1u << (Async::HW::OHCIDescriptor::kStatusShift + Async::HW::OHCIDescriptor::kControlHighShift));
             desc->control = control;
 
@@ -123,12 +124,13 @@ kern_return_t IsochRxDmaRing::SetupRings(Memory::IIsochDMAMemory& dma,
         const uint8_t interruptBits =
             (i % 8 == 7) ? Async::HW::OHCIDescriptor::kIntAlways : Async::HW::OHCIDescriptor::kIntNever;
 
-        uint32_t control = Async::HW::OHCIDescriptor::BuildControl(
-            reqCount,
-            Async::HW::OHCIDescriptor::kCmdInputLast,
-            Async::HW::OHCIDescriptor::kKeyStandard,
-            interruptBits,
-            Async::HW::OHCIDescriptor::kBranchAlways);
+        uint32_t control = Async::HW::OHCIDescriptor::BuildControl({
+            .reqCount = reqCount,
+            .command = Async::HW::OHCIDescriptor::kCmdInputLast,
+            .key = Async::HW::OHCIDescriptor::kKeyStandard,
+            .interruptBits = interruptBits,
+            .branchBits = Async::HW::OHCIDescriptor::kBranchAlways,
+        });
         control |= (1u << (Async::HW::OHCIDescriptor::kStatusShift + Async::HW::OHCIDescriptor::kControlHighShift));
         desc->control = control;
 

--- a/ASFWDriver/Isoch/Receive/StreamProcessor.hpp
+++ b/ASFWDriver/Isoch/Receive/StreamProcessor.hpp
@@ -92,7 +92,7 @@ public:
         
         // Payload Calculation (cipLength = total minus isoch header, payloadBytes = minus CIP header)
         size_t payloadBytes = cipLength - 8;  // Subtract 8 bytes for CIP header
-        size_t dbsBytes = header->dataBlockSize * 4;
+        size_t dbsBytes = static_cast<size_t>(header->dataBlockSize) * 4u;
         
         if (dbsBytes == 0) {
             // Should not happen for AM824

--- a/ASFWDriver/Isoch/Transmit/IsochAudioTxPipeline.cpp
+++ b/ASFWDriver/Isoch/Transmit/IsochAudioTxPipeline.cpp
@@ -14,15 +14,17 @@ inline uint32_t EncodeMidiPlaceholderSlot(uint32_t midiSlotIndex) noexcept {
     return Encoding::AM824Encoder::encodeLabelOnly(label);
 }
 
+// Positional arguments mirror PCM input then AM824 output layout.
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 inline void EncodePcmFramesWithAm824Placeholders(const int32_t* pcmInterleaved,
-                                                 uint32_t frames,
+                                                 uint32_t frames, // NOLINT(bugprone-easily-swappable-parameters)
                                                  uint32_t pcmChannels,
                                                  uint32_t am824Slots,
                                                  uint32_t* outWireQuadlets) noexcept {
     const uint32_t midiSlots = (am824Slots > pcmChannels) ? (am824Slots - pcmChannels) : 0;
     for (uint32_t f = 0; f < frames; ++f) {
-        const int32_t* frameIn = pcmInterleaved + (f * pcmChannels);
-        uint32_t* frameOut = outWireQuadlets + (f * am824Slots);
+        const int32_t* frameIn = pcmInterleaved + (static_cast<size_t>(f) * pcmChannels);
+        uint32_t* frameOut = outWireQuadlets + (static_cast<size_t>(f) * am824Slots);
 
         for (uint32_t ch = 0; ch < pcmChannels; ++ch) {
             frameOut[ch] = Encoding::AM824Encoder::encode(frameIn[ch]);
@@ -98,6 +100,7 @@ void IsochAudioTxPipeline::SetZeroCopyOutputBuffer(void* base, uint64_t bytes, u
              assembler_.isZeroCopyEnabled() ? "ENABLED" : "fallback");
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 kern_return_t IsochAudioTxPipeline::Configure(uint8_t sid,
                                               uint32_t streamModeRaw,
                                               uint32_t requestedChannels,
@@ -151,7 +154,8 @@ kern_return_t IsochAudioTxPipeline::Configure(uint8_t sid,
              effectiveStreamMode_ == Encoding::StreamMode::kBlocking ? "blocking" : "non-blocking");
 
     const uint32_t framesPerDataPacket = assembler_.samplesPerDataPacket();
-    const uint32_t payloadBytes = framesPerDataPacket * am824Slots * sizeof(uint32_t);
+    const uint32_t payloadBytes = static_cast<uint32_t>(
+        static_cast<size_t>(framesPerDataPacket) * am824Slots * sizeof(uint32_t));
     const uint32_t packetBytes = Encoding::kCIPHeaderSize + payloadBytes;
     ASFW_LOG(Isoch,
              "IT: Channel geometry resolved pcm=%u dbs=%u midiSlots=%u framesPerData=%u payloadBytes=%u packetBytes=%u",
@@ -469,7 +473,8 @@ Tx::IsochTxPacket IsochAudioTxPipeline::NextSilentPacket(uint32_t transmitCycle)
     }
 
     Tx::IsochTxPacket out{};
-    out.words = reinterpret_cast<const uint32_t*>(pkt.data);
+    std::memcpy(silentPacketStorage_.data(), pkt.data, pkt.size);
+    out.words = reinterpret_cast<const uint32_t*>(silentPacketStorage_.data());
     out.sizeBytes = pkt.size;
     out.isData = pkt.isData;
     out.dbc = pkt.dbc;
@@ -559,8 +564,8 @@ void IsochAudioTxPipeline::InjectNearHw(uint32_t hwPacketIndex, Tx::IsochTxDescr
         }
 
         if (framesRead < framesPerPacket) {
-            const size_t samplesRead = framesRead * pcmChannels;
-            const size_t totalSamples = framesPerPacket * pcmChannels;
+            const size_t samplesRead = static_cast<size_t>(framesRead) * pcmChannels;
+            const size_t totalSamples = static_cast<size_t>(framesPerPacket) * pcmChannels;
             std::memset(&samples[samplesRead], 0,
                         (totalSamples - samplesRead) * sizeof(int32_t));
         }

--- a/ASFWDriver/Isoch/Transmit/IsochAudioTxPipeline.hpp
+++ b/ASFWDriver/Isoch/Transmit/IsochAudioTxPipeline.hpp
@@ -14,6 +14,7 @@
 #include "../../Shared/TxSharedQueue.hpp"
 #include "../../Logging/Logging.hpp"
 
+#include <array>
 #include <atomic>
 #include <cstdint>
 #include <cstring>
@@ -88,6 +89,8 @@ public:
     // -------------------------------------------------------------------------
     // Tx::IIsochTxPacketProvider
     // -------------------------------------------------------------------------
+    // The returned payload pointer remains valid until the next
+    // NextSilentPacket() call on this pipeline instance.
     [[nodiscard]] Tx::IsochTxPacket NextSilentPacket(uint32_t transmitCycle) noexcept override;
 
     // -------------------------------------------------------------------------
@@ -117,6 +120,7 @@ private:
     } adaptiveFill_;
 
     Encoding::PacketAssembler assembler_{};
+    alignas(std::uint32_t) std::array<std::uint8_t, Encoding::kMaxAssembledPacketSize> silentPacketStorage_{};
     Shared::TxSharedQueueSPSC sharedTxQueue_{};
 
     // ZERO-COPY: Direct pointer to CoreAudio output buffer

--- a/ASFWDriver/Isoch/Transmit/IsochTransmitContext.cpp
+++ b/ASFWDriver/Isoch/Transmit/IsochTransmitContext.cpp
@@ -445,11 +445,6 @@ void IsochTransmitContext::DumpPayloadBuffers(uint32_t numPackets) const noexcep
     ring_.DumpPayloadBuffers(numPackets);
 }
 
-void IsochTransmitContext::PrimeOnly() noexcept {
-    if (!ring_.HasRings()) return;
-    ring_.Prime(audio_);
-}
-
 void IsochTransmitContext::DumpDescriptorRing(uint32_t startPacket, uint32_t numPackets) const noexcept {
     ring_.DumpDescriptorRing(startPacket, numPackets);
 }

--- a/ASFWDriver/Isoch/Transmit/IsochTransmitContext.hpp
+++ b/ASFWDriver/Isoch/Transmit/IsochTransmitContext.hpp
@@ -119,7 +119,6 @@ public:
     
     void LogStatistics() const noexcept;
     void DumpPayloadBuffers(uint32_t numPackets = 4) const noexcept;
-    void PrimeOnly() noexcept;
     void DumpDescriptorRing(uint32_t startPacket = 0, uint32_t numPackets = 8) const noexcept;
 
 private:

--- a/ASFWDriver/Isoch/Transmit/IsochTxDescriptorSlab.hpp
+++ b/ASFWDriver/Isoch/Transmit/IsochTxDescriptorSlab.hpp
@@ -52,13 +52,15 @@ public:
 
     [[nodiscard]] uint8_t* PayloadPtr(uint32_t packetIndex) noexcept {
         return bufRegion_.virtualBase
-            ? (reinterpret_cast<uint8_t*>(bufRegion_.virtualBase) + (packetIndex * Layout::kMaxPacketSize))
+            ? (reinterpret_cast<uint8_t*>(bufRegion_.virtualBase) +
+               (static_cast<size_t>(packetIndex) * Layout::kMaxPacketSize))
             : nullptr;
     }
 
     [[nodiscard]] const uint8_t* PayloadPtr(uint32_t packetIndex) const noexcept {
         return bufRegion_.virtualBase
-            ? (reinterpret_cast<const uint8_t*>(bufRegion_.virtualBase) + (packetIndex * Layout::kMaxPacketSize))
+            ? (reinterpret_cast<const uint8_t*>(bufRegion_.virtualBase) +
+               (static_cast<size_t>(packetIndex) * Layout::kMaxPacketSize))
             : nullptr;
     }
 

--- a/ASFWDriver/Isoch/Transmit/IsochTxDmaRing.cpp
+++ b/ASFWDriver/Isoch/Transmit/IsochTxDmaRing.cpp
@@ -361,7 +361,7 @@ void IsochTxDmaRing::DumpPayloadBuffers(uint32_t numPackets) const noexcept {
 
     for (uint32_t pktIdx = 0; pktIdx < numPackets; ++pktIdx) {
         const uint8_t* payloadVirt = reinterpret_cast<const uint8_t*>(buf.virtualBase) +
-                                     (pktIdx * Layout::kMaxPacketSize);
+                                     (static_cast<size_t>(pktIdx) * Layout::kMaxPacketSize);
         const uint32_t* payload32 = reinterpret_cast<const uint32_t*>(payloadVirt);
 
         const uint32_t cip0 = payload32[0];

--- a/ASFWDriver/Isoch/Transmit/IsochTxLayout.hpp
+++ b/ASFWDriver/Isoch/Transmit/IsochTxLayout.hpp
@@ -40,7 +40,8 @@ struct Layout final {
 
     // Worst-case packet size we reserve per slot (kept simple: fixed stride per packet).
     static constexpr uint32_t kMaxPacketSize = 4096;
-    static constexpr size_t kPayloadBufferSize = kNumPackets * kMaxPacketSize;
+    static constexpr size_t kPayloadBufferSize =
+        static_cast<size_t>(kNumPackets) * static_cast<size_t>(kMaxPacketSize);
 
     // Guard band in packets used by verifier mismatch checks.
     static constexpr uint32_t kGuardBandPackets = 4;
@@ -52,11 +53,11 @@ struct Layout final {
     // Static assertions
     static_assert(kDescriptorsPerPage >= kBlocksPerPacket, "Need at least one packet per page");
     static_assert((kDescriptorsPerPage % kBlocksPerPacket) == 0, "Keep packets within a page");
-    static_assert((kDescriptorsPerPage * kDescriptorStride) <= kUsablePerPage, "Must fit in usable space");
+    static_assert((static_cast<size_t>(kDescriptorsPerPage) * kDescriptorStride) <= kUsablePerPage,
+                  "Must fit in usable space");
     static_assert(kBlocksPerPacket == 3, "Z must be 3 for OMI(2)+OL(1)");
     static_assert(sizeof(Async::HW::OHCIDescriptor) == 16, "OHCI descriptor must be 16 bytes");
     static_assert(kDescriptorStride == sizeof(Async::HW::OHCIDescriptor), "Stride must match descriptor size");
 };
 
 } // namespace ASFW::Isoch::Tx
-

--- a/ASFWDriver/Isoch/Transmit/IsochTxRecoveryController.cpp
+++ b/ASFWDriver/Isoch/Transmit/IsochTxRecoveryController.cpp
@@ -42,6 +42,7 @@ bool IsochTxRecoveryController::TryBegin(uint64_t nowNs, uint32_t& outReasons) n
     return true;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void IsochTxRecoveryController::Complete(uint64_t nowNs, uint32_t reasons, bool success) noexcept {
     if (success) {
         lastRestartNs_.store(nowNs, std::memory_order_relaxed);
@@ -55,4 +56,3 @@ void IsochTxRecoveryController::Complete(uint64_t nowNs, uint32_t reasons, bool 
 }
 
 } // namespace ASFW::Isoch
-

--- a/ASFWDriver/Isoch/Transmit/IsochTxVerifier.cpp
+++ b/ASFWDriver/Isoch/Transmit/IsochTxVerifier.cpp
@@ -82,6 +82,7 @@ void IsochTxVerifier::Kick(const Inputs& inputs) noexcept {
 #endif
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void IsochTxVerifier::CaptureBeforeOverwrite(uint32_t packetIndex,
                                              uint32_t hwPacketIndexCmdPtr,
                                              uint32_t cmdPtr,
@@ -245,7 +246,7 @@ void IsochTxVerifier::RunWork() noexcept {
             : inputs_.pcmChannels;
         const uint16_t expectedDataReq = static_cast<uint16_t>(
             Encoding::kCIPHeaderSize +
-            inputs_.framesPerPacket * expectedAm824Slots * sizeof(uint32_t));
+            static_cast<size_t>(inputs_.framesPerPacket) * expectedAm824Slots * sizeof(uint32_t));
 
         const bool isNoDataByReq = (e.reqCount == expectedNoDataReq);
         const bool isDataByReq = (e.reqCount > expectedNoDataReq);

--- a/ASFWDriver/Isoch/Transmit/IsochTxVerifier.hpp
+++ b/ASFWDriver/Isoch/Transmit/IsochTxVerifier.hpp
@@ -72,7 +72,9 @@ private:
         uint32_t cipQ1Host{0};
         uint16_t reqCount{0};
         uint16_t audioQuadletCount{0};
-        std::array<uint32_t, Tx::Layout::kAudioWriteAhead * Config::kMaxAmdtpDbs> audioHost{};
+        std::array<uint32_t,
+                   static_cast<size_t>(Tx::Layout::kAudioWriteAhead) * Config::kMaxAmdtpDbs>
+            audioHost{};
     };
 
     static constexpr uint32_t kTraceCapacity = 1024;

--- a/ASFWDriver/Protocols/AVC/AVCCommand.hpp
+++ b/ASFWDriver/Protocols/AVC/AVCCommand.hpp
@@ -20,6 +20,7 @@
 #include <optional>
 #include "AVCDefs.hpp"
 #include "FCPTransport.hpp"
+#include "../../Common/CallbackUtils.hpp"
 #include "../../Logging/Logging.hpp"
 
 // Forward declarations for dispatch types (implementation uses libdispatch)
@@ -173,8 +174,9 @@ public:
     ///
     /// @param completion Callback with result and response CDB
     void Submit(AVCCompletion completion) {
+        auto completionState = Common::ShareCallback(std::move(completion));
         if (!cdb_.IsValid()) {
-            completion(AVCResult::kInvalidResponse, cdb_);
+            Common::InvokeSharedCallback(completionState, AVCResult::kInvalidResponse, cdb_);
             return;
         }
 
@@ -186,13 +188,13 @@ public:
         
         if (!self) {
              ASFW_LOG(AVC, "AVCCommand::Submit called without shared ownership - command dropped");
-             completion(AVCResult::kTransportError, cdb_);
+             Common::InvokeSharedCallback(completionState, AVCResult::kTransportError, cdb_);
              return;
         }
         
         fcpHandle_ = transport_.SubmitCommand(frame,
-            [self, completion](FCPStatus fcpStatus, const FCPFrame& response) {
-                self->OnFCPComplete(fcpStatus, response, completion);
+            [self, completionState](FCPStatus fcpStatus, const FCPFrame& response) {
+                self->OnFCPComplete(fcpStatus, response, completionState);
             });
     }
 
@@ -220,24 +222,24 @@ protected:
     /// @param completion User completion callback
     virtual void OnFCPComplete(FCPStatus fcpStatus,
                                const FCPFrame& response,
-                               AVCCompletion completion) {
+                               const std::shared_ptr<AVCCompletion>& completion) {
         // Handle FCP-level errors
         if (fcpStatus != FCPStatus::kOk) {
             AVCResult result = MapFCPStatus(fcpStatus);
-            completion(result, cdb_);
+            Common::InvokeSharedCallback(completion, result, cdb_);
             return;
         }
 
         // Decode AV/C response
         auto responseCdb = AVCCdb::Decode(response);
         if (!responseCdb) {
-            completion(AVCResult::kInvalidResponse, cdb_);
+            Common::InvokeSharedCallback(completion, AVCResult::kInvalidResponse, cdb_);
             return;
         }
 
         // Map ctype to result
         AVCResult result = CTypeToResult(responseCdb->ctype);
-        completion(result, *responseCdb);
+        Common::InvokeSharedCallback(completion, result, *responseCdb);
     }
 
     /// Map FCP status to AV/C result

--- a/ASFWDriver/Protocols/AVC/AVCCommands.hpp
+++ b/ASFWDriver/Protocols/AVC/AVCCommands.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "AVCCommand.hpp"
+#include "../../Common/CallbackUtils.hpp"
 #include <vector>
 
 namespace ASFW::Protocols::AVC {
@@ -52,13 +53,14 @@ public:
     ///
     /// @param completion Callback with result and parsed plug info
     void Submit(std::function<void(AVCResult, const PlugInfo&)> completion) {
-        AVCCommand::Submit([this, completion](AVCResult result,
-                                               const AVCCdb& response) {
+        auto completionState = Common::ShareCallback(std::move(completion));
+        AVCCommand::Submit([this, completionState](AVCResult result,
+                                                   const AVCCdb& response) {
             if (IsSuccess(result)) {
                 PlugInfo info = ParseResponse(response);
-                completion(result, info);
+                Common::InvokeSharedCallback(completionState, result, info);
             } else {
-                completion(result, {});
+                Common::InvokeSharedCallback(completionState, result, PlugInfo{});
             }
         });
     }
@@ -69,6 +71,8 @@ private:
     /// @param subunitType Subunit type (0xFF = unit)
     /// @param subunitID Subunit ID (0-7)
     /// @return Command CDB
+    // Positional AV/C subunit fields are kept in wire-order.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     static AVCCdb BuildCdb(uint8_t subunitType, uint8_t subunitID) {
         AVCCdb cdb;
         cdb.ctype = static_cast<uint8_t>(AVCCommandType::kStatus);
@@ -152,13 +156,14 @@ public:
     ///
     /// @param completion Callback with result and parsed subunit info
     void Submit(std::function<void(AVCResult, const SubunitInfo&)> completion) {
-        AVCCommand::Submit([this, completion](AVCResult result,
-                                               const AVCCdb& response) {
+        auto completionState = Common::ShareCallback(std::move(completion));
+        AVCCommand::Submit([this, completionState](AVCResult result,
+                                                   const AVCCdb& response) {
             if (IsSuccess(result)) {
                 SubunitInfo info = ParseResponse(response);
-                completion(result, info);
+                Common::InvokeSharedCallback(completionState, result, info);
             } else {
-                completion(result, {});
+                Common::InvokeSharedCallback(completionState, result, SubunitInfo{});
             }
         });
     }

--- a/ASFWDriver/Protocols/AVC/AVCDefs.hpp
+++ b/ASFWDriver/Protocols/AVC/AVCDefs.hpp
@@ -48,12 +48,12 @@ constexpr uint64_t kPCR_iPCRBase = kPCRBaseAddress + 0x80;
 
 /// Get oPCR address for plug number
 inline constexpr uint64_t GetOPCRAddress(uint8_t plugNum) {
-    return kPCR_oPCRBase + (plugNum * 4);
+    return kPCR_oPCRBase + (static_cast<uint64_t>(plugNum) * 4ULL);
 }
 
 /// Get iPCR address for plug number
 inline constexpr uint64_t GetIPCRAddress(uint8_t plugNum) {
-    return kPCR_iPCRBase + (plugNum * 4);
+    return kPCR_iPCRBase + (static_cast<uint64_t>(plugNum) * 4ULL);
 }
 
 //==============================================================================

--- a/ASFWDriver/Protocols/AVC/AVCSignalFormatCommand.hpp
+++ b/ASFWDriver/Protocols/AVC/AVCSignalFormatCommand.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "AVCCommand.hpp"
+#include "../../Common/CallbackUtils.hpp"
 #include "StreamFormats/StreamFormatTypes.hpp"
 #include <vector>
 
@@ -34,15 +35,17 @@ public:
         : AVCCommand(transport, BuildCdb(subunitAddr, isInput, plugID)) {}
 
     void Submit(std::function<void(AVCResult, SignalFormat)> completion) {
-        AVCCommand::Submit([completion](AVCResult result, const AVCCdb& response) {
+        auto completionState = Common::ShareCallback(std::move(completion));
+        AVCCommand::Submit([completionState](AVCResult result, const AVCCdb& response) {
             if (IsSuccess(result) && response.operandLength >= 2) {
                 SignalFormat fmt;
                 fmt.format = response.operands[0];
                 // Use Music Subunit specific mapping
                 fmt.sampleRate = StreamFormats::MusicSubunitCodeToSampleRate(response.operands[1]);
-                completion(result, fmt);
+                Common::InvokeSharedCallback(completionState, result, fmt);
             } else {
-                completion(result, {0xFF, StreamFormats::SampleRate::kUnknown});
+                Common::InvokeSharedCallback(completionState, result,
+                                             SignalFormat{0xFF, StreamFormats::SampleRate::kUnknown});
             }
         });
     }
@@ -75,14 +78,15 @@ public:
         : AVCCommand(transport, BuildCdb(plugID)) {}
 
     void Submit(std::function<void(AVCResult, SignalFormat)> completion) {
-        AVCCommand::Submit([completion](AVCResult result, const AVCCdb& response) {
+        auto completionState = Common::ShareCallback(std::move(completion));
+        AVCCommand::Submit([completionState](AVCResult result, const AVCCdb& response) {
             if (IsSuccess(result) && response.operandLength >= 3) {
                 SignalFormat fmt;
                 fmt.formatHierarchy = response.operands[1];
                 fmt.formatSync = response.operands[2];
-                completion(result, fmt);
+                Common::InvokeSharedCallback(completionState, result, fmt);
             } else {
-                completion(result, {0xFF, 0xFF});
+                Common::InvokeSharedCallback(completionState, result, SignalFormat{0xFF, 0xFF});
             }
         });
     }

--- a/ASFWDriver/Protocols/AVC/AVCStreamFormatCommand.hpp
+++ b/ASFWDriver/Protocols/AVC/AVCStreamFormatCommand.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "AVCCommand.hpp"
+#include "../../Common/CallbackUtils.hpp"
 #include <vector>
 #include <optional>
 
@@ -42,41 +43,46 @@ struct StreamFormat {
 class AVCStreamFormatCommand : public AVCCommand {
 public:
     /// Constructor for querying current format
+    // Positional plug-addressing follows the AV/C command encoding.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     AVCStreamFormatCommand(FCPTransport& transport,
-                          uint8_t subunitAddr,
-                          uint8_t plugNum,
-                          bool isInput,
-                          bool useAlternateOpcode = false)
+                           uint8_t subunitAddr,
+                           uint8_t plugNum,
+                           bool isInput,
+                           bool useAlternateOpcode = false)
         : AVCCommand(transport, BuildCdb(subunitAddr, plugNum, isInput, 
                                         kStreamFormatSubfunc_Current, 0xFF,
                                         useAlternateOpcode)) {}
     
     /// Constructor for querying supported formats
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     AVCStreamFormatCommand(FCPTransport& transport,
-                          uint8_t subunitAddr,
-                          uint8_t plugNum,
-                          bool isInput,
-                          uint8_t listIndex,
-                          bool useAlternateOpcode = false)
+                           uint8_t subunitAddr,
+                           uint8_t plugNum,
+                           bool isInput,
+                           uint8_t listIndex,
+                           bool useAlternateOpcode = false)
         : AVCCommand(transport, BuildCdb(subunitAddr, plugNum, isInput,
                                         kStreamFormatSubfunc_Supported, listIndex,
                                         useAlternateOpcode)) {}
     
     /// Submit command with parsed format response
     void Submit(std::function<void(AVCResult, const std::optional<StreamFormat>&)> completion) {
-        AVCCommand::Submit([completion](AVCResult result, const AVCCdb& response) {
+        auto completionState = Common::ShareCallback(std::move(completion));
+        AVCCommand::Submit([completionState](AVCResult result, const AVCCdb& response) {
             if (IsSuccess(result)) {
                 auto format = ParseFormat(response);
-                completion(result, format);
+                Common::InvokeSharedCallback(completionState, result, format);
             } else {
-                completion(result, std::nullopt);
+                Common::InvokeSharedCallback(completionState, result, std::optional<StreamFormat>{});
             }
         });
     }
 
 private:
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     static AVCCdb BuildCdb(uint8_t subunitAddr, uint8_t plugNum, bool isInput,
-                          uint8_t subfunction, uint8_t listIndex, bool useAlternateOpcode) {
+                           uint8_t subfunction, uint8_t listIndex, bool useAlternateOpcode) { // NOLINT(bugprone-easily-swappable-parameters)
         AVCCdb cdb;
         cdb.ctype = static_cast<uint8_t>(AVCCommandType::kStatus);
         cdb.subunit = subunitAddr;

--- a/ASFWDriver/Protocols/AVC/AVCUnit.cpp
+++ b/ASFWDriver/Protocols/AVC/AVCUnit.cpp
@@ -6,6 +6,7 @@
 //
 
 #include "AVCUnit.hpp"
+#include "../../Common/CallbackUtils.hpp"
 #include "../../Logging/Logging.hpp"
 #include "Descriptors/DescriptorAccessor.hpp"
 #include "AVCSignalFormatCommand.hpp"
@@ -56,6 +57,7 @@ AVCUnit::AVCUnit(std::shared_ptr<Discovery::FWDevice> device,
 }
 
 void AVCUnit::ProbeUnitInfo(std::function<void(bool)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     // UNIT_INFO: [STATUS, unit, opcode=0x30], no operands
     AVCCdb cdb{};
     cdb.ctype = static_cast<uint8_t>(AVCCommandType::kStatus);
@@ -63,15 +65,15 @@ void AVCUnit::ProbeUnitInfo(std::function<void(bool)> completion) {
     cdb.opcode = static_cast<uint8_t>(AVCOpcode::kUnitInfo);
     cdb.operandLength = 0;
 
-    SubmitCommand(cdb, [this, completion](AVCResult result, const AVCCdb&) {
+    SubmitCommand(cdb, [this, completionState](AVCResult result, const AVCCdb&) {
         if (!IsSuccess(result)) {
             ASFW_LOG_V1(AVC, "AVCUnit: UNIT_INFO failed: result=%d",
                          static_cast<int>(result));
-            completion(false);
+            Common::InvokeSharedCallback(completionState, false);
             return;
         }
         ASFW_LOG_V2(AVC, "AVCUnit: UNIT_INFO succeeded");
-        completion(true);
+        Common::InvokeSharedCallback(completionState, true);
     });
 }
 
@@ -84,31 +86,32 @@ AVCUnit::~AVCUnit() {
 //==============================================================================
 
 void AVCUnit::Initialize(std::function<void(bool)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     if (initialized_) {
         ASFW_LOG_V2(AVC, "AVCUnit: Already initialized");
-        completion(true);
+        Common::InvokeSharedCallback(completionState, true);
         return;
     }
 
     ASFW_LOG_V1(AVC, "AVCUnit: Initializing...");
 
-    ProbeDescriptorMechanism([this, completion](bool descriptorOk) {
-        ProbeSignalFormat([this, completion](bool signalFormatOk) {
-            ProbeUnitInfo([this, completion](bool unitOk) {
+    ProbeDescriptorMechanism([this, completionState](bool descriptorOk) {
+        ProbeSignalFormat([this, completionState](bool signalFormatOk) {
+            ProbeUnitInfo([this, completionState](bool unitOk) {
                 if (!unitOk) {
                     ASFW_LOG_V1(AVC, "AVCUnit: UNIT_INFO probe failed");
-                    completion(false);
+                    Common::InvokeSharedCallback(completionState, false);
                     return;
                 }
 
-            ProbeSubunits([this, completion](bool subunitOk) {
+            ProbeSubunits([this, completionState](bool subunitOk) {
                 if (!subunitOk) {
                     ASFW_LOG_V1(AVC, "AVCUnit: Subunit probe failed");
-                    completion(false);
+                    Common::InvokeSharedCallback(completionState, false);
                     return;
                 }
 
-                ProbePlugs([this, completion](bool plugsOk) {
+                ProbePlugs([this, completionState](bool plugsOk) {
                     initialized_ = plugsOk;
 
                     if (plugsOk) { // NOSONAR(cpp:S3923): branches log different diagnostic messages
@@ -125,7 +128,7 @@ void AVCUnit::Initialize(std::function<void(bool)> completion) {
                         ASFW_LOG_V1(AVC, "AVCUnit: Plug probe failed");
                     }
 
-                    completion(plugsOk);
+                    Common::InvokeSharedCallback(completionState, plugsOk);
                 });
             });
         });
@@ -159,16 +162,17 @@ void AVCUnit::ReScan(std::function<void(bool)> completion) {
 //==============================================================================
 
 void AVCUnit::ProbeSubunits(std::function<void(bool)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     // Create SUBUNIT_INFO command (page 0)
     auto cmd = std::make_shared<AVCSubunitInfoCommand>(*fcpTransport_, 0);
 
     // Submit command
-    cmd->Submit([this, completion, cmd](AVCResult result,
+    cmd->Submit([this, completionState, cmd](AVCResult result,
                                          const AVCSubunitInfoCommand::SubunitInfo& info) {
         if (!IsSuccess(result)) {
         ASFW_LOG_V1(AVC, "AVCUnit: SUBUNIT_INFO failed: result=%d",
                          static_cast<int>(result));
-            completion(false);
+            Common::InvokeSharedCallback(completionState, false);
             return;
         }
 
@@ -178,7 +182,7 @@ void AVCUnit::ProbeSubunits(std::function<void(bool)> completion) {
         ASFW_LOG_V1(AVC, "AVCUnit: Found %zu subunits", subunits_.size());
 
         // Now parse capabilities for each subunit
-        ParseSubunitCapabilities(0, completion);
+        ParseSubunitCapabilities(0, *completionState);
     });
 }
 
@@ -234,20 +238,21 @@ void AVCUnit::StoreSubunitInfo(const AVCSubunitInfoCommand::SubunitInfo& info) {
 
 
 void AVCUnit::ParseSubunitCapabilities(size_t index, std::function<void(bool)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     if (index >= subunits_.size()) {
         // All done
-        completion(true);
+        Common::InvokeSharedCallback(completionState, true);
         return;
     }
 
     auto subunit = subunits_[index];
-    subunit->ParseCapabilities(*this, [this, index, completion](bool success) {
+    subunit->ParseCapabilities(*this, [this, index, completionState](bool success) {
         if (!success) {
             ASFW_LOG_V2(AVC, "AVCUnit: Failed to parse capabilities for subunit %zu", index);
             // Continue anyway? Yes, partial success is better than failure.
         }
         // Next
-        ParseSubunitCapabilities(index + 1, completion);
+        ParseSubunitCapabilities(index + 1, *completionState);
     });
 }
 
@@ -257,16 +262,17 @@ void AVCUnit::ParseSubunitCapabilities(size_t index, std::function<void(bool)> c
 //==============================================================================
 
 void AVCUnit::ProbePlugs(std::function<void(bool)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     // Query unit-level plugs (subunit = 0xFF) using new command (Opcode 0x02 Subfunction 0x00)
     auto cmd = std::make_shared<AVCUnitPlugInfoCommand>(*this);
 
-    cmd->Submit([this, completion](AVCResult result,
+    cmd->Submit([this, completionState](AVCResult result,
                                          const UnitPlugCounts& info) {
         if (!IsSuccess(result)) {
             ASFW_LOG_V1(AVC,
                          "AVCUnit: PLUG_INFO failed: result=%d",
                          static_cast<int>(result));
-            completion(false);
+            Common::InvokeSharedCallback(completionState, false);
             return;
         }
 
@@ -278,15 +284,16 @@ void AVCUnit::ProbePlugs(std::function<void(bool)> completion) {
                     info.isoInputPlugs, info.isoOutputPlugs,
                     info.extInputPlugs, info.extOutputPlugs);
 
-        completion(true);
+        Common::InvokeSharedCallback(completionState, true);
     });
 }
 
 void AVCUnit::ProbeSignalFormat(std::function<void(bool)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     // Query Plug 0
     auto cmd = std::make_shared<AVCOutputPlugSignalFormatCommand>(*fcpTransport_, 0);
 
-    cmd->Submit([this, completion](AVCResult result,
+    cmd->Submit([this, completionState](AVCResult result,
                                    const AVCOutputPlugSignalFormatCommand::SignalFormat& fmt) {
         if (IsSuccess(result)) {
             ASFW_LOG_INFO(Discovery, "Received Signal Format: Format=0x%02x, RateCode=0x%02x", fmt.formatHierarchy, fmt.formatSync);
@@ -308,7 +315,7 @@ void AVCUnit::ProbeSignalFormat(std::function<void(bool)> completion) {
             ASFW_LOG_ERROR(Discovery, "Failed to send Signal Format Query: result=%d", static_cast<int>(result));
         }
         // Always continue
-        completion(true);
+        Common::InvokeSharedCallback(completionState, true);
     });
 }
 
@@ -389,12 +396,13 @@ bool AVCUnit::ParseUnitIdentifier(const std::vector<uint8_t>& data) {
 }
 
 void AVCUnit::ProbeDescriptorMechanism(std::function<void(bool)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     ASFW_LOG_V2(AVC, "AVCUnit: Probing descriptor mechanism (Status Descriptor 0x80)...");
 
     if (!descriptorAccessor_) {
         ASFW_LOG_V2(AVC, "AVCUnit: No DescriptorAccessor, skipping descriptors");
         descriptorInfo_.descriptorMechanismSupported = false;
-        completion(true);
+        Common::InvokeSharedCallback(completionState, true);
         return;
     }
 
@@ -405,12 +413,12 @@ void AVCUnit::ProbeDescriptorMechanism(std::function<void(bool)> completion) {
 
     descriptorAccessor_->readWithOpenCloseSequence(
         specifier,
-        [this, self, completion](const DescriptorAccessor::ReadDescriptorResult& result) {
+        [this, self, completionState](const DescriptorAccessor::ReadDescriptorResult& result) {
             if (!result.success) {
                 ASFW_LOG_V2(AVC, "AVCUnit: Status Descriptor read failed: %d",
                              static_cast<int>(result.avcResult));
                 descriptorInfo_.descriptorMechanismSupported = false;
-                completion(true);  // Continue despite failure
+                Common::InvokeSharedCallback(completionState, true);  // Continue despite failure
                 return;
             }
 
@@ -427,18 +435,19 @@ void AVCUnit::ProbeDescriptorMechanism(std::function<void(bool)> completion) {
             }
             
             // Skip TraverseRootLists for Music Subunits using Status Descriptor model
-            completion(true);
+            Common::InvokeSharedCallback(completionState, true);
         });
 }
 
 void AVCUnit::TraverseRootLists(size_t listIndex,
                                 std::function<void(bool)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     if (listIndex >= descriptorInfo_.rootListIDs.size()) {
         // All lists traversed
         ASFW_LOG_V2(AVC,
                      "AVCUnit: Traversed all %zu root object lists",
                      descriptorInfo_.rootListContents.size());
-        completion(true);
+        Common::InvokeSharedCallback(completionState, true);
         return;
     }
 
@@ -449,7 +458,7 @@ void AVCUnit::TraverseRootLists(size_t listIndex,
 
     auto self = shared_from_this();
     ReadRootObjectList(listID,
-        [this, self, listIndex, listID, completion]
+        [this, self, listIndex, listID, completionState]
         (bool success, std::vector<uint64_t> objectIDs) {
 
             if (success) {
@@ -469,16 +478,17 @@ void AVCUnit::TraverseRootLists(size_t listIndex,
             }
 
             // Continue to next list (graceful degradation)
-            TraverseRootLists(listIndex + 1, completion);
+            TraverseRootLists(listIndex + 1, *completionState);
         });
 }
 
 void AVCUnit::ReadRootObjectList(
     uint64_t listID,
     std::function<void(bool success, std::vector<uint64_t> objectIDs)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
 
     if (!descriptorAccessor_) {
-        completion(false, {});
+        Common::InvokeSharedCallback(completionState, false, std::vector<uint64_t>{});
         return;
     }
 
@@ -500,14 +510,14 @@ void AVCUnit::ReadRootObjectList(
 
     descriptorAccessor_->readWithOpenCloseSequence(
         specifier,
-        [this, self, listID, completion]
+        [this, self, listID, completionState]
         (const DescriptorAccessor::ReadDescriptorResult& result) {
 
             if (!result.success) {
                 ASFW_LOG_V2(AVC,
                                 "AVCUnit: Failed to read list 0x%llx: result=%d",
                                 listID, static_cast<int>(result.avcResult));
-                completion(false, {});
+                Common::InvokeSharedCallback(completionState, false, std::vector<uint64_t>{});
                 return;
             }
 
@@ -515,7 +525,7 @@ void AVCUnit::ReadRootObjectList(
             const auto& data = result.data;
             if (data.size() < 4) {
                 ASFW_LOG_V1(AVC, "AVCUnit: List descriptor too short");
-                completion(false, {});
+                Common::InvokeSharedCallback(completionState, false, std::vector<uint64_t>{});
                 return;
             }
 
@@ -534,7 +544,7 @@ void AVCUnit::ReadRootObjectList(
 
             if (data.size() < expectedSize) {
                 ASFW_LOG_V1(AVC, "AVCUnit: List data too short for entries");
-                completion(false, {});
+                Common::InvokeSharedCallback(completionState, false, std::vector<uint64_t>{});
                 return;
             }
 
@@ -551,7 +561,7 @@ void AVCUnit::ReadRootObjectList(
                 ptr += objectIdSize;
             }
 
-            completion(true, std::move(objectIDs));
+            Common::InvokeSharedCallback(completionState, true, std::move(objectIDs));
         });
 }
 

--- a/ASFWDriver/Protocols/AVC/AVCUnitPlugInfoCommand.hpp
+++ b/ASFWDriver/Protocols/AVC/AVCUnitPlugInfoCommand.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "IAVCCommandSubmitter.hpp"
+#include "../../Common/CallbackUtils.hpp"
 #include <functional>
 
 namespace ASFW::Protocols::AVC {
@@ -39,11 +40,12 @@ public:
 
     /// Submit command
     void Submit(std::function<void(AVCResult, const UnitPlugCounts&)> completion) {
-        submitter_.SubmitCommand(cdb_, [completion](AVCResult result, const AVCCdb& response) {
+        auto completionState = Common::ShareCallback(std::move(completion));
+        submitter_.SubmitCommand(cdb_, [completionState](AVCResult result, const AVCCdb& response) {
             if (IsSuccess(result)) {
-                completion(result, ParseResponse(response));
+                Common::InvokeSharedCallback(completionState, result, ParseResponse(response));
             } else {
-                completion(result, UnitPlugCounts{});
+                Common::InvokeSharedCallback(completionState, result, UnitPlugCounts{});
             }
         });
     }

--- a/ASFWDriver/Protocols/AVC/Audio/AudioSubunit.cpp
+++ b/ASFWDriver/Protocols/AVC/Audio/AudioSubunit.cpp
@@ -9,19 +9,21 @@
 #include "../AVCUnit.hpp"
 #include "../AVCCommands.hpp"
 #include "../AudioFunctionBlockCommand.hpp"
+#include "../../../Common/CallbackUtils.hpp"
 #include "../../../Logging/Logging.hpp"
 
 using namespace ASFW::Protocols::AVC::Audio;
 
 void AudioSubunit::ParseCapabilities(AVCUnit& unit, std::function<void(bool)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     ASFW_LOG_INFO(Discovery, "AudioSubunit: Parsing capabilities for Audio subunit (id=%d)", GetID());
     
     auto unitPtr = unit.shared_from_this();
     
-    QueryPlugCounts(unit, [this, unitPtr, completion](bool success) {
+    QueryPlugCounts(unit, [this, unitPtr, completionState](bool success) {
         if (!success) {
             ASFW_LOG_WARNING(Discovery, "AudioSubunit: Failed to query plug counts");
-            completion(false);
+            Common::InvokeSharedCallback(completionState, false);
             return;
         }
         
@@ -37,41 +39,43 @@ void AudioSubunit::ParseCapabilities(AVCUnit& unit, std::function<void(bool)> co
                 inputPlugs_[i].plugNumber = i;
                 inputPlugs_[i].isInput = true;
             }
-            QueryPlugFormats(*unitPtr, 0, true, completion);
+            QueryPlugFormats(*unitPtr, 0, true, *completionState);
         } else if (numOutputPlugs_ > 0) {
             outputPlugs_.resize(numOutputPlugs_);
             for (size_t i = 0; i < numOutputPlugs_; ++i) {
                 outputPlugs_[i].plugNumber = i;
                 outputPlugs_[i].isInput = false;
             }
-            QueryPlugFormats(*unitPtr, 0, false, completion);
+            QueryPlugFormats(*unitPtr, 0, false, *completionState);
         } else {
             ASFW_LOG_INFO(Discovery, "AudioSubunit: No plugs to query");
-            completion(true);
+            Common::InvokeSharedCallback(completionState, true);
         }
     });
 }
 
 void AudioSubunit::QueryPlugCounts(AVCUnit& unit, std::function<void(bool)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     uint8_t subunitAddr = (static_cast<uint8_t>(GetType()) << 3) | (GetID() & 0x07);
     
     auto cmd = std::make_shared<AVCPlugInfoCommand>(unit.GetFCPTransport(), subunitAddr);
     
-    cmd->Submit([this, completion, cmd](AVCResult result, const AVCPlugInfoCommand::PlugInfo& info) {
+    cmd->Submit([this, completionState, cmd](AVCResult result, const AVCPlugInfoCommand::PlugInfo& info) {
         if (IsSuccess(result)) {
             numInputPlugs_ = info.numDestPlugs;
             numOutputPlugs_ = info.numSrcPlugs;
-            completion(true);
+            Common::InvokeSharedCallback(completionState, true);
         } else {
             ASFW_LOG_ERROR(Discovery, "AudioSubunit: PLUG_INFO failed: result=%d",
                           static_cast<int>(result));
-            completion(false);
+            Common::InvokeSharedCallback(completionState, false);
         }
     });
 }
 
 void AudioSubunit::QueryPlugFormats(AVCUnit& unit, size_t plugIndex, bool isInput,
                                    std::function<void(bool)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     auto& plugs = isInput ? inputPlugs_ : outputPlugs_;
     
     if (plugIndex >= plugs.size()) {
@@ -81,10 +85,10 @@ void AudioSubunit::QueryPlugFormats(AVCUnit& unit, size_t plugIndex, bool isInpu
                 outputPlugs_[i].plugNumber = i;
                 outputPlugs_[i].isInput = false;
             }
-            QueryPlugFormats(unit, 0, false, completion);
+            QueryPlugFormats(unit, 0, false, *completionState);
         } else {
             ASFW_LOG_INFO(Discovery, "AudioSubunit: Finished querying all plug formats");
-            completion(true);
+            Common::InvokeSharedCallback(completionState, true);
         }
         return;
     }
@@ -97,7 +101,7 @@ void AudioSubunit::QueryPlugFormats(AVCUnit& unit, size_t plugIndex, bool isInpu
     auto cmd = std::make_shared<AVCStreamFormatCommand>(unit.GetFCPTransport(),
                                                         subunitAddr, plugNum, isInput);
     
-    cmd->Submit([this, unitPtr, plugIndex, isInput, completion, cmd](
+    cmd->Submit([this, unitPtr, plugIndex, isInput, completionState, cmd](
                 AVCResult result, const std::optional<StreamFormat>& format) {
         auto& plugs = isInput ? inputPlugs_ : outputPlugs_;
         
@@ -112,11 +116,13 @@ void AudioSubunit::QueryPlugFormats(AVCUnit& unit, size_t plugIndex, bool isInpu
                            plugs[plugIndex].plugNumber, isInput ? "input" : "output");
         }
         
-        QueryPlugFormats(*unitPtr, plugIndex + 1, isInput, completion);
+        QueryPlugFormats(*unitPtr, plugIndex + 1, isInput, *completionState);
     });
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void AudioSubunit::SetAudioVolume(AVCUnit& unit, uint8_t plugId, int16_t volume, std::function<void(bool)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     uint8_t subunitAddr = (static_cast<uint8_t>(GetType()) << 3) | (GetID() & 0x07);
     
     // Volume data: 2 bytes, big endian
@@ -133,18 +139,19 @@ void AudioSubunit::SetAudioVolume(AVCUnit& unit, uint8_t plugId, int16_t volume,
         data
     );
     
-    cmd->Submit([completion, cmd](AVCResult result, const std::vector<uint8_t>&) {
+    cmd->Submit([completionState, cmd](AVCResult result, const std::vector<uint8_t>&) {
         if (IsSuccess(result)) {
             ASFW_LOG_V1(AVC, "AudioSubunit: Set volume success");
-            completion(true);
+            Common::InvokeSharedCallback(completionState, true);
         } else {
             ASFW_LOG_ERROR(AVC, "AudioSubunit: Set volume failed: result=%d", static_cast<int>(result));
-            completion(false);
+            Common::InvokeSharedCallback(completionState, false);
         }
     });
 }
 
 void AudioSubunit::SetAudioMute(AVCUnit& unit, uint8_t plugId, bool mute, std::function<void(bool)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     uint8_t subunitAddr = (static_cast<uint8_t>(GetType()) << 3) | (GetID() & 0x07);
     
     // Mute data: 1 byte (0x70 = Mute, 0x60 = Unmute) - typical for Audio Subunit
@@ -161,14 +168,13 @@ void AudioSubunit::SetAudioMute(AVCUnit& unit, uint8_t plugId, bool mute, std::f
         std::vector<uint8_t>{muteVal}
     );
     
-    cmd->Submit([completion, cmd](AVCResult result, const std::vector<uint8_t>&) {
+    cmd->Submit([completionState, cmd](AVCResult result, const std::vector<uint8_t>&) {
         if (IsSuccess(result)) {
             ASFW_LOG_V1(AVC, "AudioSubunit: Set mute success");
-            completion(true);
+            Common::InvokeSharedCallback(completionState, true);
         } else {
             ASFW_LOG_ERROR(AVC, "AudioSubunit: Set mute failed: result=%d", static_cast<int>(result));
-            completion(false);
+            Common::InvokeSharedCallback(completionState, false);
         }
     });
 }
-

--- a/ASFWDriver/Protocols/AVC/CMP/CMPClient.cpp
+++ b/ASFWDriver/Protocols/AVC/CMP/CMPClient.cpp
@@ -6,6 +6,7 @@
 //
 
 #include "CMPClient.hpp"
+#include "../../../Common/CallbackUtils.hpp"
 #include "../../../Logging/Logging.hpp"
 #include <DriverKit/IOLib.h>
 #include <os/log.h>
@@ -40,7 +41,11 @@ void CMPClient::SetDeviceNode(uint8_t nodeId, IRM::Generation generation) {
 // ============================================================================
 
 void CMPClient::ReadPCRQuadlet(uint32_t addressLo, PCRReadCallback callback) {
-    Async::FWAddress addr{PCRRegisters::kAddressHi, addressLo};
+    auto callbackState = Common::ShareCallback(std::move(callback));
+    Async::FWAddress addr{Async::FWAddress::AddressParts{
+        .addressHi = PCRRegisters::kAddressHi,
+        .addressLo = addressLo,
+    }};
     
     // PCR operations use device's max speed (typically S400)
     // Note: CMP to device PCRs can use full speed (unlike IRM which requires S100)
@@ -52,7 +57,7 @@ void CMPClient::ReadPCRQuadlet(uint32_t addressLo, PCRReadCallback callback) {
              addressLo, deviceNodeId_, generation_.value);
     
     busOps_.ReadQuad(gen, node, addr, speed,
-        [callback, addressLo](Async::AsyncStatus status, std::span<const uint8_t> payload) {
+        [callbackState, addressLo](Async::AsyncStatus status, std::span<const uint8_t> payload) {
             if (status == Async::AsyncStatus::kSuccess && payload.size() == 4) {
                 uint32_t raw = 0;
                 std::memcpy(&raw, payload.data(), sizeof(raw));
@@ -64,21 +69,25 @@ void CMPClient::ReadPCRQuadlet(uint32_t addressLo, PCRReadCallback callback) {
                          PCRBits::GetP2P(hostValue),
                          PCRBits::GetChannel(hostValue));
                 
-                callback(true, hostValue);
+                Common::InvokeSharedCallback(callbackState, true, hostValue);
             } else {
                 ASFW_LOG(CMP,
                          "CMPClient: Read PCR 0x%08X failed: status=%{public}s(%u)",
                          addressLo,
                          ASFW::Async::ToString(status),
                          static_cast<unsigned>(status));
-                callback(false, 0);
+                Common::InvokeSharedCallback(callbackState, false, 0u);
             }
         });
 }
 
 void CMPClient::CompareSwapPCR(uint32_t addressLo, uint32_t expected, uint32_t desired,
                                 CMPCallback callback) {
-    Async::FWAddress addr{PCRRegisters::kAddressHi, addressLo};
+    auto callbackState = Common::ShareCallback(std::move(callback));
+    Async::FWAddress addr{Async::FWAddress::AddressParts{
+        .addressHi = PCRRegisters::kAddressHi,
+        .addressLo = addressLo,
+    }};
     
     FW::FwSpeed speed{2};  // S400
     FW::NodeId node{deviceNodeId_};
@@ -96,7 +105,7 @@ void CMPClient::CompareSwapPCR(uint32_t addressLo, uint32_t expected, uint32_t d
     
     busOps_.Lock(gen, node, addr, FW::LockOp::kCompareSwap,
         std::span{operand}, 4, speed,
-        [callback, expected, desired, addressLo](Async::AsyncStatus status, std::span<const uint8_t> payload) {
+        [callbackState, expected, desired, addressLo](Async::AsyncStatus status, std::span<const uint8_t> payload) {
             if (status == Async::AsyncStatus::kSuccess && payload.size() == 4) {
                 uint32_t raw = 0;
                 std::memcpy(&raw, payload.data(), sizeof(raw));
@@ -106,11 +115,11 @@ void CMPClient::CompareSwapPCR(uint32_t addressLo, uint32_t expected, uint32_t d
                 if (succeeded) {
                     ASFW_LOG(CMP, "CMPClient: Lock PCR 0x%08X succeeded (0x%08X → 0x%08X)",
                              addressLo, expected, desired);
-                    callback(CMPStatus::Success);
+                    Common::InvokeSharedCallback(callbackState, CMPStatus::Success);
                 } else {
                     ASFW_LOG(CMP, "CMPClient: Lock PCR 0x%08X contention (expected=0x%08X actual=0x%08X)",
                              addressLo, expected, oldValue);
-                    callback(CMPStatus::Failed);
+                    Common::InvokeSharedCallback(callbackState, CMPStatus::Failed);
                 }
             } else {
                 ASFW_LOG(CMP,
@@ -118,7 +127,7 @@ void CMPClient::CompareSwapPCR(uint32_t addressLo, uint32_t expected, uint32_t d
                          addressLo,
                          ASFW::Async::ToString(status),
                          static_cast<unsigned>(status));
-                callback(CMPStatus::Failed);
+                Common::InvokeSharedCallback(callbackState, CMPStatus::Failed);
             }
         });
 }

--- a/ASFWDriver/Protocols/AVC/Descriptors/AVCDescriptorCommands.hpp
+++ b/ASFWDriver/Protocols/AVC/Descriptors/AVCDescriptorCommands.hpp
@@ -10,6 +10,7 @@
 
 #include "DescriptorTypes.hpp"
 #include "../AVCCommand.hpp"
+#include "../../../Common/CallbackUtils.hpp"
 #include <vector>
 
 namespace ASFW::Protocols::AVC {
@@ -28,8 +29,9 @@ public:
         : AVCCommand(transport, BuildCdb(subunitAddr, specifier, subfunction)) {}
 
     void Submit(std::function<void(AVCResult)> completion) {
-        AVCCommand::Submit([completion](AVCResult result, const AVCCdb& response) {
-            completion(result);
+        auto completionState = Common::ShareCallback(std::move(completion));
+        AVCCommand::Submit([completionState](AVCResult result, const AVCCdb&) {
+            Common::InvokeSharedCallback(completionState, result);
         });
     }
 
@@ -80,8 +82,9 @@ public:
 
     void Submit(std::function<void(AVCResult, const ReadResult&)> completion) {
         size_t specSize = specifierSize_;
+        auto completionState = Common::ShareCallback(std::move(completion));
         
-        AVCCommand::Submit([completion, specSize](AVCResult result, const AVCCdb& response) {
+        AVCCommand::Submit([completionState, specSize](AVCResult result, const AVCCdb& response) {
             ReadResult readResult;
             readResult.status = ReadResultStatus::kComplete; // Default
             readResult.dataLength = 0;
@@ -120,17 +123,19 @@ public:
                 }
             }
             
-            completion(result, readResult);
+            Common::InvokeSharedCallback(completionState, result, readResult);
         });
     }
 
 private:
     size_t specifierSize_; // Store for response parsing
 
-    static AVCCdb BuildCdb(uint8_t subunitAddr, 
-                          const DescriptorSpecifier& specifier,
-                          uint16_t offset, 
-                          uint16_t length) {
+    // Positional specifier/offset/length follows the descriptor read command layout.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+    static AVCCdb BuildCdb(uint8_t subunitAddr,
+                           const DescriptorSpecifier& specifier,
+                           uint16_t offset, // NOLINT(bugprone-easily-swappable-parameters)
+                           uint16_t length) {
         AVCCdb cdb;
         cdb.ctype = static_cast<uint8_t>(AVCCommandType::kControl);
         cdb.subunit = subunitAddr; // FCP Frame Header handles subunit addressing
@@ -167,8 +172,9 @@ public:
         : AVCCommand(transport, BuildCdb(subunitAddr, specifier)) {}
 
     void Submit(std::function<void(AVCResult)> completion) {
-        AVCCommand::Submit([completion](AVCResult result, const AVCCdb& response) {
-            completion(result);
+        auto completionState = Common::ShareCallback(std::move(completion));
+        AVCCommand::Submit([completionState](AVCResult result, const AVCCdb&) {
+            Common::InvokeSharedCallback(completionState, result);
         });
     }
 

--- a/ASFWDriver/Protocols/AVC/Descriptors/AVCInfoBlock.cpp
+++ b/ASFWDriver/Protocols/AVC/Descriptors/AVCInfoBlock.cpp
@@ -21,8 +21,9 @@ static inline uint16_t ReadBE16(const uint8_t* data) {
 // AVCInfoBlock - Construction
 //==============================================================================
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 AVCInfoBlock::AVCInfoBlock(
-    uint16_t compoundLength,
+    uint16_t compoundLength, // NOLINT(bugprone-easily-swappable-parameters)
     uint16_t primaryFieldsLength,
     uint16_t type,
     std::vector<uint8_t> primaryData,
@@ -76,7 +77,6 @@ std::expected<AVCInfoBlock, AVCResult> AVCInfoBlock::Parse(
     // compound_length excludes itself (2 bytes), so total size is +2
     size_t claimedTotalSize = static_cast<size_t>(compoundLength) + 2;
     size_t effectiveLength = length;
-    bool truncated = false;
 
     // compound_length includes Type(2) + PrimLen(2) + Fields...
     // So minimum valid compound_length is 4.
@@ -90,7 +90,6 @@ std::expected<AVCInfoBlock, AVCResult> AVCInfoBlock::Parse(
         ASFW_LOG_V3(Discovery,
             "Info block truncated: claimed %zu bytes (len=%u), available %zu bytes. Parsing what is available.",
             claimedTotalSize, compoundLength, length);
-        truncated = true;
         effectiveLength = length;
     } else {
         effectiveLength = claimedTotalSize;

--- a/ASFWDriver/Protocols/AVC/Descriptors/DescriptorAccessor.cpp
+++ b/ASFWDriver/Protocols/AVC/Descriptors/DescriptorAccessor.cpp
@@ -7,6 +7,7 @@
 
 #include "DescriptorAccessor.hpp"
 #include "../AVCDefs.hpp"
+#include "../../../Common/CallbackUtils.hpp"
 #include "../../../Logging/Logging.hpp"
 #include "../../../Logging/LogConfig.hpp"
 #include <algorithm>
@@ -28,6 +29,7 @@ DescriptorAccessor::DescriptorAccessor(FCPTransport& transport, uint8_t subunitA
 
 void DescriptorAccessor::openForRead(const DescriptorSpecifier& specifier,
                                      SimpleCompletion completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     ASFW_LOG_V3(Discovery, "OPEN DESCRIPTOR: subunit=0x%02x, specifier type=0x%02x, size=%zu",
                   subunitAddr_, static_cast<uint8_t>(specifier.type), specifier.size());
     
@@ -38,27 +40,28 @@ void DescriptorAccessor::openForRead(const DescriptorSpecifier& specifier,
         OpenDescriptorSubfunction::kReadOpen
     );
     
-    cmd->Submit([completion](AVCResult result) {
+    cmd->Submit([completionState](AVCResult result) {
         bool success = IsSuccess(result);
         ASFW_LOG_V3(Discovery, "OPEN DESCRIPTOR result: %d (success=%d)", 
                       static_cast<int>(result), success);
-        completion(success);
+        Common::InvokeSharedCallback(completionState, success);
     });
 }
 
 void DescriptorAccessor::close(const DescriptorSpecifier& specifier,
                                SimpleCompletion completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     auto cmd = std::make_shared<AVCCloseDescriptorCommand>(
         transport_,
         subunitAddr_,
         specifier
     );
     
-    cmd->Submit([completion](AVCResult result) {
+    cmd->Submit([completionState](AVCResult result) {
         bool success = IsSuccess(result);
         ASFW_LOG_V3(Discovery, "CLOSE DESCRIPTOR result: %d (success=%d)",
                       static_cast<int>(result), success);
-        completion(success);
+        Common::InvokeSharedCallback(completionState, success);
     });
 }
 

--- a/ASFWDriver/Protocols/AVC/Descriptors/DescriptorTypes.hpp
+++ b/ASFWDriver/Protocols/AVC/Descriptors/DescriptorTypes.hpp
@@ -231,7 +231,8 @@ struct DescriptorSpecifier {
     /// 6.2.4 Entry descriptor specified by position
     /// Structure: [20] + [list ID (variable)] + [entry position (variable)]
     /// Note: sizes defined in Unit Identifier
-    static DescriptorSpecifier forEntryPosition(const std::vector<uint8_t>& listID, 
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+    static DescriptorSpecifier forEntryPosition(const std::vector<uint8_t>& listID,
                                                 const std::vector<uint8_t>& position) {
         std::vector<uint8_t> data = listID;
         data.insert(data.end(), position.begin(), position.end());

--- a/ASFWDriver/Protocols/AVC/FCPTransport.cpp
+++ b/ASFWDriver/Protocols/AVC/FCPTransport.cpp
@@ -190,10 +190,10 @@ ASFW::Async::AsyncHandle FCPTransport::SubmitWriteCommand(const FCPFrame& frame)
 
     const FW::Generation gen{pending_->generation};
     const FW::NodeId node{static_cast<uint8_t>(device_->GetNodeID() & 0x3Fu)};
-    const Async::FWAddress addr{
-        static_cast<uint16_t>((config_.commandAddress >> 32U) & 0xFFFFU),
-        static_cast<uint32_t>(config_.commandAddress & 0xFFFFFFFFU),
-    };
+    const Async::FWAddress addr{Async::FWAddress::AddressParts{
+        .addressHi = static_cast<uint16_t>((config_.commandAddress >> 32U) & 0xFFFFU),
+        .addressLo = static_cast<uint32_t>(config_.commandAddress & 0xFFFFFFFFU),
+    }};
 
     return busOps_->WriteBlock(gen,
                                node,
@@ -238,6 +238,7 @@ bool FCPTransport::CancelCommand(FCPHandle handle) {
 // Response Reception
 //==============================================================================
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void FCPTransport::OnFCPResponse(uint16_t srcNodeID,
                                  uint32_t generation,
                                  std::span<const uint8_t> payload) {

--- a/ASFWDriver/Protocols/AVC/Music/MusicSubunit.cpp
+++ b/ASFWDriver/Protocols/AVC/Music/MusicSubunit.cpp
@@ -434,148 +434,6 @@ static std::string ExtractPlugName(const ASFW::Protocols::AVC::Descriptors::AVCI
     return "";
 }
 
-// Extract plugs from RoutingStatus block (0x8108) using position-based direction
-// Apple's VirtualMusicSubunit.cpp shows: first numDestPlugs blocks are Input, next numSourcePlugs are Output
-static void ExtractPlugsFromRoutingStatus(
-    const ASFW::Protocols::AVC::Descriptors::AVCInfoBlock& routingBlock,
-    std::vector<MusicSubunit::PlugInfo>& plugs)
-{
-    using namespace ASFW::Protocols::AVC::Descriptors;
-    using namespace ASFW::Protocols::AVC::StreamFormats;
-    
-    const auto& primaryData = routingBlock.GetPrimaryData();
-    
-    // RoutingStatus primary fields: [0]=numDestPlugs, [1]=numSourcePlugs, [2-3]=musicPlugCount
-    if (primaryData.size() < 2) {
-        ASFW_LOG_V0(MusicSubunit, "RoutingStatus: Primary fields too short (%zu bytes)", primaryData.size());
-        return;
-    }
-    
-    uint8_t numDestPlugs = primaryData[0];
-    uint8_t numSourcePlugs = primaryData[1];
-    
-    ASFW_LOG_V1(MusicSubunit, "RoutingStatus: numDestPlugs=%u, numSourcePlugs=%u", numDestPlugs, numSourcePlugs);
-    
-    // Find all SubunitPlugInfo (0x8109) blocks in order (recursive to handle nested structures)
-    auto subunitPlugInfoBlocks = routingBlock.FindAllNestedRecursive(0x8109);
-    
-    ASFW_LOG_V3(MusicSubunit, "RoutingStatus: Found %zu SubunitPlugInfo blocks", subunitPlugInfoBlocks.size());
-    
-    // Process each SubunitPlugInfo block
-    size_t blockIndex = 0;
-    for (const auto& plugInfoBlock : subunitPlugInfoBlocks) {
-        const auto& plugPrimaryData = plugInfoBlock.GetPrimaryData();
-        
-        // SubunitPlugInfo primary fields: [0]=subunit_plug_id, [1-2]=fdf_fmt, [3]=usage, [4-5]=numClusters, [6-7]=numChannels
-        if (plugPrimaryData.size() < 4) {
-            ASFW_LOG_V3(MusicSubunit, "SubunitPlugInfo: Primary fields too short (%zu bytes)", plugPrimaryData.size());
-            blockIndex++;
-            continue;
-        }
-        
-        PlugInfo plug;
-        plug.plugID = plugPrimaryData[0];  // Byte 0 is the actual subunit_plug_id
-        
-        // Map Usage (byte 3) to MusicPlugType
-        uint8_t usage = plugPrimaryData[3];
-        if (usage == 0x04 || usage == 0x05 || usage == 0x0B) {
-            plug.type = MusicPlugType::kAudio;
-        } else {
-            plug.type = static_cast<MusicPlugType>(usage);
-        }
-        
-        // Determine direction from position:
-        // - Blocks 0 to (numDestPlugs-1) are Destination (Input)
-        // - Blocks numDestPlugs to (numDestPlugs+numSourcePlugs-1) are Source (Output)
-        plug.direction = PlugDirection::kInput;  // default: dest plugs and out-of-range
-        if (blockIndex >= numDestPlugs) {
-            if (blockIndex < static_cast<size_t>(numDestPlugs + numSourcePlugs)) {
-                plug.direction = PlugDirection::kOutput;
-            } else {
-                ASFW_LOG_V1(MusicSubunit, "SubunitPlugInfo: Block %zu beyond expected count (dest=%u, src=%u)",
-                            blockIndex, numDestPlugs, numSourcePlugs);
-            }
-        }
-        
-        // Extract name from nested blocks
-        plug.name = ExtractPlugName(plugInfoBlock);
-        
-        if (!plug.name.empty()) { // NOSONAR(cpp:S3923): branches log different diagnostic messages
-            ASFW_LOG_V1(MusicSubunit, "MusicSubunit: Found Plug ID %u (%{public}s): '%{public}s'",
-                        plug.plugID, 
-                        plug.direction == PlugDirection::kInput ? "Input" : "Output",
-                        plug.name.c_str());
-        } else {
-            ASFW_LOG_V1(MusicSubunit, "MusicSubunit: Plug ID %u (%{public}s) has no name", 
-                        plug.plugID,
-                        plug.direction == PlugDirection::kInput ? "Input" : "Output");
-        }
-        // Extract ClusterInfo (0x810A) blocks and their signals
-        // ClusterInfo contains: formatCode, portType, numSignals, then signal entries
-        auto clusterBlocks = plugInfoBlock.FindAllNestedRecursive(0x810A);
-        
-        ASFW_LOG_V1(MusicSubunit, "Plug %u: Found %zu ClusterInfo blocks", plug.plugID, clusterBlocks.size());
-        
-        for (const auto& clusterBlock : clusterBlocks) {
-            const auto& clusterData = clusterBlock.GetPrimaryData();
-            
-            // ClusterInfo primary fields: [0]=formatCode, [1]=portType, [2]=numSignals
-            // Followed by 4 bytes per signal: musicPlugID(2), channel(1), location(1)
-            if (clusterData.size() < 3) {
-                ASFW_LOG_V1(MusicSubunit, "ClusterInfo: Too short (%zu bytes)", clusterData.size());
-                continue;
-            }
-            
-            ChannelFormatInfo channelFormat;
-            channelFormat.formatCode = static_cast<StreamFormatCode>(clusterData[0]);
-            uint8_t numSignals = clusterData[2];
-            channelFormat.channelCount = numSignals;
-            
-            ASFW_LOG_V1(MusicSubunit, "ClusterInfo: formatCode=0x%02X, numSignals=%u, dataSize=%zu",
-                        clusterData[0], numSignals, clusterData.size());
-            
-            // Parse signal entries (4 bytes each)
-            for (uint8_t sig = 0; sig < numSignals; ++sig) {
-                size_t sigOffset = 3 + sig * 4;
-                if (sigOffset + 4 > clusterData.size()) break;
-                
-                ChannelFormatInfo::ChannelDetail detail;
-                detail.musicPlugID = (static_cast<uint16_t>(clusterData[sigOffset]) << 8) | 
-                                     clusterData[sigOffset + 1];
-                detail.position = sig;  // Position within cluster
-                // clusterData[sigOffset + 2] = channel index within stream
-                // clusterData[sigOffset + 3] = location code (ignored for now)
-                
-                // Name will be populated later from MusicPlugChannel lookup
-                channelFormat.channels.push_back(detail);
-                
-                ASFW_LOG_V1(MusicSubunit, "  Signal %u: musicPlugID=0x%04X, position=%u",
-                            sig, detail.musicPlugID, detail.position);
-            }
-            
-            ASFW_LOG_V1(MusicSubunit, "ClusterInfo: Added %zu channels to format", channelFormat.channels.size());
-            
-            // Add to currentFormat (will be populated later with rate info)
-            if (!plug.currentFormat) {
-                AudioStreamFormat fmt;
-                fmt.formatHierarchy = FormatHierarchy::kAM824;
-                fmt.subtype = AM824Subtype::kCompound;
-                fmt.channelFormats.push_back(channelFormat);
-                plug.currentFormat = fmt;
-            } else {
-                plug.currentFormat->channelFormats.push_back(channelFormat);
-            }
-        }
-        
-        plugs.push_back(plug);
-        blockIndex++;
-    }
-    
-    // Also extract MusicPlugInfo (0x810B) blocks for individual channel names
-    // These provide more granular names like "Analog Out 1", "Analog In 2"
-    // Accessible via ExtractMusicPlugChannels helper below
-}
-
 // Extract individual channel names from MusicPlugInfo (0x810B) blocks
 // These blocks contain per-channel information with music_plug_id and name
 static void ExtractMusicPlugChannels(
@@ -613,27 +471,6 @@ static void ExtractMusicPlugChannels(
         channels.push_back(channel);
     }
 }
-
-// Helper to extract plug info from a block (recursive) - used as fallback when no RoutingStatus found
-static void ExtractPlugsFromBlock(
-    const ASFW::Protocols::AVC::Descriptors::AVCInfoBlock& block,
-    std::vector<MusicSubunit::PlugInfo>& plugs)
-{
-    using namespace ASFW::Protocols::AVC::Descriptors;
-    using namespace ASFW::Protocols::AVC::StreamFormats;
-
-    // Check for RoutingStatus (0x8108) - this contains the plug direction info
-    if (block.GetType() == 0x8108) {
-        ExtractPlugsFromRoutingStatus(block, plugs);
-        return;  // Don't recurse further - RoutingStatus handles its children
-    }
-    
-    // Recurse into children to find RoutingStatus blocks
-    for (const auto& child : block.GetNestedBlocks()) {
-        ExtractPlugsFromBlock(child, plugs);
-    }
-}
-
 
 //==============================================================================
 // Music Subunit Identifier Descriptor Parser
@@ -1460,6 +1297,7 @@ void MusicSubunit::LogConnection(size_t index, const StreamFormats::ConnectionIn
     }
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void MusicSubunit::SetAudioVolume(ASFW::Protocols::AVC::IAVCCommandSubmitter& submitter, uint8_t plugId, int16_t volume, std::function<void(bool)> completion) {
     // Target Audio Subunit 0 (0x01 << 3 | 0 = 0x08)
     uint8_t subunitAddr = (static_cast<uint8_t>(AVCSubunitType::kAudio) << 3) | 0;

--- a/ASFWDriver/Protocols/AVC/PCRSpace.cpp
+++ b/ASFWDriver/Protocols/AVC/PCRSpace.cpp
@@ -6,6 +6,7 @@
 //
 
 #include "PCRSpace.hpp"
+#include "../../Common/CallbackUtils.hpp"
 #include "../../Logging/Logging.hpp"
 
 #include <array>
@@ -19,11 +20,12 @@ using namespace ASFW::Protocols::AVC;
 void PCRSpace::ReadPCR(PlugType type,
                        uint8_t plugNum,
                        std::function<void(std::optional<PCRValue>)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     if (plugNum > 30) {
         ASFW_LOG_ERROR(Async,
                      "PCRSpace: Invalid plug number %u (max 30)",
                      plugNum);
-        completion(std::nullopt);
+        Common::InvokeSharedCallback(completionState, std::optional<PCRValue>{});
         return;
     }
 
@@ -32,16 +34,16 @@ void PCRSpace::ReadPCR(PlugType type,
     auto device = unit_.GetDevice();
     if (!device) {
         ASFW_LOG_ERROR(Async, "PCRSpace: Device destroyed");
-        completion(std::nullopt);
+        Common::InvokeSharedCallback(completionState, std::optional<PCRValue>{});
         return;
     }
 
     const FW::Generation gen = busInfo_.GetGeneration();
     const FW::NodeId node{static_cast<uint8_t>(device->GetNodeID() & 0x3Fu)};
-    const Async::FWAddress addr{
-        static_cast<uint16_t>((pcrAddress >> 32U) & 0xFFFFU),
-        static_cast<uint32_t>(pcrAddress & 0xFFFFFFFFU),
-    };
+    const Async::FWAddress addr{Async::FWAddress::AddressParts{
+        .addressHi = static_cast<uint16_t>((pcrAddress >> 32U) & 0xFFFFU),
+        .addressLo = static_cast<uint32_t>(pcrAddress & 0xFFFFFFFFU),
+    }};
 
     busOps_.ReadBlock(
         gen,
@@ -49,13 +51,13 @@ void PCRSpace::ReadPCR(PlugType type,
         addr,
         4,
         FW::FwSpeed::S100,
-        [completion, pcrAddress](Async::AsyncStatus status, std::span<const uint8_t> response) {
+        [completionState, pcrAddress](Async::AsyncStatus status, std::span<const uint8_t> response) {
             if (status != Async::AsyncStatus::kSuccess) {
                 ASFW_LOG_ERROR(Async,
                              "PCRSpace: PCR read failed at 0x%llx: status=%d",
                              pcrAddress,
                              static_cast<int>(status));
-                completion(std::nullopt);
+                Common::InvokeSharedCallback(completionState, std::optional<PCRValue>{});
                 return;
             }
 
@@ -63,7 +65,7 @@ void PCRSpace::ReadPCR(PlugType type,
                 ASFW_LOG_ERROR(Async,
                              "PCRSpace: PCR read response too short: %zu bytes",
                              response.size());
-                completion(std::nullopt);
+                Common::InvokeSharedCallback(completionState, std::optional<PCRValue>{});
                 return;
             }
 
@@ -81,7 +83,7 @@ void PCRSpace::ReadPCR(PlugType type,
                         pcrAddress, raw,
                         pcr.online, pcr.channel, pcr.p2pCount);
 
-            completion(pcr);
+            Common::InvokeSharedCallback(completionState, std::optional<PCRValue>{pcr});
         });
 }
 
@@ -94,18 +96,19 @@ void PCRSpace::UpdatePCR(PlugType type,
                          const PCRValue& oldValue,
                          const PCRValue& newValue,
                          std::function<void(bool)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     if (plugNum > 30) {
         ASFW_LOG_ERROR(Async,
                      "PCRSpace: Invalid plug number %u (max 30)",
                      plugNum);
-        completion(false);
+        Common::InvokeSharedCallback(completionState, false);
         return;
     }
 
     if (!newValue.IsValid()) {
         ASFW_LOG_ERROR(Async,
                      "PCRSpace: Invalid PCR value");
-        completion(false);
+        Common::InvokeSharedCallback(completionState, false);
         return;
     }
 
@@ -114,7 +117,7 @@ void PCRSpace::UpdatePCR(PlugType type,
     auto device = unit_.GetDevice();
     if (!device) {
         ASFW_LOG_ERROR(Async, "PCRSpace: Device destroyed");
-        completion(false);
+        Common::InvokeSharedCallback(completionState, false);
         return;
     }
 
@@ -137,10 +140,10 @@ void PCRSpace::UpdatePCR(PlugType type,
 
     const FW::Generation gen = busInfo_.GetGeneration();
     const FW::NodeId node{static_cast<uint8_t>(device->GetNodeID() & 0x3Fu)};
-    const Async::FWAddress addr{
-        static_cast<uint16_t>((pcrAddress >> 32U) & 0xFFFFU),
-        static_cast<uint32_t>(pcrAddress & 0xFFFFFFFFU),
-    };
+    const Async::FWAddress addr{Async::FWAddress::AddressParts{
+        .addressHi = static_cast<uint16_t>((pcrAddress >> 32U) & 0xFFFFU),
+        .addressLo = static_cast<uint32_t>(pcrAddress & 0xFFFFFFFFU),
+    }};
     const std::span<const uint8_t> operand{lockData.data(), lockData.size()};
 
     busOps_.Lock(gen,
@@ -150,14 +153,14 @@ void PCRSpace::UpdatePCR(PlugType type,
                  operand,
                  4,
                  FW::FwSpeed::S100,
-        [completion, pcrAddress, oldRaw, newRaw](Async::AsyncStatus status,
+        [completionState, pcrAddress, oldRaw, newRaw](Async::AsyncStatus status,
                                                 std::span<const uint8_t> response) {
             if (status != Async::AsyncStatus::kSuccess) {
                 ASFW_LOG_ERROR(Async,
                              "PCRSpace: PCR lock failed at 0x%llx: status=%d",
                              pcrAddress,
                              static_cast<int>(status));
-                completion(false);
+                Common::InvokeSharedCallback(completionState, false);
                 return;
             }
 
@@ -165,7 +168,7 @@ void PCRSpace::UpdatePCR(PlugType type,
                 ASFW_LOG_ERROR(Async,
                              "PCRSpace: PCR lock response too short: %zu bytes",
                              response.size());
-                completion(false);
+                Common::InvokeSharedCallback(completionState, false);
                 return;
             }
 
@@ -180,7 +183,7 @@ void PCRSpace::UpdatePCR(PlugType type,
                              "PCRSpace: PCR lock compare failed: "
                              "expected 0x%08x, got 0x%08x",
                              oldRaw, actualOld);
-                completion(false);
+                Common::InvokeSharedCallback(completionState, false);
                 return;
             }
 
@@ -188,7 +191,7 @@ void PCRSpace::UpdatePCR(PlugType type,
                         "PCRSpace: Updated PCR[%llu]: 0x%08x → 0x%08x",
                         pcrAddress, oldRaw, newRaw);
 
-            completion(true);
+            Common::InvokeSharedCallback(completionState, true);
         });
 }
 
@@ -199,12 +202,13 @@ void PCRSpace::UpdatePCR(PlugType type,
 void PCRSpace::CreateConnection(uint8_t plugNum,
                                  PlugType plugType,
                                  std::function<void(std::optional<uint8_t>)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     // Step 1: Read current PCR value
-    ReadPCR(plugType, plugNum, [this, plugNum, plugType, completion](std::optional<PCRValue> currentPCR) {
+    ReadPCR(plugType, plugNum, [this, plugNum, plugType, completionState](std::optional<PCRValue> currentPCR) {
         if (!currentPCR) {
             ASFW_LOG_ERROR(Async,
                          "PCRSpace: Failed to read PCR for connection");
-            completion(std::nullopt);
+            Common::InvokeSharedCallback(completionState, std::optional<uint8_t>{});
             return;
         }
 
@@ -218,7 +222,7 @@ void PCRSpace::CreateConnection(uint8_t plugNum,
         // For now, stub out with a placeholder channel
         ASFW_LOG_ERROR(Async,
                      "PCRSpace: IRM allocation not yet implemented");
-        completion(std::nullopt);
+        Common::InvokeSharedCallback(completionState, std::optional<uint8_t>{});
     });
 }
 
@@ -226,12 +230,13 @@ void PCRSpace::DestroyConnection(uint8_t plugNum,
                                   PlugType plugType,
                                   uint8_t channel,
                                   std::function<void(bool)> completion) {
+    auto completionState = Common::ShareCallback(std::move(completion));
     // Step 1: Read current PCR value
-    ReadPCR(plugType, plugNum, [this, plugNum, plugType, channel, completion](std::optional<PCRValue> currentPCR) {
+    ReadPCR(plugType, plugNum, [this, plugNum, plugType, channel, completionState](std::optional<PCRValue> currentPCR) {
         if (!currentPCR) {
             ASFW_LOG_ERROR(Async,
                          "PCRSpace: Failed to read PCR for disconnection");
-            completion(false);
+            Common::InvokeSharedCallback(completionState, false);
             return;
         }
 
@@ -250,11 +255,11 @@ void PCRSpace::DestroyConnection(uint8_t plugNum,
         uint32_t bandwidth = CalculateBandwidth();
 
         UpdatePCR(plugType, plugNum, *currentPCR, newPCR,
-            [this, channel, bandwidth, completion](bool success) {
+            [this, channel, bandwidth, completionState](bool success) {
                 if (!success) {
                     ASFW_LOG_ERROR(Async,
                                  "PCRSpace: Failed to update PCR for disconnection");
-                    completion(false);
+                    Common::InvokeSharedCallback(completionState, false);
                     return;
                 }
 
@@ -267,7 +272,7 @@ void PCRSpace::DestroyConnection(uint8_t plugNum,
                             "PCRSpace: Connection destroyed (channel %u - IRM release not implemented)",
                             channel);
 
-                completion(true);
+                Common::InvokeSharedCallback(completionState, true);
             });
     });
 }

--- a/ASFWDriver/Protocols/AVC/StreamFormats/AVCSignalSourceCommand.hpp
+++ b/ASFWDriver/Protocols/AVC/StreamFormats/AVCSignalSourceCommand.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "../IAVCCommandSubmitter.hpp"
+#include "../../../Common/CallbackUtils.hpp"
 #include "StreamFormatTypes.hpp"
 #include <functional>
 
@@ -38,21 +39,24 @@ public:
     /// @param subunitAddr Subunit address
     /// @param destPlugNumber Destination plug number to query
     /// @param isSubunitPlug true for subunit plug, false for unit plug
+    // Positional plug-addressing follows the AV/C signal-source wire format.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     AVCSignalSourceCommand(IAVCCommandSubmitter& submitter,
-                          uint8_t subunitAddr,
-                          uint8_t destPlugNumber,
-                          bool isSubunitPlug = true)
+                           uint8_t subunitAddr,
+                           uint8_t destPlugNumber,
+                           bool isSubunitPlug = true)
         : submitter_(submitter)
         , cdb_(BuildCdb(subunitAddr, destPlugNumber, isSubunitPlug)) {}
 
     /// Submit command with connection info response
     void Submit(std::function<void(AVC::AVCResult, const ConnectionInfo&)> completion) {
-        submitter_.SubmitCommand(cdb_, [completion](AVC::AVCResult result, const AVC::AVCCdb& response) {
+        auto completionState = Common::ShareCallback(std::move(completion));
+        submitter_.SubmitCommand(cdb_, [completionState](AVC::AVCResult result, const AVC::AVCCdb& response) {
             if (AVC::IsSuccess(result)) {
                 auto connInfo = ParseConnectionInfo(response);
-                completion(result, connInfo);
+                Common::InvokeSharedCallback(completionState, result, connInfo);
             } else {
-                completion(result, ConnectionInfo{});
+                Common::InvokeSharedCallback(completionState, result, ConnectionInfo{});
             }
         });
     }
@@ -61,6 +65,7 @@ private:
     IAVCCommandSubmitter& submitter_;
     AVC::AVCCdb cdb_;
 
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     static AVC::AVCCdb BuildCdb(uint8_t subunitAddr, uint8_t destPlugNumber, bool isSubunitPlug) {
         AVC::AVCCdb cdb;
         cdb.ctype = static_cast<uint8_t>(AVC::AVCCommandType::kStatus);

--- a/ASFWDriver/Protocols/AVC/StreamFormats/AVCStreamFormatCommands.hpp
+++ b/ASFWDriver/Protocols/AVC/StreamFormats/AVCStreamFormatCommands.hpp
@@ -13,6 +13,7 @@
 
 #include "../AVCCommand.hpp"
 #include "../IAVCCommandSubmitter.hpp"
+#include "../../../Common/CallbackUtils.hpp"
 #include "StreamFormatTypes.hpp"
 #include "StreamFormatParser.hpp"
 #include <vector>
@@ -53,11 +54,13 @@ public:
     /// @param plugNum Plug number
     /// @param isInput true for input/destination plug, false for output/source plug
     /// @param useAlternateOpcode true to use 0x2F instead of 0xBF
+    // Positional plug-addressing follows the AV/C command layout.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     AVCStreamFormatCommand(IAVCCommandSubmitter& submitter,
-                          uint8_t subunitAddr,
-                          uint8_t plugNum,
-                          bool isInput,
-                          bool useAlternateOpcode = false)
+                           uint8_t subunitAddr,
+                           uint8_t plugNum,
+                           bool isInput,
+                           bool useAlternateOpcode = false)
         : submitter_(submitter)
         , cdb_(BuildCdb(subunitAddr, plugNum, isInput,
                        kStreamFormatSubfunc_Current, 0xFF,
@@ -71,12 +74,13 @@ public:
     /// @param isInput true for input/destination plug, false for output/source plug
     /// @param listIndex Index in supported format list (0-based)
     /// @param useAlternateOpcode true to use 0x2F instead of 0xBF
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     AVCStreamFormatCommand(IAVCCommandSubmitter& submitter,
-                          uint8_t subunitAddr,
-                          uint8_t plugNum,
-                          bool isInput,
-                          uint8_t listIndex,
-                          bool useAlternateOpcode = false)
+                           uint8_t subunitAddr,
+                           uint8_t plugNum,
+                           bool isInput,
+                           uint8_t listIndex,
+                           bool useAlternateOpcode = false)
         : submitter_(submitter)
         , cdb_(BuildCdb(subunitAddr, plugNum, isInput,
                        kStreamFormatSubfunc_Supported, listIndex,
@@ -90,12 +94,13 @@ public:
     /// @param isInput true for input/destination plug, false for output/source plug
     /// @param format Format to set
     /// @param useAlternateOpcode true to use 0x2F instead of 0xBF
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     AVCStreamFormatCommand(IAVCCommandSubmitter& submitter,
-                          uint8_t subunitAddr,
-                          uint8_t plugNum,
-                          bool isInput,
-                          const AudioStreamFormat& format,
-                          bool useAlternateOpcode = false)
+                           uint8_t subunitAddr,
+                           uint8_t plugNum,
+                           bool isInput,
+                           const AudioStreamFormat& format,
+                           bool useAlternateOpcode = false)
         : submitter_(submitter)
         , cdb_(BuildCdb(subunitAddr, plugNum, isInput,
                        kStreamFormatSubfunc_Current, 0xFF,
@@ -109,12 +114,13 @@ public:
     /// Submit command with parsed format response
     /// Uses StreamFormatParser for robust parsing
     void Submit(std::function<void(AVC::AVCResult, const std::optional<AudioStreamFormat>&)> completion) {
-        submitter_.SubmitCommand(cdb_, [this, completion](AVC::AVCResult result, const AVC::AVCCdb& response) {
+        auto completionState = Common::ShareCallback(std::move(completion));
+        submitter_.SubmitCommand(cdb_, [this, completionState](AVC::AVCResult result, const AVC::AVCCdb& response) {
             if (AVC::IsSuccess(result)) {
                 auto format = ParseFormatResponse(response);
-                completion(result, format);
+                Common::InvokeSharedCallback(completionState, result, format);
             } else {
-                completion(result, std::nullopt);
+                Common::InvokeSharedCallback(completionState, result, std::optional<AudioStreamFormat>{});
             }
         });
     }
@@ -128,8 +134,9 @@ private:
     // CDB Building
     //==========================================================================
 
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     static AVC::AVCCdb BuildCdb(uint8_t subunitAddr, uint8_t plugNum, bool isInput,
-                                uint8_t subfunction, uint8_t listIndex, bool useAlternateOpcode,
+                                uint8_t subfunction, uint8_t listIndex, bool useAlternateOpcode, // NOLINT(bugprone-easily-swappable-parameters)
                                 const AudioStreamFormat* formatToSet = nullptr) {
         AVC::AVCCdb cdb;
         // If setting format, use CONTROL, otherwise STATUS
@@ -261,14 +268,15 @@ inline void QueryAllSupportedFormats(
 ) {
     auto formats = std::make_shared<std::vector<AudioStreamFormat>>();
     auto iteration = std::make_shared<uint8_t>(0);
+    auto completionState = Common::ShareCallback(std::move(completion));
 
     // Recursive lambda for iteration
     // Use shared_ptr to allow capturing itself
     auto queryNext = std::make_shared<std::function<void()>>();
     
-    *queryNext = [&submitter, subunitAddr, plugNum, isInput, maxIterations, formats, iteration, completion, queryNext]() {
+    *queryNext = [&submitter, subunitAddr, plugNum, isInput, maxIterations, formats, iteration, completionState, queryNext]() {
         if (*iteration >= maxIterations) {
-            completion(*formats);
+            Common::InvokeSharedCallback(completionState, *formats);
             return;
         }
 
@@ -276,7 +284,7 @@ inline void QueryAllSupportedFormats(
             submitter, subunitAddr, plugNum, isInput, *iteration
         );
 
-        cmd->Submit([formats, iteration, completion, queryNext](
+        cmd->Submit([formats, iteration, completionState, queryNext](
             AVC::AVCResult result,
             const std::optional<AudioStreamFormat>& format
         ) {
@@ -286,7 +294,7 @@ inline void QueryAllSupportedFormats(
                 (*queryNext)(); // Query next format
             } else {
                 // No more formats or error - done
-                completion(*formats);
+                Common::InvokeSharedCallback(completionState, *formats);
             }
         });
     };

--- a/ASFWDriver/Protocols/AVC/StreamFormats/StreamFormatParser.cpp
+++ b/ASFWDriver/Protocols/AVC/StreamFormats/StreamFormatParser.cpp
@@ -255,9 +255,10 @@ SyncMode StreamFormatParser::ExtractSyncMode(uint8_t syncByte) {
     return (syncByte & 0x04) ? SyncMode::kSynchronized : SyncMode::kNoSync;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 std::vector<ChannelFormatInfo> StreamFormatParser::ParseChannelFormats(
     const uint8_t* data,
-    size_t length,
+    size_t length, // NOLINT(bugprone-easily-swappable-parameters)
     uint8_t numFields
 ) {
     std::vector<ChannelFormatInfo> formats;

--- a/ASFWDriver/Protocols/AVC/Subunit.hpp
+++ b/ASFWDriver/Protocols/AVC/Subunit.hpp
@@ -43,10 +43,15 @@ public:
     uint8_t GetNumDestPlugs() const { return numDestPlugs_; }
     uint8_t GetNumSrcPlugs() const { return numSrcPlugs_; }
 
+    struct PlugCounts {
+        uint8_t dest{0};
+        uint8_t src{0};
+    };
+
     /// Set plug counts (called by AVCUnit after PLUG_INFO)
-    void SetPlugCounts(uint8_t dest, uint8_t src) {
-        numDestPlugs_ = dest;
-        numSrcPlugs_ = src;
+    void SetPlugCounts(PlugCounts counts) {
+        numDestPlugs_ = counts.dest;
+        numSrcPlugs_ = counts.src;
     }
 
     /// Parse capabilities (optional, override in subclasses)

--- a/ASFWDriver/Protocols/Audio/DICE/Core/DICETransaction.cpp
+++ b/ASFWDriver/Protocols/Audio/DICE/Core/DICETransaction.cpp
@@ -4,6 +4,7 @@
 // DICETransaction.cpp - DICE async transaction implementation
 
 #include "DICETransaction.hpp"
+#include "../../../../Common/CallbackUtils.hpp"
 #include "../../../../Logging/Logging.hpp"
 #include <cstring>
 
@@ -18,14 +19,15 @@ DICETransaction::DICETransaction(Protocols::Ports::FireWireBusOps& busOps,
 
 Async::FWAddress DICETransaction::MakeAddress(uint32_t offset) const {
     const uint64_t addr = kDICEBaseAddress + offset;
-    return Async::FWAddress{
-        static_cast<uint16_t>((addr >> 32U) & 0xFFFFU),
-        static_cast<uint32_t>(addr & 0xFFFFFFFFU),
-    };
+    return Async::FWAddress{Async::FWAddress::AddressParts{
+        .addressHi = static_cast<uint16_t>((addr >> 32U) & 0xFFFFU),
+        .addressLo = static_cast<uint32_t>(addr & 0xFFFFFFFFU),
+    }};
 }
 
 void DICETransaction::ReadQuadlet(uint32_t offset,
                                   std::function<void(IOReturn, uint32_t)> callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     const auto gen = busInfo_.GetGeneration();
     const auto addr = MakeAddress(offset);
 
@@ -34,22 +36,24 @@ void DICETransaction::ReadQuadlet(uint32_t offset,
                       addr,
                       4,
                       FW::FwSpeed::S100,
-                      [callback = std::move(callback)](Async::AsyncStatus status,
+                      [callbackState](Async::AsyncStatus status,
                                                        std::span<const uint8_t> payload) {
         if (status != Async::AsyncStatus::kSuccess || payload.size() < 4) {
             IOReturn ret = (status == Async::AsyncStatus::kSuccess) ? kIOReturnUnderrun : kIOReturnError;
-            callback(ret, 0);
+            Common::InvokeSharedCallback(callbackState, ret, 0u);
             return;
         }
         
         uint32_t value = QuadletFromWire(payload.data());
-        callback(kIOReturnSuccess, value);
+        Common::InvokeSharedCallback(callbackState, kIOReturnSuccess, value);
     });
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void DICETransaction::WriteQuadlet(uint32_t offset,
                                    uint32_t value,
                                    DICEWriteCallback callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     // Use instance buffer instead of thread_local (not supported in DriverKit)
     QuadletToWire(value, writeQuadletBuffer_);
 
@@ -62,25 +66,27 @@ void DICETransaction::WriteQuadlet(uint32_t offset,
                        addr,
                        data,
                        FW::FwSpeed::S100,
-                       [callback = std::move(callback)](Async::AsyncStatus status,
+                       [callbackState](Async::AsyncStatus status,
                                                         std::span<const uint8_t>) {
         IOReturn ret = (status == Async::AsyncStatus::kSuccess) ? kIOReturnSuccess : kIOReturnError;
-        callback(ret);
+        Common::InvokeSharedCallback(callbackState, ret);
     });
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void DICETransaction::ReadBlock(uint32_t offset, size_t byteCount, DICEReadCallback callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     // Validate alignment
     if (byteCount % 4 != 0) {
         ASFW_LOG(DICE, "ReadBlock: byteCount %zu not quadlet-aligned", byteCount);
-        callback(kIOReturnBadArgument, nullptr, 0);
+        Common::InvokeSharedCallback(callbackState, kIOReturnBadArgument, nullptr, static_cast<size_t>(0));
         return;
     }
     
     // For large reads, we'd need to chunk - for now assume single read
     if (byteCount > kMaxFrameSize) {
         ASFW_LOG(DICE, "ReadBlock: byteCount %zu exceeds max frame size, chunking not yet implemented", byteCount);
-        callback(kIOReturnOverrun, nullptr, 0);
+        Common::InvokeSharedCallback(callbackState, kIOReturnOverrun, nullptr, static_cast<size_t>(0));
         return;
     }
     
@@ -93,20 +99,20 @@ void DICETransaction::ReadBlock(uint32_t offset, size_t byteCount, DICEReadCallb
                       addr,
                       length,
                       FW::FwSpeed::S100,
-                      [callback = std::move(callback), byteCount](Async::AsyncStatus status,
+                      [callbackState, byteCount](Async::AsyncStatus status,
                                                                   std::span<const uint8_t> payload) {
         if (status != Async::AsyncStatus::kSuccess) {
-            callback(kIOReturnError, nullptr, 0);
+            Common::InvokeSharedCallback(callbackState, kIOReturnError, nullptr, static_cast<size_t>(0));
             return;
         }
         
         if (payload.size() < byteCount) {
             ASFW_LOG(DICE, "ReadBlock: short read %zu < %zu", payload.size(), byteCount);
-            callback(kIOReturnUnderrun, payload.data(), payload.size());
+            Common::InvokeSharedCallback(callbackState, kIOReturnUnderrun, payload.data(), payload.size());
             return;
         }
         
-        callback(kIOReturnSuccess, payload.data(), payload.size());
+        Common::InvokeSharedCallback(callbackState, kIOReturnSuccess, payload.data(), payload.size());
     });
 }
 
@@ -114,16 +120,17 @@ void DICETransaction::WriteBlock(uint32_t offset,
                                  const uint8_t* buffer,
                                  size_t byteCount,
                                  DICEWriteCallback callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     // Validate alignment
     if (byteCount % 4 != 0) {
         ASFW_LOG(DICE, "WriteBlock: byteCount %zu not quadlet-aligned", byteCount);
-        callback(kIOReturnBadArgument);
+        Common::InvokeSharedCallback(callbackState, kIOReturnBadArgument);
         return;
     }
     
     if (byteCount > kMaxFrameSize) {
         ASFW_LOG(DICE, "WriteBlock: byteCount %zu exceeds max frame size, chunking not yet implemented", byteCount);
-        callback(kIOReturnOverrun);
+        Common::InvokeSharedCallback(callbackState, kIOReturnOverrun);
         return;
     }
     
@@ -136,18 +143,19 @@ void DICETransaction::WriteBlock(uint32_t offset,
                        addr,
                        data,
                        FW::FwSpeed::S100,
-                       [callback = std::move(callback)](Async::AsyncStatus status,
+                       [callbackState](Async::AsyncStatus status,
                                                         std::span<const uint8_t>) {
         IOReturn ret = (status == Async::AsyncStatus::kSuccess) ? kIOReturnSuccess : kIOReturnError;
-        callback(ret);
+        Common::InvokeSharedCallback(callbackState, ret);
     });
 }
 
 void DICETransaction::ReadGeneralSections(std::function<void(IOReturn, GeneralSections)> callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     ReadBlock(0, GeneralSections::kWireSize,
-              [callback](IOReturn status, const uint8_t* data, size_t size) {
+              [callbackState](IOReturn status, const uint8_t* data, size_t size) {
         if (status != kIOReturnSuccess || size < GeneralSections::kWireSize) {
-            callback(status, {});
+            Common::InvokeSharedCallback(callbackState, status, GeneralSections{});
             return;
         }
         
@@ -158,7 +166,7 @@ void DICETransaction::ReadGeneralSections(std::function<void(IOReturn, GeneralSe
                  sections.txStreamFormat.offset, sections.txStreamFormat.size,
                  sections.rxStreamFormat.offset, sections.rxStreamFormat.size);
         
-        callback(kIOReturnSuccess, sections);
+        Common::InvokeSharedCallback(callbackState, kIOReturnSuccess, sections);
     });
 }
 
@@ -168,13 +176,14 @@ void DICETransaction::ReadGeneralSections(std::function<void(IOReturn, GeneralSe
 
 void DICETransaction::ReadGlobalState(const GeneralSections& sections,
                                       std::function<void(IOReturn, GlobalState)> callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     // Read enough of global section for capabilities (0x68 bytes minimum)
     const size_t readSize = (sections.global.size >= 0x68) ? 0x68 : sections.global.size;
     
     ReadBlock(sections.global.offset, readSize,
-              [callback](IOReturn status, const uint8_t* data, size_t size) {
+              [callbackState](IOReturn status, const uint8_t* data, size_t size) {
         if (status != kIOReturnSuccess) {
-            callback(status, {});
+            Common::InvokeSharedCallback(callbackState, status, GlobalState{});
             return;
         }
         
@@ -240,7 +249,7 @@ void DICETransaction::ReadGlobalState(const GeneralSections& sections,
         ASFW_LOG(DICE, "Global: rate=%uHz caps=0x%08x version=0x%08x nickname='%{public}s'",
                  state.sampleRate, state.clockCaps, state.version, state.nickname);
         
-        callback(kIOReturnSuccess, state);
+        Common::InvokeSharedCallback(callbackState, kIOReturnSuccess, state);
     });
 }
 
@@ -402,6 +411,7 @@ void LogStreamConfigDetails(const char* prefix, const StreamConfig& config) {
 
 void DICETransaction::ReadRxStreamConfig(const GeneralSections& sections,
                                         std::function<void(IOReturn, StreamConfig)> callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     const size_t readSize = (sections.rxStreamFormat.size > 512) ? 512 : sections.rxStreamFormat.size;
     if (sections.rxStreamFormat.size > 512) {
         ASFW_LOG(DICE, "RX stream format section (%u bytes) exceeds read limit %zu; diagnostics may be partial",
@@ -409,21 +419,22 @@ void DICETransaction::ReadRxStreamConfig(const GeneralSections& sections,
     }
     
     ReadBlock(sections.rxStreamFormat.offset, readSize,
-              [callback](IOReturn status, const uint8_t* data, size_t size) {
+              [callbackState](IOReturn status, const uint8_t* data, size_t size) {
         if (status != kIOReturnSuccess) {
-            callback(status, {});
+            Common::InvokeSharedCallback(callbackState, status, StreamConfig{});
             return;
         }
         
         StreamConfig config = ParseStreamConfig(data, size, true);
         LogStreamConfigDetails("RX", config);
         
-        callback(kIOReturnSuccess, config);
+        Common::InvokeSharedCallback(callbackState, kIOReturnSuccess, config);
     });
 }
 
 void DICETransaction::ReadTxStreamConfig(const GeneralSections& sections,
                                         std::function<void(IOReturn, StreamConfig)> callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     const size_t readSize = (sections.txStreamFormat.size > 512) ? 512 : sections.txStreamFormat.size;
     if (sections.txStreamFormat.size > 512) {
         ASFW_LOG(DICE, "TX stream format section (%u bytes) exceeds read limit %zu; diagnostics may be partial",
@@ -432,16 +443,16 @@ void DICETransaction::ReadTxStreamConfig(const GeneralSections& sections,
 
     ReadBlock(sections.txStreamFormat.offset,
               readSize,
-              [callback = std::move(callback)](IOReturn status, const uint8_t* data, size_t size) {
+              [callbackState](IOReturn status, const uint8_t* data, size_t size) {
                   if (status != kIOReturnSuccess) {
-                      callback(status, {});
+                      Common::InvokeSharedCallback(callbackState, status, StreamConfig{});
                       return;
                   }
 
                   StreamConfig config = ParseStreamConfig(data, size, false);
                   LogStreamConfigDetails("TX", config);
 
-                  callback(kIOReturnSuccess, config);
+                  Common::InvokeSharedCallback(callbackState, kIOReturnSuccess, config);
               });
 }
 
@@ -518,17 +529,16 @@ const char* GlobalState::SupportedRatesDescription() const {
     // Return a static description based on clockCaps bits
     // Bits 0-6 correspond to 32k, 44.1k, 48k, 88.2k, 96k, 176.4k, 192k
     static char desc[128];
-    char* p = desc;
-    *p = '\0';
-    
-    if (clockCaps & RateCaps::k32000)  p += std::snprintf(p, 16, "32k ");
-    if (clockCaps & RateCaps::k44100)  p += std::snprintf(p, 16, "44.1k ");
-    if (clockCaps & RateCaps::k48000)  p += std::snprintf(p, 16, "48k ");
-    if (clockCaps & RateCaps::k88200)  p += std::snprintf(p, 16, "88.2k ");
-    if (clockCaps & RateCaps::k96000)  p += std::snprintf(p, 16, "96k ");
-    if (clockCaps & RateCaps::k176400) p += std::snprintf(p, 16, "176.4k ");
-    if (clockCaps & RateCaps::k192000) p += std::snprintf(p, 16, "192k ");
-    
+    desc[0] = '\0';
+
+    if (clockCaps & RateCaps::k32000)  strlcat(desc, "32k ", sizeof(desc));
+    if (clockCaps & RateCaps::k44100)  strlcat(desc, "44.1k ", sizeof(desc));
+    if (clockCaps & RateCaps::k48000)  strlcat(desc, "48k ", sizeof(desc));
+    if (clockCaps & RateCaps::k88200)  strlcat(desc, "88.2k ", sizeof(desc));
+    if (clockCaps & RateCaps::k96000)  strlcat(desc, "96k ", sizeof(desc));
+    if (clockCaps & RateCaps::k176400) strlcat(desc, "176.4k ", sizeof(desc));
+    if (clockCaps & RateCaps::k192000) strlcat(desc, "192k ", sizeof(desc));
+
     return desc;
 }
 

--- a/ASFWDriver/Protocols/Audio/IDeviceProtocol.hpp
+++ b/ASFWDriver/Protocols/Audio/IDeviceProtocol.hpp
@@ -72,6 +72,8 @@ public:
     }
 
     /// Check if protocol can expose/control a boolean control.
+    // These virtuals intentionally match the host-facing `(class, element[, value])` contract.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     virtual bool SupportsBooleanControl(uint32_t classIdFourCC,
                                         uint32_t element) const {
         (void)classIdFourCC;
@@ -80,6 +82,7 @@ public:
     }
 
     /// Read protocol-backed boolean control value.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     virtual IOReturn GetBooleanControlValue(uint32_t classIdFourCC,
                                             uint32_t element,
                                             bool& outValue) {
@@ -90,6 +93,7 @@ public:
     }
 
     /// Write protocol-backed boolean control value.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     virtual IOReturn SetBooleanControlValue(uint32_t classIdFourCC,
                                             uint32_t element,
                                             bool value) {

--- a/ASFWDriver/Protocols/Audio/Oxford/Apogee/ApogeeDuetProtocol.cpp
+++ b/ASFWDriver/Protocols/Audio/Oxford/Apogee/ApogeeDuetProtocol.cpp
@@ -6,6 +6,7 @@
 
 #include "ApogeeDuetProtocol.hpp"
 
+#include "../../../../Common/CallbackUtils.hpp"
 #include "../../../../Logging/Logging.hpp"
 #include "../../../AVC/AVCDefs.hpp"
 #include "../../../AVC/FCPTransport.hpp"
@@ -37,7 +38,6 @@ constexpr uint8_t kCTypeStatus = 0x01;
 constexpr uint8_t kSubunitUnit = 0xFF;
 constexpr uint8_t kOpcodeVendorDependent = 0x00;
 constexpr uint32_t kControlSyncTimeoutMs = 1500;
-constexpr uint32_t kClassIdPhantomPower = static_cast<uint32_t>('phan');
 constexpr uint32_t kClassIdPhaseInvert = static_cast<uint32_t>('phsi');
 
 constexpr size_t kVendorHeaderSize = 9; // OUI(3) + Prefix(3) + Code + Arg1 + Arg2.
@@ -105,6 +105,7 @@ constexpr size_t kVendorHeaderSize = 9; // OUI(3) + Prefix(3) + Code + Arg1 + Ar
     return OutputMuteMode::Never;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void BuildMuteMode(OutputMuteMode mode, bool& mute, bool& unmute) noexcept {
     switch (mode) {
         case OutputMuteMode::Never:
@@ -172,6 +173,7 @@ struct ApogeeDuetProtocol::VendorCommand {
         return command;
     }
 
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     static VendorCommand InGain(uint8_t index, uint8_t value) {
         VendorCommand command{};
         command.code = Code::InGain;
@@ -187,6 +189,7 @@ struct ApogeeDuetProtocol::VendorCommand {
         return command;
     }
 
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     static VendorCommand MixerSrc(uint8_t source, uint8_t destination, uint16_t gain) {
         VendorCommand command{};
         command.code = Code::MixerSrc;
@@ -499,8 +502,9 @@ IOReturn ApogeeDuetProtocol::SetBooleanControlValue(uint32_t classIdFourCC,
 void ApogeeDuetProtocol::SendVendorCommand(const VendorCommand& command,
                                            bool isStatus,
                                            VendorResultCallback callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     if (!fcpTransport_) {
-        callback(kIOReturnNotReady, command);
+        Common::InvokeSharedCallback(callbackState, kIOReturnNotReady, command);
         return;
     }
 
@@ -514,7 +518,7 @@ void ApogeeDuetProtocol::SendVendorCommand(const VendorCommand& command,
 
     if (paddedLength < Protocols::AVC::kAVCFrameMinSize ||
         paddedLength > Protocols::AVC::kAVCFrameMaxSize) {
-        callback(kIOReturnBadArgument, command);
+        Common::InvokeSharedCallback(callbackState, kIOReturnBadArgument, command);
         return;
     }
 
@@ -537,22 +541,22 @@ void ApogeeDuetProtocol::SendVendorCommand(const VendorCommand& command,
 
     const auto handle = fcpTransport_->SubmitCommand(
         frame,
-        [callback, command, isStatus](FCPStatus status, const FCPFrame& response) {
+        [callbackState, command, isStatus](FCPStatus status, const FCPFrame& response) {
             const IOReturn transportStatus = MapFCPStatusToIOReturn(status);
             if (transportStatus != kIOReturnSuccess) {
-                callback(transportStatus, command);
+                Common::InvokeSharedCallback(callbackState, transportStatus, command);
                 return;
             }
 
             if (response.length < Protocols::AVC::kAVCFrameMinSize) {
-                callback(kIOReturnBadMessageID, command);
+                Common::InvokeSharedCallback(callbackState, kIOReturnBadMessageID, command);
                 return;
             }
 
             const AVCResult avcResult = CTypeToResult(response.data[0]);
             const IOReturn avcStatus = MapAVCResultToIOReturn(avcResult);
             if (avcStatus != kIOReturnSuccess) {
-                callback(avcStatus, command);
+                Common::InvokeSharedCallback(callbackState, avcStatus, command);
                 return;
             }
 
@@ -561,12 +565,12 @@ void ApogeeDuetProtocol::SendVendorCommand(const VendorCommand& command,
                 const size_t operandLength = response.length - 3U;
                 std::span<const uint8_t> payload{response.data.data() + 3U, operandLength};
                 if (!parsed.ParseStatusPayload(payload)) {
-                    callback(kIOReturnBadMessageID, command);
+                    Common::InvokeSharedCallback(callbackState, kIOReturnBadMessageID, command);
                     return;
                 }
             }
 
-            callback(kIOReturnSuccess, parsed);
+            Common::InvokeSharedCallback(callbackState, kIOReturnSuccess, parsed);
         });
     (void)handle;
 }
@@ -965,158 +969,185 @@ uint32_t ApogeeDuetProtocol::ReadQuadletBE(const uint8_t* data) noexcept {
 }
 
 void ApogeeDuetProtocol::GetKnobState(ResultCallback<KnobState> callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     ExecuteVendorSequence(
         BuildKnobStateQuery(),
         true,
-        [callback](IOReturn status, const std::vector<VendorCommand>& responses) {
+        [callbackState](IOReturn status, const std::vector<VendorCommand>& responses) {
             if (status != kIOReturnSuccess || responses.empty()) {
-                callback(status != kIOReturnSuccess ? status : kIOReturnError, {});
+                Common::InvokeSharedCallback(callbackState,
+                                             status != kIOReturnSuccess ? status : kIOReturnError,
+                                             KnobState{});
                 return;
             }
-            callback(kIOReturnSuccess, ParseKnobState(responses[0]));
+            Common::InvokeSharedCallback(callbackState, kIOReturnSuccess, ParseKnobState(responses[0]));
         });
 }
 
 void ApogeeDuetProtocol::SetKnobState(const KnobState& state, VoidCallback callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     ExecuteVendorSequence(
         {BuildKnobStateControl(state)},
         false,
-        [callback](IOReturn status, const std::vector<VendorCommand>&) { callback(status); });
+        [callbackState](IOReturn status, const std::vector<VendorCommand>&) {
+            Common::InvokeSharedCallback(callbackState, status);
+        });
 }
 
 void ApogeeDuetProtocol::GetOutputParams(ResultCallback<OutputParams> callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     ExecuteVendorSequence(
         BuildOutputParamsQuery(),
         true,
-        [callback](IOReturn status, const std::vector<VendorCommand>& responses) {
+        [callbackState](IOReturn status, const std::vector<VendorCommand>& responses) {
             if (status != kIOReturnSuccess) {
-                callback(status, {});
+                Common::InvokeSharedCallback(callbackState, status, OutputParams{});
                 return;
             }
-            callback(kIOReturnSuccess, ParseOutputParams(responses));
+            Common::InvokeSharedCallback(callbackState, kIOReturnSuccess, ParseOutputParams(responses));
         });
 }
 
 void ApogeeDuetProtocol::SetOutputParams(const OutputParams& params, VoidCallback callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     ExecuteVendorSequence(
         BuildOutputParamsControl(params),
         false,
-        [callback](IOReturn status, const std::vector<VendorCommand>&) { callback(status); });
+        [callbackState](IOReturn status, const std::vector<VendorCommand>&) {
+            Common::InvokeSharedCallback(callbackState, status);
+        });
 }
 
 void ApogeeDuetProtocol::GetInputParams(ResultCallback<InputParams> callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     ExecuteVendorSequence(
         BuildInputParamsQuery(),
         true,
-        [callback](IOReturn status, const std::vector<VendorCommand>& responses) {
+        [callbackState](IOReturn status, const std::vector<VendorCommand>& responses) {
             if (status != kIOReturnSuccess) {
-                callback(status, {});
+                Common::InvokeSharedCallback(callbackState, status, InputParams{});
                 return;
             }
-            callback(kIOReturnSuccess, ParseInputParams(responses));
+            Common::InvokeSharedCallback(callbackState, kIOReturnSuccess, ParseInputParams(responses));
         });
 }
 
 void ApogeeDuetProtocol::SetInputParams(const InputParams& params, VoidCallback callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     ExecuteVendorSequence(
         BuildInputParamsControl(params),
         false,
-        [callback](IOReturn status, const std::vector<VendorCommand>&) { callback(status); });
+        [callbackState](IOReturn status, const std::vector<VendorCommand>&) {
+            Common::InvokeSharedCallback(callbackState, status);
+        });
 }
 
 void ApogeeDuetProtocol::GetMixerParams(ResultCallback<MixerParams> callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     ExecuteVendorSequence(
         BuildMixerParamsQuery(),
         true,
-        [callback](IOReturn status, const std::vector<VendorCommand>& responses) {
+        [callbackState](IOReturn status, const std::vector<VendorCommand>& responses) {
             if (status != kIOReturnSuccess) {
-                callback(status, {});
+                Common::InvokeSharedCallback(callbackState, status, MixerParams{});
                 return;
             }
-            callback(kIOReturnSuccess, ParseMixerParams(responses));
+            Common::InvokeSharedCallback(callbackState, kIOReturnSuccess, ParseMixerParams(responses));
         });
 }
 
 void ApogeeDuetProtocol::SetMixerParams(const MixerParams& params, VoidCallback callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     ExecuteVendorSequence(
         BuildMixerParamsControl(params),
         false,
-        [callback](IOReturn status, const std::vector<VendorCommand>&) { callback(status); });
+        [callbackState](IOReturn status, const std::vector<VendorCommand>&) {
+            Common::InvokeSharedCallback(callbackState, status);
+        });
 }
 
 void ApogeeDuetProtocol::GetDisplayParams(ResultCallback<DisplayParams> callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     ExecuteVendorSequence(
         BuildDisplayParamsQuery(),
         true,
-        [callback](IOReturn status, const std::vector<VendorCommand>& responses) {
+        [callbackState](IOReturn status, const std::vector<VendorCommand>& responses) {
             if (status != kIOReturnSuccess) {
-                callback(status, {});
+                Common::InvokeSharedCallback(callbackState, status, DisplayParams{});
                 return;
             }
-            callback(kIOReturnSuccess, ParseDisplayParams(responses));
+            Common::InvokeSharedCallback(callbackState, kIOReturnSuccess, ParseDisplayParams(responses));
         });
 }
 
 void ApogeeDuetProtocol::SetDisplayParams(const DisplayParams& params, VoidCallback callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     ExecuteVendorSequence(
         BuildDisplayParamsControl(params),
         false,
-        [callback](IOReturn status, const std::vector<VendorCommand>&) { callback(status); });
+        [callbackState](IOReturn status, const std::vector<VendorCommand>&) {
+            Common::InvokeSharedCallback(callbackState, status);
+        });
 }
 
 void ApogeeDuetProtocol::ClearDisplay(VoidCallback callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     ExecuteVendorSequence(
         {VendorCommand::Make(VendorCommand::Code::DisplayClear)},
         false,
-        [callback](IOReturn status, const std::vector<VendorCommand>&) { callback(status); });
+        [callbackState](IOReturn status, const std::vector<VendorCommand>&) {
+            Common::InvokeSharedCallback(callbackState, status);
+        });
 }
 
 void ApogeeDuetProtocol::GetInputMeter(ResultCallback<InputMeterState> callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     const auto gen = busInfo_.GetGeneration();
     const auto node = FW::NodeId{static_cast<uint8_t>(nodeId_ & 0x3Fu)};
     const uint64_t addr64 = kMeterBaseAddress + kMeterInputOffset;
-    const Async::FWAddress addr{
-        static_cast<uint16_t>((addr64 >> 32U) & 0xFFFFU),
-        static_cast<uint32_t>(addr64 & 0xFFFFFFFFU),
-    };
+    const Async::FWAddress addr{Async::FWAddress::AddressParts{
+        .addressHi = static_cast<uint16_t>((addr64 >> 32U) & 0xFFFFU),
+        .addressLo = static_cast<uint32_t>(addr64 & 0xFFFFFFFFU),
+    }};
 
     busOps_.ReadBlock(gen,
                       node,
                       addr,
                       8,
                       FW::FwSpeed::S100,
-                      [callback = std::move(callback)](Async::AsyncStatus status,
+                      [callbackState](Async::AsyncStatus status,
                                                        std::span<const uint8_t> payload) {
                           if (status != Async::AsyncStatus::kSuccess || payload.size() < 8U) {
-                              callback(kIOReturnError, {});
+                              Common::InvokeSharedCallback(callbackState, kIOReturnError, InputMeterState{});
                               return;
                           }
 
                           InputMeterState state{};
                           state.levels[0] = static_cast<int32_t>(ReadQuadletBE(payload.data()));
                           state.levels[1] = static_cast<int32_t>(ReadQuadletBE(payload.data() + 4U));
-                          callback(kIOReturnSuccess, state);
+                          Common::InvokeSharedCallback(callbackState, kIOReturnSuccess, state);
                       });
 }
 
 void ApogeeDuetProtocol::GetMixerMeter(ResultCallback<MixerMeterState> callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     const auto gen = busInfo_.GetGeneration();
     const auto node = FW::NodeId{static_cast<uint8_t>(nodeId_ & 0x3Fu)};
     const uint64_t addr64 = kMeterBaseAddress + kMeterMixerOffset;
-    const Async::FWAddress addr{
-        static_cast<uint16_t>((addr64 >> 32U) & 0xFFFFU),
-        static_cast<uint32_t>(addr64 & 0xFFFFFFFFU),
-    };
+    const Async::FWAddress addr{Async::FWAddress::AddressParts{
+        .addressHi = static_cast<uint16_t>((addr64 >> 32U) & 0xFFFFU),
+        .addressLo = static_cast<uint32_t>(addr64 & 0xFFFFFFFFU),
+    }};
 
     busOps_.ReadBlock(gen,
                       node,
                       addr,
                       16,
                       FW::FwSpeed::S100,
-                      [callback = std::move(callback)](Async::AsyncStatus status,
+                      [callbackState](Async::AsyncStatus status,
                                                        std::span<const uint8_t> payload) {
                           if (status != Async::AsyncStatus::kSuccess || payload.size() < 16U) {
-                              callback(kIOReturnError, {});
+                              Common::InvokeSharedCallback(callbackState, kIOReturnError, MixerMeterState{});
                               return;
                           }
 
@@ -1125,55 +1156,59 @@ void ApogeeDuetProtocol::GetMixerMeter(ResultCallback<MixerMeterState> callback)
                           state.streamInputs[1] = static_cast<int32_t>(ReadQuadletBE(payload.data() + 4U));
                           state.mixerOutputs[0] = static_cast<int32_t>(ReadQuadletBE(payload.data() + 8U));
                           state.mixerOutputs[1] = static_cast<int32_t>(ReadQuadletBE(payload.data() + 12U));
-                          callback(kIOReturnSuccess, state);
+                          Common::InvokeSharedCallback(callbackState, kIOReturnSuccess, state);
                       });
 }
 
 void ApogeeDuetProtocol::GetFirmwareId(ResultCallback<uint32_t> callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     const auto gen = busInfo_.GetGeneration();
     const auto node = FW::NodeId{static_cast<uint8_t>(nodeId_ & 0x3Fu)};
     const uint64_t addr64 = kOxfordCsrBase + kOxfordFirmwareIdOffset;
-    const Async::FWAddress addr{
-        static_cast<uint16_t>((addr64 >> 32U) & 0xFFFFU),
-        static_cast<uint32_t>(addr64 & 0xFFFFFFFFU),
-    };
+    const Async::FWAddress addr{Async::FWAddress::AddressParts{
+        .addressHi = static_cast<uint16_t>((addr64 >> 32U) & 0xFFFFU),
+        .addressLo = static_cast<uint32_t>(addr64 & 0xFFFFFFFFU),
+    }};
 
     busOps_.ReadBlock(gen,
                       node,
                       addr,
                       4,
                       FW::FwSpeed::S100,
-                      [callback = std::move(callback)](Async::AsyncStatus status,
+                      [callbackState](Async::AsyncStatus status,
                                                        std::span<const uint8_t> payload) {
                           if (status != Async::AsyncStatus::kSuccess || payload.size() < 4U) {
-                              callback(kIOReturnError, 0);
+                              Common::InvokeSharedCallback(callbackState, kIOReturnError, 0u);
                               return;
                           }
-                          callback(kIOReturnSuccess, ReadQuadletBE(payload.data()));
+                          Common::InvokeSharedCallback(callbackState, kIOReturnSuccess,
+                                                       ReadQuadletBE(payload.data()));
                       });
 }
 
 void ApogeeDuetProtocol::GetHardwareId(ResultCallback<uint32_t> callback) {
+    auto callbackState = Common::ShareCallback(std::move(callback));
     const auto gen = busInfo_.GetGeneration();
     const auto node = FW::NodeId{static_cast<uint8_t>(nodeId_ & 0x3Fu)};
     const uint64_t addr64 = kOxfordCsrBase + kOxfordHardwareIdOffset;
-    const Async::FWAddress addr{
-        static_cast<uint16_t>((addr64 >> 32U) & 0xFFFFU),
-        static_cast<uint32_t>(addr64 & 0xFFFFFFFFU),
-    };
+    const Async::FWAddress addr{Async::FWAddress::AddressParts{
+        .addressHi = static_cast<uint16_t>((addr64 >> 32U) & 0xFFFFU),
+        .addressLo = static_cast<uint32_t>(addr64 & 0xFFFFFFFFU),
+    }};
 
     busOps_.ReadBlock(gen,
                       node,
                       addr,
                       4,
                       FW::FwSpeed::S100,
-                      [callback = std::move(callback)](Async::AsyncStatus status,
+                      [callbackState](Async::AsyncStatus status,
                                                        std::span<const uint8_t> payload) {
                           if (status != Async::AsyncStatus::kSuccess || payload.size() < 4U) {
-                              callback(kIOReturnError, 0);
+                              Common::InvokeSharedCallback(callbackState, kIOReturnError, 0u);
                               return;
                           }
-                          callback(kIOReturnSuccess, ReadQuadletBE(payload.data()));
+                          Common::InvokeSharedCallback(callbackState, kIOReturnSuccess,
+                                                       ReadQuadletBE(payload.data()));
                       });
 }
 

--- a/ASFWDriver/Protocols/Audio/Oxford/Apogee/ApogeeDuetProtocol.hpp
+++ b/ASFWDriver/Protocols/Audio/Oxford/Apogee/ApogeeDuetProtocol.hpp
@@ -99,6 +99,7 @@ public:
                                     bool value) override;
 
     // Mapping helper for tests and call sites.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     static bool TryMapBooleanControl(uint32_t classIdFourCC,
                                      uint32_t element,
                                      uint8_t& outChannelIndex) noexcept {

--- a/ASFWDriver/Shared/Contexts/DmaContextManagerBase.hpp
+++ b/ASFWDriver/Shared/Contexts/DmaContextManagerBase.hpp
@@ -39,7 +39,7 @@ public:
         lock_ = IOLockAlloc();
         if (!lock_) {
             // Log but don't fail - lock may be allocated later
-            ASFW_LOG_ERROR(Async, "[%{public}s] Failed to allocate lock", RoleTag::kContextName.data());
+            ASFW_LOG_ERROR(Async, "[%{public}s] Failed to allocate lock", RoleTag::kContextName);
         }
     }
 
@@ -77,7 +77,7 @@ protected:
      */
     void Transition(StateEnum newState, uint32_t txid, const char* why) {
         state_ = newState;
-        ASFW_LOG_V3(Async, "ctx=%{public}s txid=%u gen=%u state=%{public}s: %{public}s (head=%lu tail=%lu)", RoleTag::kContextName.data(), txid, 0, PolicyT::ToStr(newState), why, (unsigned long)ring_.Head(), (unsigned long)ring_.Tail());
+        ASFW_LOG_V3(Async, "ctx=%{public}s txid=%u gen=%u state=%{public}s: %{public}s (head=%lu tail=%lu)", RoleTag::kContextName, txid, 0, PolicyT::ToStr(newState), why, (unsigned long)ring_.Head(), (unsigned long)ring_.Tail());
     }
 
     /**

--- a/ASFWDriver/Shared/Memory/PayloadHandle.hpp
+++ b/ASFWDriver/Shared/Memory/PayloadHandle.hpp
@@ -70,6 +70,8 @@ public:
      * \param size Size in bytes
      * \param physAddr Physical address (for DMA)
      */
+    // Positional `(address, size, physAddr)` mirrors the DMA allocation result.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     PayloadHandle(DMAMemoryManager* dmaMgr, uint64_t address, size_t size, uint64_t physAddr) noexcept
         : dmaMgr_(dmaMgr), address_(address), size_(size), physAddr_(physAddr) {}
 

--- a/ASFWDriver/Shared/Rings/BufferRing.cpp
+++ b/ASFWDriver/Shared/Rings/BufferRing.cpp
@@ -1,7 +1,6 @@
 #include "BufferRing.hpp"
 
 #include <atomic>
-#include <cstring>
 
 #include "../../Common/BarrierUtils.hpp"
 #include "../Memory/DMAMemoryManager.hpp"
@@ -35,7 +34,7 @@ bool BufferRing::Initialize(std::span<HW::OHCIDescriptor> descriptors, std::span
     head_ = 0;
     for (size_t i = 0; i < bufferCount; ++i) {
         auto& desc = descriptors_[i];
-        std::memset(&desc, 0, sizeof(desc));
+        desc = HW::OHCIDescriptor{};
         constexpr uint32_t kCmdInputMore = HW::OHCIDescriptor::kCmdInputMore;
         constexpr uint32_t kKeyStandard = HW::OHCIDescriptor::kKeyStandard;
         constexpr uint32_t kS = 1u;  

--- a/ASFWDriver/Shared/Rings/DescriptorRing.cpp
+++ b/ASFWDriver/Shared/Rings/DescriptorRing.cpp
@@ -38,6 +38,7 @@ uint32_t DescriptorRing::CommandPtrWordTo(const HW::OHCIDescriptor* target, uint
     return (static_cast<uint32_t>(addr) & 0xFFFFFFF0u) | z;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 uint32_t DescriptorRing::CommandPtrWordFromIOVA(uint32_t iova32, uint8_t zBlocks) const noexcept {
     if (storage_.empty() || descIOVABase_ == 0) return 0;
     if ((iova32 & 0xFULL) != 0) return 0;
@@ -69,6 +70,7 @@ const HW::OHCIDescriptor* DescriptorRing::At(size_t index) const noexcept {
     return &storage_[index];
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 bool DescriptorRing::LocatePreviousLast(size_t tailIndex, HW::OHCIDescriptor*& outDescriptor, size_t& outIndex, uint8_t& outBlocks) noexcept {
     outDescriptor = nullptr; outIndex = 0; outBlocks = 0;
     if (capacity_ == 0) return false;

--- a/ASFWDriver/Shared/TxSharedQueue.hpp
+++ b/ASFWDriver/Shared/TxSharedQueue.hpp
@@ -84,6 +84,8 @@ public:
     }
 
     // Creator-side initialization (run once by ASFWAudioNub that owns the memory)
+    // Positional initialization arguments mirror the backing shared-memory layout.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     static bool InitializeInPlace(void* base, uint64_t bytes, uint32_t capacityFrames,
                                   uint32_t numChannels = 2) {
         if (!base) return false;
@@ -258,10 +260,12 @@ public:
         const uint32_t idx = w & mask_;
         const uint32_t first = std::min(n, capacity_ - idx);
         const uint32_t second = n - first;
+        const size_t firstSamples = static_cast<size_t>(first) * static_cast<size_t>(ch);
+        const size_t secondSamples = static_cast<size_t>(second) * static_cast<size_t>(ch);
 
-        std::memcpy(&data_[idx * ch], interleavedData, size_t(first) * ch * sizeof(int32_t));
+        std::memcpy(&data_[static_cast<size_t>(idx) * ch], interleavedData, firstSamples * sizeof(int32_t));
         if (second) {
-            std::memcpy(&data_[0], &interleavedData[first * ch], size_t(second) * ch * sizeof(int32_t));
+            std::memcpy(&data_[0], &interleavedData[firstSamples], secondSamples * sizeof(int32_t));
         }
 
         // Publish data then bump index
@@ -285,10 +289,12 @@ public:
         const uint32_t idx = r & mask_;
         const uint32_t first = std::min(n, capacity_ - idx);
         const uint32_t second = n - first;
+        const size_t firstSamples = static_cast<size_t>(first) * static_cast<size_t>(ch);
+        const size_t secondSamples = static_cast<size_t>(second) * static_cast<size_t>(ch);
 
-        std::memcpy(outInterleavedData, &data_[idx * ch], size_t(first) * ch * sizeof(int32_t));
+        std::memcpy(outInterleavedData, &data_[static_cast<size_t>(idx) * ch], firstSamples * sizeof(int32_t));
         if (second) {
-            std::memcpy(&outInterleavedData[first * ch], &data_[0], size_t(second) * ch * sizeof(int32_t));
+            std::memcpy(&outInterleavedData[firstSamples], &data_[0], secondSamples * sizeof(int32_t));
         }
 
         hdr_->readIndexFrames.v.store(r + n, std::memory_order_release);
@@ -310,10 +316,12 @@ public:
         const uint32_t idx = r & mask_;
         const uint32_t first = std::min(n, capacity_ - idx);
         const uint32_t second = n - first;
+        const size_t firstSamples = static_cast<size_t>(first) * static_cast<size_t>(ch);
+        const size_t secondSamples = static_cast<size_t>(second) * static_cast<size_t>(ch);
 
-        std::memcpy(outInterleavedData, &data_[idx * ch], size_t(first) * ch * sizeof(int32_t));
+        std::memcpy(outInterleavedData, &data_[static_cast<size_t>(idx) * ch], firstSamples * sizeof(int32_t));
         if (second) {
-            std::memcpy(&outInterleavedData[first * ch], &data_[0], size_t(second) * ch * sizeof(int32_t));
+            std::memcpy(&outInterleavedData[firstSamples], &data_[0], secondSamples * sizeof(int32_t));
         }
 
         return n;

--- a/ASFWDriver/Testing/HostDriverKitStubs.hpp
+++ b/ASFWDriver/Testing/HostDriverKitStubs.hpp
@@ -49,14 +49,14 @@ inline uint64_t DefaultHostMonotonicNow() {
 }
 
 inline std::function<uint64_t()>& HostMonotonicClockOverride() {
-    static std::function<uint64_t()> override;
-    return override;
+    static std::function<uint64_t()> clockOverride;
+    return clockOverride;
 }
 
 inline uint64_t HostMonotonicNow() {
-    auto& override = HostMonotonicClockOverride();
-    if (override) {
-        return override();
+    auto& clockOverride = HostMonotonicClockOverride();
+    if (clockOverride) {
+        return clockOverride();
     }
     return DefaultHostMonotonicNow();
 }

--- a/ASFWDriver/UserClient/Core/ASFWDriverUserClient.cpp
+++ b/ASFWDriver/UserClient/Core/ASFWDriverUserClient.cpp
@@ -477,6 +477,8 @@ kern_return_t ASFWDriverUserClient::ExternalMethod(uint64_t selector,
     }
 }
 
+// LOCALONLY user-client ABI entry point.
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 kern_return_t ASFWDriverUserClient::AsyncRead(uint16_t destinationID, uint16_t addressHi,
                                               uint32_t addressLo, uint32_t length,
                                               uint16_t* handle) {
@@ -488,6 +490,7 @@ kern_return_t ASFWDriverUserClient::AsyncRead(uint16_t destinationID, uint16_t a
     return kIOReturnUnsupported;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 kern_return_t ASFWDriverUserClient::AsyncWrite(uint16_t destinationID, uint16_t addressHi,
                                                uint32_t addressLo, uint32_t length,
                                                const void* payload, uint16_t* handle) {
@@ -499,9 +502,10 @@ kern_return_t ASFWDriverUserClient::AsyncWrite(uint16_t destinationID, uint16_t 
     return kIOReturnUnsupported;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 kern_return_t ASFWDriverUserClient::AsyncCompareSwap(uint16_t destinationID, uint16_t addressHi,
                                                      uint32_t addressLo, uint8_t size,
-                                                     const void* compareValue, const void* newValue,
+                                                     const void* compareValue, const void* newValue, // NOLINT(bugprone-easily-swappable-parameters)
                                                      uint16_t* handle, uint8_t* locked) {
     // LOCALONLY method - implementation is in TransactionHandler via ExternalMethod case 17
     // This should never be called directly
@@ -514,6 +518,7 @@ kern_return_t ASFWDriverUserClient::AsyncCompareSwap(uint16_t destinationID, uin
     return kIOReturnUnsupported;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void ASFWDriverUserClient::NotifyStatus(uint64_t sequence, uint32_t reason) {
     if (!ivars || !ivars->actionLock) {
         return;
@@ -564,6 +569,7 @@ void ASFWDriverUserClient::NotifyTransactionComplete(uint16_t handle, uint32_t s
     action->release();
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 kern_return_t ASFWDriverUserClient::GetTransactionResult(uint16_t handle, uint32_t* status,
                                                          uint32_t* dataLength, void* data,
                                                          uint32_t maxDataLength) {

--- a/ASFWDriver/UserClient/Handlers/TransactionHandler.cpp
+++ b/ASFWDriver/UserClient/Handlers/TransactionHandler.cpp
@@ -21,9 +21,11 @@ namespace ASFW::UserClient {
 TransactionHandler::TransactionHandler(ASFWDriver* driver, TransactionStorage* storage)
     : driver_(driver), storage_(storage) {}
 
+// Callback signature is fixed by the async subsystem completion contract.
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void TransactionHandler::AsyncCompletionCallback(ASFW::Async::AsyncHandle handle,
                                                  ASFW::Async::AsyncStatus status,
-                                                 uint8_t responseCode, void* context,
+                                                 uint8_t responseCode, void* context, // NOLINT(bugprone-easily-swappable-parameters)
                                                  const void* responsePayload,
                                                  uint32_t responseLength) {
 

--- a/ASFWDriver/UserClient/Storage/TransactionStorage.cpp
+++ b/ASFWDriver/UserClient/Storage/TransactionStorage.cpp
@@ -25,6 +25,7 @@ TransactionStorage::~TransactionStorage() {
     }
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 bool TransactionStorage::StoreResult(uint16_t handle, uint32_t status, uint8_t responseCode,
                                      const void* responsePayload,
                                      uint32_t responseLength) {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,4 +12,6 @@ sonar.exclusions=**/build/**,**/.build/**,**/DerivedData/**,**/mocks/**,**/*Stub
 
 # C/C++ configuration
 sonar.cfamily.compile-commands=compile_commands.json
-sonar.cfamily.llvm-cov.reportPath=coverage.txt
+
+# Coverage is intentionally not wired into the default manual-analysis config.
+# Add a real report path via CLI/CI only when a matching coverage artifact exists.

--- a/tests/AsyncBusContractTests.cpp
+++ b/tests/AsyncBusContractTests.cpp
@@ -115,7 +115,10 @@ TEST(AsyncBusContract, GenerationMismatch_AdapterCompletesStaleGeneration_AsyncN
     const ASFW::FW::Generation current{async.GetBusState().generation16};
     const ASFW::FW::Generation stale{current.value + 1};
 
-    ASFW::Async::FWAddress addr{0xFFFF, 0xF0000400};
+    ASFW::Async::FWAddress addr{ASFW::Async::FWAddress::AddressParts{
+        .addressHi = 0xFFFF,
+        .addressLo = 0xF0000400,
+    }};
     (void)bus.ReadBlock(stale, ASFW::FW::NodeId{1}, addr, 4, ASFW::FW::FwSpeed::S100,
                         [&](ASFW::Async::AsyncStatus s, std::span<const uint8_t> payload) {
                             called = true;

--- a/tests/AsyncSubsystemAccessorTests.cpp
+++ b/tests/AsyncSubsystemAccessorTests.cpp
@@ -83,7 +83,8 @@ TEST_F(AsyncSubsystemAccessorTest, GetGenerationTracker_LazyInitialization) {
 
 TEST_F(AsyncSubsystemAccessorTest, GetBusState_ReturnsValidStateAfterLazyInit) {
     // Must call GetGenerationTracker first to initialize
-    subsystem.GetGenerationTracker();
+    auto& tracker = subsystem.GetGenerationTracker();
+    (void)tracker;
     
     // Now GetBusState should work
     auto state = subsystem.GetBusState();
@@ -108,7 +109,8 @@ TEST_F(AsyncSubsystemAccessorTest, GetGenerationTracker_CreatesLabelAllocator) {
 
 TEST_F(AsyncSubsystemAccessorTest, MultipleGetBusStateCalls_ConsistentResults) {
     // Initialize tracker first
-    subsystem.GetGenerationTracker();
+    auto& tracker = subsystem.GetGenerationTracker();
+    (void)tracker;
     
     auto state1 = subsystem.GetBusState();
     auto state2 = subsystem.GetBusState();
@@ -117,5 +119,3 @@ TEST_F(AsyncSubsystemAccessorTest, MultipleGetBusStateCalls_ConsistentResults) {
     EXPECT_EQ(state1.generation16, state2.generation16);
     EXPECT_EQ(state1.localNodeID, state2.localNodeID);
 }
-
-

--- a/tests/BusOptionsFieldsTests.cpp
+++ b/tests/BusOptionsFieldsTests.cpp
@@ -115,7 +115,10 @@ TEST(BusOptionsFieldsTests, Encode_AllTrue_AllMax) {
 
 TEST(BusOptionsFieldsTests, SetGeneration_UpdatesOnlyGenerationBits) {
     // Start with canonical example (generation=0), bump to generation=9.
-    const uint32_t updated = ASFW::FW::SetGeneration(kTA1999027BusOptions, 9);
+    const uint32_t updated = ASFW::FW::SetGeneration({
+        .busOptionsHost = kTA1999027BusOptions,
+        .gen4 = 9,
+    });
 
     const auto d = ASFW::FW::DecodeBusOptions(updated);
     EXPECT_EQ(d.generation, 9u);
@@ -136,7 +139,10 @@ TEST(BusOptionsFieldsTests, SetGeneration_PreservesReservedBits) {
     // Inject non-zero reserved bits [11:10] and [3] into the quadlet to confirm
     // SetGeneration does not corrupt them.
     constexpr uint32_t kWithReserved = kTA1999027BusOptions | 0x00000C08u; // bits 11,10,3
-    const uint32_t updated = ASFW::FW::SetGeneration(kWithReserved, 5);
+    const uint32_t updated = ASFW::FW::SetGeneration({
+        .busOptionsHost = kWithReserved,
+        .gen4 = 5,
+    });
 
     // Generation updated.
     EXPECT_EQ(ASFW::FW::DecodeBusOptions(updated).generation, 5u);
@@ -147,7 +153,10 @@ TEST(BusOptionsFieldsTests, SetGeneration_PreservesReservedBits) {
 
 TEST(BusOptionsFieldsTests, SetGeneration_ClampTo4Bits) {
     // Values > 0xF should be masked to low 4 bits.
-    const uint32_t updated = ASFW::FW::SetGeneration(kTA1999027BusOptions, 0x1F); // 5 bits
+    const uint32_t updated = ASFW::FW::SetGeneration({
+        .busOptionsHost = kTA1999027BusOptions,
+        .gen4 = 0x1F,
+    }); // 5 bits
     EXPECT_EQ(ASFW::FW::DecodeBusOptions(updated).generation, 0xFu); // only low 4 kept
 }
 

--- a/tests/CompareAndSwapPacketTests.cpp
+++ b/tests/CompareAndSwapPacketTests.cpp
@@ -601,8 +601,13 @@ TEST_F(CompareAndSwapPacketTest, Descriptor_ControlWord_OutputMoreImmediate_ReqC
     constexpr uint8_t intCtrl = OHCIDescriptor::kIntNever;        // i=0x0
     constexpr uint8_t branchCtrl = OHCIDescriptor::kBranchNever;  // b=0x0 (required for OUTPUT_MORE)
 
-    const uint32_t control = OHCIDescriptor::BuildControl(
-        reqCount, cmd, key, intCtrl, branchCtrl, false);
+    const uint32_t control = OHCIDescriptor::BuildControl({
+        .reqCount = reqCount,
+        .command = cmd,
+        .key = key,
+        .interruptBits = intCtrl,
+        .branchBits = branchCtrl,
+    });
 
     // Extract reqCount field (lower 16 bits)
     const uint16_t extractedReqCount = static_cast<uint16_t>(control & 0xFFFFu);
@@ -636,8 +641,13 @@ TEST_F(CompareAndSwapPacketTest, Descriptor_ControlWord_OutputLast_ReqCount8) {
     constexpr uint8_t intCtrl = OHCIDescriptor::kIntAlways;       // i=0x3 (interrupt on completion)
     constexpr uint8_t branchCtrl = OHCIDescriptor::kBranchAlways; // b=0x3 (always branch)
 
-    const uint32_t control = OHCIDescriptor::BuildControl(
-        reqCount, cmd, key, intCtrl, branchCtrl, false);
+    const uint32_t control = OHCIDescriptor::BuildControl({
+        .reqCount = reqCount,
+        .command = cmd,
+        .key = key,
+        .interruptBits = intCtrl,
+        .branchBits = branchCtrl,
+    });
 
     // Extract reqCount field
     const uint16_t extractedReqCount = static_cast<uint16_t>(control & 0xFFFFu);
@@ -696,13 +706,13 @@ TEST_F(CompareAndSwapPacketTest, Descriptor_TwoDescriptorChain_HeaderAndPayload)
     std::memcpy(headerDesc.immediateData, headerBuffer.data(), headerSize);
 
     // Set control word: reqCount=16, OUTPUT_MORE, Immediate, i=Never, b=Never
-    headerDesc.common.control = OHCIDescriptor::BuildControl(
-        16,  // reqCount = 16 bytes (4 quadlets)
-        OHCIDescriptor::kCmdOutputMore,
-        OHCIDescriptor::kKeyImmediate,
-        OHCIDescriptor::kIntNever,
-        OHCIDescriptor::kBranchNever,
-        false);
+    headerDesc.common.control = OHCIDescriptor::BuildControl({
+        .reqCount = 16,
+        .command = OHCIDescriptor::kCmdOutputMore,
+        .key = OHCIDescriptor::kKeyImmediate,
+        .interruptBits = OHCIDescriptor::kIntNever,
+        .branchBits = OHCIDescriptor::kBranchNever,
+    });
 
     headerDesc.common.branchWord = 0;  // Ignored for OUTPUT_MORE (uses contiguity)
 
@@ -720,13 +730,13 @@ TEST_F(CompareAndSwapPacketTest, Descriptor_TwoDescriptorChain_HeaderAndPayload)
     std::memset(&payloadDesc, 0, sizeof(payloadDesc));
 
     // Set control word: reqCount=8, OUTPUT_LAST, Standard, i=Always, b=Always
-    payloadDesc.control = OHCIDescriptor::BuildControl(
-        8,  // reqCount = 8 bytes (compare + swap operands)
-        OHCIDescriptor::kCmdOutputLast,
-        OHCIDescriptor::kKeyStandard,
-        OHCIDescriptor::kIntAlways,
-        OHCIDescriptor::kBranchAlways,
-        false);
+    payloadDesc.control = OHCIDescriptor::BuildControl({
+        .reqCount = 8,
+        .command = OHCIDescriptor::kCmdOutputLast,
+        .key = OHCIDescriptor::kKeyStandard,
+        .interruptBits = OHCIDescriptor::kIntAlways,
+        .branchBits = OHCIDescriptor::kBranchAlways,
+    });
 
     payloadDesc.branchWord = 0;  // EOL marker
     payloadDesc.dataAddress = 0x12345000;  // Mock payload IOVA (4-byte aligned)

--- a/tests/ConfigROMBuilderTests.cpp
+++ b/tests/ConfigROMBuilderTests.cpp
@@ -192,7 +192,10 @@ TEST(ConfigROMBuilderTests, UpdateGenerationRefreshesBusInfoAndHeaderCrc) {
     const uint32_t busInfo = builder.BusInfoQuad();
     EXPECT_EQ((busInfo & ASFW::FW::BusOptionsFields::kGenerationMask) >> ASFW::FW::BusOptionsFields::kGenerationShift, 9u);
     EXPECT_EQ((busInfo & ~ASFW::FW::BusOptionsFields::kGenerationMask), (busOptions & ~ASFW::FW::BusOptionsFields::kGenerationMask));
-    EXPECT_EQ(busInfo, SetGeneration(busOptions, 9));
+    EXPECT_EQ(busInfo, SetGeneration({
+        .busOptionsHost = busOptions,
+        .gen4 = 9,
+    }));
 
     const uint32_t header = builder.HeaderQuad();
     EXPECT_EQ(header >> 24, 4u);

--- a/tests/TLabelMatchingTests.cpp
+++ b/tests/TLabelMatchingTests.cpp
@@ -200,7 +200,9 @@ TEST_F(TLabelMatchingTest, PacketBuilder_BitPositionVerification_Label0) {
     uint8_t label = 0;
 
     uint8_t headerBuffer[16] = {0};
-    builder_.BuildReadQuadlet(params, label, context, headerBuffer, sizeof(headerBuffer));
+    const size_t headerSize =
+        builder_.BuildReadQuadlet(params, label, context, headerBuffer, sizeof(headerBuffer));
+    ASSERT_NE(0u, headerSize);
 
     uint32_t quadlet0;
     std::memcpy(&quadlet0, headerBuffer, sizeof(quadlet0));
@@ -247,7 +249,9 @@ TEST_F(TLabelMatchingTest, PacketBuilder_BitPositionVerification_Label48) {
     uint8_t label = 48;
 
     uint8_t headerBuffer[16] = {0};
-    builder_.BuildReadQuadlet(params, label, context, headerBuffer, sizeof(headerBuffer));
+    const size_t headerSize =
+        builder_.BuildReadQuadlet(params, label, context, headerBuffer, sizeof(headerBuffer));
+    ASSERT_NE(0u, headerSize);
 
     uint32_t quadlet0;
     std::memcpy(&quadlet0, headerBuffer, sizeof(quadlet0));

--- a/tools/quality/sonar-local.sh
+++ b/tools/quality/sonar-local.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SETTINGS="${ROOT}/sonar-project.properties"
+REGEN_COMMANDS=false
+WAIT_FOR_GATE=true
+BRANCH_NAME=""
+EXTRA_SCANNER_ARGS=()
+
+usage() {
+  cat <<'EOF'
+Usage: tools/quality/sonar-local.sh [options] [-- <extra sonar-scanner args>]
+
+Options:
+  --regen-commands    Regenerate compile_commands.json via ./build.sh --commands --no-bump
+  --no-wait           Do not wait for quality gate status
+  --branch NAME       Override sonar.branch.name (default: current git branch)
+  --settings PATH     Use an alternate sonar-project.properties file
+  -h, --help          Show this help
+
+Environment:
+  SONAR_TOKEN         Preferred SonarCloud token
+  SONARQUBE_TOKEN     Accepted fallback; exported to SONAR_TOKEN for the scan
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --regen-commands)
+      REGEN_COMMANDS=true
+      shift
+      ;;
+    --no-wait)
+      WAIT_FOR_GATE=false
+      shift
+      ;;
+    --branch)
+      BRANCH_NAME="$2"
+      shift 2
+      ;;
+    --settings)
+      if [[ "$2" != /* ]]; then
+        SETTINGS="${ROOT}/$2"
+      else
+        SETTINGS="$2"
+      fi
+      shift 2
+      ;;
+    --)
+      shift
+      EXTRA_SCANNER_ARGS+=("$@")
+      break
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 127
+  }
+}
+
+has_nonempty_compile_db() {
+  local db="$1"
+  [[ -f "$db" ]] || return 1
+  python3 - "$db" <<'PY'
+import json, sys
+path = sys.argv[1]
+try:
+    with open(path) as f:
+        data = json.load(f)
+    sys.exit(0 if isinstance(data, list) and len(data) > 0 else 1)
+except Exception:
+    sys.exit(1)
+PY
+}
+
+require_cmd sonar-scanner
+require_cmd python3
+
+if [[ ! -f "${SETTINGS}" ]]; then
+  echo "Sonar settings file not found: ${SETTINGS}" >&2
+  exit 2
+fi
+
+token="${SONAR_TOKEN:-${SONARQUBE_TOKEN:-}}"
+if [[ -z "${token}" ]]; then
+  echo "Set SONAR_TOKEN or SONARQUBE_TOKEN before running sonar-local.sh." >&2
+  exit 2
+fi
+export SONAR_TOKEN="${token}"
+
+compile_db="${ROOT}/compile_commands.json"
+if $REGEN_COMMANDS || ! has_nonempty_compile_db "${compile_db}"; then
+  echo "Generating compile_commands.json via ./build.sh --commands --no-bump..."
+  (cd "${ROOT}" && ./build.sh --commands --no-bump)
+fi
+
+if ! has_nonempty_compile_db "${compile_db}"; then
+  echo "compile_commands.json is missing or empty: ${compile_db}" >&2
+  exit 2
+fi
+
+if [[ -z "${BRANCH_NAME}" ]]; then
+  BRANCH_NAME="$(git -C "${ROOT}" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+fi
+
+scanner_args=("-Dproject.settings=${SETTINGS}")
+if [[ -n "${BRANCH_NAME}" && "${BRANCH_NAME}" != "HEAD" ]]; then
+  scanner_args+=("-Dsonar.branch.name=${BRANCH_NAME}")
+fi
+if $WAIT_FOR_GATE; then
+  scanner_args+=("-Dsonar.qualitygate.wait=true")
+fi
+
+echo "Running sonar-scanner from ${ROOT}"
+if [[ -n "${BRANCH_NAME}" && "${BRANCH_NAME}" != "HEAD" ]]; then
+  echo "Branch: ${BRANCH_NAME}"
+fi
+echo "Settings: ${SETTINGS}"
+
+cd "${ROOT}"
+exec sonar-scanner "${scanner_args[@]}" "${EXTRA_SCANNER_ARGS[@]}"


### PR DESCRIPTION
## Summary
- fix the ASFWDriver analyzer and targeted clang-tidy findings from the current sweep
- clean the remaining in-repo warning noise in ASFWDriver/tests
- refactor AsyncSubsystem::Start into smaller helpers
- add local Sonar manual-analysis prep and runner

## Verification
- xcodebuild analyze for ASFWDriver
- host test build (407/407)
- manual Sonar scanner runner prepared for project-level scans once analysis is triggered