### PR TITLE
fix(async,bus): harden generation and completion handling

### DIFF
--- a/ASFWDriver/Async/AsyncSubsystemBusReset.cpp
+++ b/ASFWDriver/Async/AsyncSubsystemBusReset.cpp
@@ -27,7 +27,7 @@ void AsyncSubsystem::OnBusResetBegin(uint8_t nextGen) {
 
     // Step 2: Cancel transactions from OLD generation only
     // Read current generation from tracker (set by previous bus reset)
-    const uint8_t oldGen = generationTracker_ ? generationTracker_->GetCurrentState().generation8 : 0;
+    const uint16_t oldGen = generationTracker_ ? generationTracker_->GetCurrentState().generation16 : 0;
 
     if (tracking_) {
         // Cancel any lingering transactions (all generations) to guarantee label bitmap is clean.

--- a/ASFWDriver/Async/AsyncSubsystemLifecycle.cpp
+++ b/ASFWDriver/Async/AsyncSubsystemLifecycle.cpp
@@ -625,7 +625,7 @@ std::optional<TransactionContext> AsyncSubsystem::PrepareTransactionContext() {
 
     // Step 4: Query current generation from GenerationTracker
     const auto busState = generationTracker_->GetCurrentState();
-    const uint8_t currentGeneration = busState.generation8;
+    const uint16_t currentGeneration = busState.generation16;
 
     // Step 5: Resolve speed code. TODO(ASFW-Topology): query TopologyManager instead of using the
     // compatibility S100 default.

--- a/ASFWDriver/Async/AsyncTypes.hpp
+++ b/ASFWDriver/Async/AsyncTypes.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <functional>
 #include <span>
+#include <type_traits>
 #include <DriverKit/IOReturn.h>
 
 // Forward declaration - we'll define FWAddress helpers before FWAddress uses them
@@ -280,16 +281,21 @@ struct RetryPolicy {
 
 struct PacketContext {
     uint16_t sourceNodeID{0};
-    uint8_t generation{0};
+    uint16_t generation{0};
     uint8_t speedCode{0};
 };
 
 struct TransactionContext {
     uint16_t sourceNodeID{0};
-    uint8_t generation{0};
+    uint16_t generation{0};
     uint8_t speedCode{0};
     PacketContext packetContext{};
 };
+
+static_assert(std::is_same_v<decltype(PacketContext::generation), uint16_t>,
+              "PacketContext::generation must keep full 16-bit bus generation");
+static_assert(std::is_same_v<decltype(TransactionContext::generation), uint16_t>,
+              "TransactionContext::generation must keep full 16-bit bus generation");
 
 struct ReadParams {
     uint16_t destinationID{0};

--- a/ASFWDriver/Async/Contexts/ATContextBase.hpp
+++ b/ASFWDriver/Async/Contexts/ATContextBase.hpp
@@ -716,6 +716,50 @@ std::optional<TxCompletion> ATContextBase<Derived, Tag>::ScanCompletion() noexce
 
         const uint16_t xferStatus = HW::AT_xferStatus(*desc);
         if (xferStatus == 0) {
+            // Two-descriptor transactions use OUTPUT_MORE (header) followed by
+            // OUTPUT_LAST (payload). Hardware may only write completion status on
+            // OUTPUT_LAST. If the current head is an OUTPUT_MORE precursor and the
+            // next descriptor has completed, advance head to that descriptor first.
+            const uint16_t controlHi = static_cast<uint16_t>(desc->control >> HW::OHCIDescriptor::kControlHighShift);
+            const uint8_t cmd = static_cast<uint8_t>((controlHi >> HW::OHCIDescriptor::kCmdShift) & 0xF);
+            const uint8_t key = static_cast<uint8_t>((controlHi >> HW::OHCIDescriptor::kKeyShift) & 0x7);
+            if (cmd != HW::OHCIDescriptor::kCmdOutputLast) {
+                const uint8_t blocks = (key == HW::OHCIDescriptor::kKeyImmediate) ? 2 : 1;
+                const size_t nextIndex = (headIndex + blocks) % capacity;
+                HW::OHCIDescriptor* nextDesc = ring_->At(nextIndex);
+                if (nextDesc) {
+                    const bool nextIsImm = HW::IsImmediate(*nextDesc);
+                    if (dmaManager_) {
+                        dmaManager_->FetchRange(nextDesc, nextIsImm ? sizeof(HW::OHCIDescriptorImmediate)
+                                                                    : sizeof(HW::OHCIDescriptor));
+                    }
+                    const uint16_t nextStatus = HW::AT_xferStatus(*nextDesc);
+                    if (nextStatus != 0) {
+                        ASFW_LOG_V2(Async,
+                                    "ScanCompletion: advancing past OUTPUT_MORE precursor head=%zu -> %zu (next status=0x%04x)",
+                                    headIndex,
+                                    nextIndex,
+                                    nextStatus);
+                        for (uint8_t i = 0; i < blocks; ++i) {
+                            const size_t clearIndex = (headIndex + i) % capacity;
+                            HW::OHCIDescriptor* clearDesc = ring_->At(clearIndex);
+                            if (!clearDesc) {
+                                continue;
+                            }
+                            ClearDescriptorStatus(*clearDesc);
+                            if (dmaManager_) {
+                                const bool clearImm = HW::IsImmediate(*clearDesc);
+                                const size_t flushSize = clearImm ? sizeof(HW::OHCIDescriptorImmediate)
+                                                                  : sizeof(HW::OHCIDescriptor);
+                                dmaManager_->PublishRange(clearDesc, flushSize);
+                            }
+                        }
+                        ring_->SetHead(nextIndex);
+                        continue;
+                    }
+                }
+            }
+
             // Per Apple's handleCompletedCommand (DecompilationAnalysis_handleCompletedCommand.md):
             // When statusWord==0, hardware hasn't completed. But check if this is an
             // ORPHANED descriptor - one that was cancelled/timed out and hardware skipped over.

--- a/ASFWDriver/Async/Track/TransactionCompletionHandler.hpp
+++ b/ASFWDriver/Async/Track/TransactionCompletionHandler.hpp
@@ -102,9 +102,6 @@ public:
                 return;
             }
 
-            // Store ACK code in transaction for timeout handler
-            txn->SetAckCode(ackCode);
-
             // PHY packets complete on AT path only (no AR response expected).
             if (txn->GetCompletionStrategy() == CompletionStrategy::CompleteOnPHY) {
                 ASFW_LOG(Async, "  → Completed (PHY, AT-only) ackCode=0x%X event=0x%02X", ackCode, eventCode);
@@ -175,6 +172,50 @@ public:
             const auto strategy = txn->GetCompletionStrategy();
             const bool needsARData = txn->IsReadOperation() || strategy == CompletionStrategy::CompleteOnAR;
 
+            // Normalize ACK semantics from OHCI event code first.
+            // Some controllers report raw ackCode values (e.g. 0x8) that do not map
+            // directly to IEEE 1394 ack constants; eventCode is authoritative.
+            uint8_t normalizedAckCode = ackCode;
+            switch (static_cast<OHCIEventCode>(eventCode)) {
+                case OHCIEventCode::kAckComplete:
+                    normalizedAckCode = 0x0;
+                    break;
+                case OHCIEventCode::kAckPending:
+                    normalizedAckCode = 0x1;
+                    break;
+                case OHCIEventCode::kAckBusyX:
+                    normalizedAckCode = 0x4;
+                    break;
+                case OHCIEventCode::kAckBusyA:
+                    normalizedAckCode = 0x5;
+                    break;
+                case OHCIEventCode::kAckBusyB:
+                    normalizedAckCode = 0x6;
+                    break;
+                case OHCIEventCode::kAckTardy:
+                    normalizedAckCode = 0xC;
+                    break;
+                case OHCIEventCode::kAckDataError:
+                    normalizedAckCode = 0xD;
+                    break;
+                case OHCIEventCode::kAckTypeError:
+                    normalizedAckCode = 0xE;
+                    break;
+                default:
+                    break;
+            }
+            if (normalizedAckCode != ackCode) {
+                ASFW_LOG_V2(Async,
+                            "  ℹ️  Normalized ackCode 0x%X -> 0x%X from event=0x%02X",
+                            ackCode,
+                            normalizedAckCode,
+                            eventCode);
+                ackCode = normalizedAckCode;
+            }
+
+            // Store normalized ACK code in transaction for timeout handler.
+            txn->SetAckCode(ackCode);
+
             switch (ackCode) {
                 case 0x1:  // kFWAckPending (split transaction)
                     ASFW_LOG_V2(Async, "  → AwaitingAR (ackPending, need AR response)");
@@ -235,6 +276,26 @@ public:
                     transitionTag1 = "OnATCompletion: ackError";
                     transitionTag2 = "OnATCompletion: ackError";
                     postKr = kIOReturnError;
+                    break;
+
+                case 0x8:
+                    // Compatibility fallback for controllers that surface legacy/packed
+                    // ack values. For write-like commands without response payload, treat
+                    // this as completion on AT; reads/locks still require AR data.
+                    if (needsARData) {
+                        ASFW_LOG_V2(Async, "  → AwaitingAR (legacy ackCode=0x8, data required)");
+                        txn->TransitionTo(TransactionState::ATCompleted, "OnATCompletion: legacy_ack8");
+                        txn->TransitionTo(TransactionState::AwaitingAR, "OnATCompletion: legacy_ack8");
+                        break;
+                    }
+                    if (txn->TryMarkCompleted()) {
+                        ASFW_LOG_V1(Async, "  → Completed (legacy ackCode=0x8, AT path won)");
+                        postAction = PostAction::kCompleteSuccess;
+                        transitionTag1 = "OnATCompletion: legacy_ack8";
+                        transitionTag2 = "OnATCompletion: legacy_ack8";
+                    } else {
+                        ASFW_LOG_V3(Async, "  → legacy ackCode=0x8 but AR already completed, ignoring");
+                    }
                     break;
 
                 default:

--- a/ASFWDriver/Bus/BusResetCoordinator.hpp
+++ b/ASFWDriver/Bus/BusResetCoordinator.hpp
@@ -140,6 +140,9 @@ class BusResetCoordinator {
      */
     void EscalateDiscoveryDelay();
 
+    /// Request a user-initiated bus reset (short or long).
+    void RequestUserReset(bool shortReset);
+
   private:
 #ifdef ASFW_HOST_TEST
     friend class BusResetCoordinatorTestPeer;

--- a/ASFWDriver/Bus/BusResetCoordinatorActions.cpp
+++ b/ASFWDriver/Bus/BusResetCoordinatorActions.cpp
@@ -516,6 +516,12 @@ void BusResetCoordinator::RecordRecoveryReason(std::string reason) {
     metrics_.lastFailureReason = *cycle_.recoveryReason;
 }
 
+void BusResetCoordinator::RequestUserReset(bool shortReset) {
+    RequestSoftwareReset({ResetRequestKind::ManualBusManager,
+                          shortReset ? ResetFlavor::Short : ResetFlavor::Long, std::nullopt,
+                          "UserClient-initiated", std::nullopt});
+}
+
 void BusResetCoordinator::ResetDelegationRetryCounter() {
     delegateRetryCount_ = 0;
     delegateSuppressed_ = false;

--- a/ASFWDriver/Bus/BusResetCoordinatorFSM.cpp
+++ b/ASFWDriver/Bus/BusResetCoordinatorFSM.cpp
@@ -8,6 +8,7 @@
 #endif
 
 #include "../Async/Interfaces/IAsyncControllerPort.hpp"
+#include "../Hardware/HardwareInterface.hpp"
 #include "BusManager.hpp"
 #include "Logging.hpp"
 #include "TopologyManager.hpp"
@@ -162,6 +163,14 @@ BusResetCoordinator::StepResult BusResetCoordinator::StepRearming() {
     if (!G_NodeIDValid()) {
         YieldAndReschedule(kDeferredPollMs, "Waiting for NodeID valid");
         return StepResult::Yield;
+    }
+
+    // Per Linux bus_reset_work(): re-assert cycleMaster after bus reset.
+    // The OHCI hardware may have auto-cleared it if cycleTooLong fired during
+    // the reset sequence. Without cycle-start packets, devices like the Nikon
+    // SAA7356HL cannot complete MCU firmware download.
+    if (hardware_ != nullptr) {
+        hardware_->SetLinkControlBits(LinkControlBits::kCycleMaster);
     }
 
     EnableFilters();

--- a/ASFWDriver/Controller/ControllerCore.hpp
+++ b/ASFWDriver/Controller/ControllerCore.hpp
@@ -115,6 +115,11 @@ class ControllerCore {
 
     Async::IAsyncControllerPort& AsyncSubsystem() const;
 
+    // Diagnostic accessors for UserClient handlers
+    HardwareInterface* GetHardware() const;
+    BusResetCoordinator* GetBusResetCoordinator() const;
+    BusManager* GetBusManager() const;
+
     Discovery::ConfigROMStore* GetConfigROMStore() const;
     Discovery::ROMScanner* GetROMScanner() const;
     void AttachROMScanner(std::shared_ptr<Discovery::ROMScanner> romScanner);

--- a/ASFWDriver/Controller/ControllerCoreFacades.cpp
+++ b/ASFWDriver/Controller/ControllerCoreFacades.cpp
@@ -116,6 +116,15 @@ void ControllerCore::SetCMPClient(std::shared_ptr<CMP::CMPClient> client) {
     deps_.cmpClient = std::move(client);
 }
 
+// Diagnostic accessors for UserClient handlers
+HardwareInterface* ControllerCore::GetHardware() const { return deps_.hardware.get(); }
+
+BusResetCoordinator* ControllerCore::GetBusResetCoordinator() const {
+    return deps_.busReset.get();
+}
+
+BusManager* ControllerCore::GetBusManager() const { return deps_.busManager.get(); }
+
 // Phase 2: Interface facade accessors
 Async::IFireWireBus& ControllerCore::Bus() {
     if (!busImpl_) {

--- a/ASFWDriver/Controller/ControllerCoreInterrupts.cpp
+++ b/ASFWDriver/Controller/ControllerCoreInterrupts.cpp
@@ -91,12 +91,14 @@ void ControllerCore::HandleInterrupt(const InterruptSnapshot& snapshot) {
             "Common causes: Self-ID buffer access, Config ROM mapping, or context register access");
     }
 
-    // Check for cycle timing errors (adapted from Linux irq handler)
+    // Check for cycle timing errors (adapted from Linux irq_handler)
     if ((events & IntEventBits::kCycleTooLong) != 0U) {
         ASFW_LOG(Controller, "⚠️ WARNING: Cycle too long - isochronous cycle overran 125μs budget");
-        ASFW_LOG(Controller,
-                 "This indicates DMA descriptors or system latency causing timing violation");
-        // Per OHCI §6.2.1: cycleTooLong fires when cycle exceeds 125μs nominal
+        // Per OHCI §6.2.1: hardware auto-clears cycleMaster when cycleTooLong fires.
+        // Per Linux irq_handler (ohci.c): re-assert cycleMaster immediately.
+        // Without this, cycle-start packets stop permanently, preventing devices that
+        // depend on them (e.g. Nikon SAA7356HL MCU firmware download) from initializing.
+        hw.SetLinkControlBits(LinkControlBits::kCycleMaster);
     }
 
     // Per Linux irq_handler: postedWriteErr very often pairs with unrecoverableError

--- a/ASFWDriver/Hardware/HardwareInterface.cpp
+++ b/ASFWDriver/Hardware/HardwareInterface.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 
 #include "../Async/Interfaces/IAsyncControllerPort.hpp"
+#include "IEEE1394.hpp"
 #include "Logging.hpp"
 
 #ifndef ASFW_HOST_TEST
@@ -333,8 +334,12 @@ bool HardwareInterface::SendPhyGlobalResume(uint8_t phyId) {
 }
 
 bool HardwareInterface::InitiateBusReset(bool shortReset) {
-    (void)shortReset;
-    return UpdatePhyRegister(1, 0, 0x40);
+    if (shortReset) {
+        // IEEE 1394a short bus reset: PHY register 5, bit 6 (SBR)
+        return UpdatePhyRegister(kPhyReg5Address, 0, kPhyInitiateShortBusReset);
+    }
+    // Long bus reset: PHY register 1, bit 6 (IBR)
+    return UpdatePhyRegister(kPhyReg1Address, 0, kPhyInitiateBusReset);
 }
 
 void HardwareInterface::SetContender(bool enable) {

--- a/ASFWDriver/Hardware/IEEE1394.hpp
+++ b/ASFWDriver/Hardware/IEEE1394.hpp
@@ -90,7 +90,18 @@ constexpr uint8_t kPhyContender  = 0x40;  // Bit 6
 // PHY gap count mask (register-level value: lower 6 bits)
 constexpr uint8_t kPhyGapCountMask = 0x3Fu; // 6-bit gap count field in PHY reg1
 
-// PHY register 5: Bit 6 enables IEEE 1394a accelerated arbitration (Enab_accel)
+// PHY register 1: bus reset control
+// Bit 6 = IBR (Initiate Bus Reset) — long bus reset
+constexpr uint8_t kPhyReg1Address = 1;
+constexpr uint8_t kPhyInitiateBusReset = 0x40;  // Bit 6
+
+// PHY register 5: IEEE 1394a enhancement bits
+// Bit 6 = SBR (Initiate Short Bus Reset) per IEEE 1394a §7.2.2
+// Bit 6 = Enab_accel (accelerated arbitration)
+// Bit 5 = Enab_multi (multi-speed packet concatenation)
+// Per Linux firewire_ohci configure_1394a_enhancements(): both bits are set together.
 constexpr uint8_t kPhyReg5Address = 5;
-constexpr uint8_t kPhyEnableAcceleration = 0x40;  // Bit 6
+constexpr uint8_t kPhyEnableAcceleration = 0x40;  // Bit 6 (also SBR when written standalone)
+constexpr uint8_t kPhyInitiateShortBusReset = 0x40; // Bit 6 = SBR (IEEE 1394a)
+constexpr uint8_t kPhyEnableMulti = 0x20;            // Bit 5
 }

--- a/tests/CompletionRefactorPlanTests.cpp
+++ b/tests/CompletionRefactorPlanTests.cpp
@@ -79,6 +79,23 @@ TEST(CompletionRefactorPlan, AckCompleteWriteCompletesOnAT) {
     EXPECT_EQ(h.mgr.Find(TLabel{1}), nullptr);  // Extracted on completion
 }
 
+TEST(CompletionRefactorPlan, AckCompleteEventNormalizesLegacyAck8ForWrite) {
+    Harness h;
+    ASSERT_TRUE(h.initOk);
+    CallbackRecorder cb;
+    auto* txn = h.AllocateTxn(/*label=*/6, /*gen=*/1, /*node=*/0x1234,
+                              /*tcode=*/0x1, CompletionStrategy::CompleteOnAT, cb);
+    ASSERT_NE(txn, nullptr);
+
+    h.handler.OnATCompletion(MakeTx(/*label=*/6,
+                                    /*ackCode=*/0x8,
+                                    /*eventCode=*/static_cast<uint8_t>(OHCIEventCode::kAckComplete)));
+
+    EXPECT_EQ(cb.called, 1);
+    EXPECT_EQ(cb.lastKr, kIOReturnSuccess);
+    EXPECT_EQ(h.mgr.Find(TLabel{6}), nullptr);
+}
+
 TEST(CompletionRefactorPlan, AckPendingWriteWaitsForARThenCompletes) {
     Harness h;
     ASSERT_TRUE(h.initOk);


### PR DESCRIPTION
## Summary

This PR contains a small set of async/bus correctness fixes.

- preserve the full 16-bit bus generation in async transaction context and bus-reset lifecycle paths
- normalize OHCI ACK semantics from event codes before completing async transactions
- handle `OUTPUT_MORE` precursor descriptors when hardware reports completion on the following `OUTPUT_LAST` descriptor
- re-assert `cycleMaster` after `cycleTooLong` / bus reset and add explicit short/long bus reset support

## Why

These changes make async transaction matching and bus-reset recovery more robust across bus-reset cycles and controller-specific OHCI completion behavior.

The bus-reset changes follow OHCI / IEEE 1394 behavior and align with the Linux firewire-ohci handling of cycle-too-long recovery, where `cycleMaster` is re-asserted after hardware clears it. The async completion changes make descriptor scanning and ACK interpretation more tolerant of controller-specific OHCI reporting.

They also make the core async/bus layer a safer foundation for future protocol work that depends on generation-correct response matching, split-transaction ACK handling, and reliable bus-reset recovery.

This supersedes #8 by folding the 16-bit generation fix into the broader async/bus correctness pass.

## Test Plan

- `./build.sh --no-bump`
- `ctest --test-dir build/tests_build -R 'CompletionRefactorPlan|AsyncBusContract|AsyncSubsystemAccessor' --output-on-failure`
- `ctest --test-dir build/tests_build -R 'BusResetCoordinator|BusManagerGapOptimization' --output-on-failure`

Results:

- build succeeded
- async-focused host tests passed: 20/20
- bus-focused host tests passed: 23/23
