### PR TITLE
feat(sbp2): add ORB wire primitives

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -128,10 +128,11 @@ jobs:
 
       - name: Install Sonar Build Wrapper (optional for C/C++ analysis)
         uses: SonarSource/sonarqube-scan-action/install-build-wrapper@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && env.SONAR_TOKEN != ''
 
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7
+        if: env.SONAR_TOKEN != ''
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,6 +30,11 @@ jobs:
           # BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
+          if [[ -z "$BUILD_CERTIFICATE_BASE64" || -z "$P12_PASSWORD" || -z "$KEYCHAIN_PASSWORD" ]]; then
+            echo "Signing secrets are unavailable; skipping certificate import."
+            exit 0
+          fi
+
           # create variables
           CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
           PP_PATH=$RUNNER_TEMP/build_pp.provisionprofile
@@ -54,16 +59,27 @@ jobs:
           # cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles      
       
       - name: Generate Compilation Database
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.CERT_BASE_64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
           chmod +x bump.sh
           ls -l bump.sh
           set -o pipefail
+          CODE_SIGN_ARGS=()
+          if [[ -z "$BUILD_CERTIFICATE_BASE64" || -z "$P12_PASSWORD" || -z "$KEYCHAIN_PASSWORD" ]]; then
+            echo "Signing secrets are unavailable; building without code signing."
+            CODE_SIGN_ARGS=(CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO)
+          fi
+
           xcodebuild -project ASFW.xcodeproj \
             -scheme ASFW \
             -configuration Debug \
             -arch arm64 \
             -derivedDataPath build/DerivedData \
             clean build \
+            "${CODE_SIGN_ARGS[@]}" \
             | tee xcodebuild.log \
             | xcpretty -r json-compilation-database --output compile_commands.json || {
               echo "::error::Build failed! Showing last 100 lines of log:"

--- a/ASFWDriver/ASFWDriver.cpp
+++ b/ASFWDriver/ASFWDriver.cpp
@@ -250,6 +250,8 @@ kern_return_t IMPL(ASFWDriver, Start) {
         }
     }
 
+    DriverWiring::EnsureSbp2Deps(ctx);
+
     if (ctx.deps.speedPolicy) {
         if (!ctx.deps.romScanner) {
             OSSharedPtr<IODispatchQueue> discoveryQueue = nullptr;

--- a/ASFWDriver/Async/Rx/PacketRouter.hpp
+++ b/ASFWDriver/Async/Rx/PacketRouter.hpp
@@ -200,6 +200,7 @@ public:
 
     /// Configure optional response sender for automatic WrResp emission.
     void SetResponseSender(ResponseSender* sender) noexcept { responseSender_ = sender; }
+    [[nodiscard]] ResponseSender* GetResponseSender() const noexcept { return responseSender_; }
 
     PacketRouter(const PacketRouter&) = delete;
     PacketRouter& operator=(const PacketRouter&) = delete;

--- a/ASFWDriver/Async/Tx/ResponseSender.cpp
+++ b/ASFWDriver/Async/Tx/ResponseSender.cpp
@@ -6,10 +6,34 @@
 #include "../Tx/Submitter.hpp"
 #include "../../Bus/GenerationTracker.hpp"
 #include "../../Logging/Logging.hpp"
+
 #include <DriverKit/IOReturn.h>
 #include <utility>
 
 namespace ASFW::Async {
+
+namespace {
+
+constexpr uint8_t kSrcBusID = 0;
+constexpr uint8_t kSpeedS400 = 0x02;
+constexpr uint8_t kRetryX = 1;
+constexpr uint8_t kPriority = 0;
+
+uint32_t BuildQ0(uint8_t tLabel, uint8_t tCode) {
+    return (static_cast<uint32_t>(kSrcBusID & 0x01) << 23) |
+           (static_cast<uint32_t>(kSpeedS400 & 0x07) << 16) |
+           (static_cast<uint32_t>(tLabel & 0x3F) << 10) |
+           (static_cast<uint32_t>(kRetryX) << 8) |
+           (static_cast<uint32_t>(tCode & 0x0F) << 4) |
+           (static_cast<uint32_t>(kPriority) & 0x0F);
+}
+
+uint32_t BuildQ1(uint16_t destID, ResponseCode rcode) {
+    return (static_cast<uint32_t>(destID) << 16) |
+           (static_cast<uint32_t>(static_cast<uint8_t>(rcode) & 0x0F) << 12);
+}
+
+} // namespace
 
 ResponseSender::ResponseSender(DescriptorBuilder& builder,
                                Tx::Submitter& submitter,
@@ -20,87 +44,140 @@ ResponseSender::ResponseSender(DescriptorBuilder& builder,
     , ctxMgr_(ctxMgr)
     , generationTracker_(generationTracker) {}
 
-void ResponseSender::SendWriteResponse(const ARPacketView& request, ResponseCode rcode) noexcept {
+void ResponseSender::SendResponse(const ARPacketView& request,
+                                  ResponseCode rcode,
+                                  uint8_t responseTCode,
+                                  const uint32_t* header,
+                                  std::size_t headerBytes,
+                                  uint64_t payloadDeviceAddress,
+                                  std::size_t payloadLength) noexcept {
     // Per IEEE 1394, broadcast requests (destID=0xFFFF) do not get responses.
     if (request.destID == 0xFFFF) {
-        ASFW_LOG_V3(Async, "ResponseSender: skip WrResp for broadcast destID=0xFFFF");
+        ASFW_LOG_V3(Async, "ResponseSender: skip response for broadcast destID=0xFFFF");
         return;
     }
 
+    auto* atRspCtx = ctxMgr_.GetAtResponseContext();
+    if (!atRspCtx) {
+        ASFW_LOG_ERROR(Async, "ResponseSender: ATResponseContext unavailable, cannot send response");
+        return;
+    }
+
+    auto chain = builder_.BuildTransactionChain(
+        header,
+        headerBytes,
+        payloadDeviceAddress,
+        payloadLength,
+        /*needsFlush*/ false);
+    if (chain.Empty()) {
+        ASFW_LOG_ERROR(
+            Async,
+            "ResponseSender: failed to build response chain (tCode=0x%x payload=%zu)",
+            responseTCode,
+            payloadLength);
+        return;
+    }
+
+    const auto submitRes = submitter_.submit_tx_chain(atRspCtx, std::move(chain));
+    if (submitRes.kr != kIOReturnSuccess) {
+        ASFW_LOG_ERROR(
+            Async,
+            "ResponseSender: submit_tx_chain failed (tCode=0x%x kr=0x%x)",
+            responseTCode,
+            submitRes.kr);
+        return;
+    }
+
+    ASFW_LOG_V2(
+        Async,
+        "ResponseSender: response queued (tCode=0x%x tLabel=%u dst=0x%04x rcode=0x%x payload=%zu)",
+        responseTCode,
+        static_cast<unsigned>(request.tLabel & 0x3F),
+        request.sourceID,
+        static_cast<unsigned>(rcode),
+        payloadLength);
+}
+
+void ResponseSender::SendWriteResponse(const ARPacketView& request, ResponseCode rcode) noexcept {
     // Only write requests (quadlet/block) receive a WrResp.
     if (request.tCode != 0x0 && request.tCode != 0x1) {
         ASFW_LOG_V3(Async, "ResponseSender: skip WrResp for non-write tCode=0x%x", request.tCode);
         return;
     }
 
-    auto* atRspCtx = ctxMgr_.GetAtResponseContext();
-    if (!atRspCtx) {
-        ASFW_LOG_ERROR(Async, "ResponseSender: ATResponseContext unavailable, cannot send WrResp");
-        return;
-    }
-
-    // Get local node ID from GenerationTracker (explicitly set, not relying on OHCI auto-fill)
-    const auto busState = generationTracker_.GetCurrentState();
-    const uint16_t localNodeID = busState.localNodeID;
-    
-    // Destination: respond back to the request initiator
-    // Source: our local node ID (typically 0xFFC0)
-    const uint16_t destID = request.sourceID;
-    const uint16_t srcID  = localNodeID;
-    const uint8_t  tLabel = static_cast<uint8_t>(request.tLabel & 0x3F);
-
-    // Build WRITE_RESPONSE header in OHCI AT Data format (NOT IEEE 1394 wire format!)
-    // 
-    // OHCI AT Data format (host byte order, per Linux ohci.h):
-    // Quadlet 0: [srcBusID:1][unused:5][speed:3][tLabel:6][rt:2][tCode:4][pri:4]
-    //            bit[23]     [22:19]    [18:16]  [15:10]  [9:8]  [7:4]   [3:0]
-    // Quadlet 1: [destinationId:16][rCode:4][reserved:12]
-    //            bits[31:16]        [15:12]   [11:0]
-    // Quadlet 2: [reserved:32] (for responses)
-    //
-    // The OHCI controller converts this to IEEE 1394 wire format during transmission.
-    
     uint32_t header[3]{};
-    constexpr uint8_t kSrcBusID = 0;      // Local bus
-    constexpr uint8_t kSpeedS400 = 0x02;  // Default S400 speed
-    constexpr uint8_t kRetryX = 1;        // Match Linux fw_fill_response() RETRY_1
-    constexpr uint8_t kTCodeWriteResponse = 0x2;
-    constexpr uint8_t kPriority = 0;
-
-    // Quadlet 0: OHCI AT format (same as PacketBuilder uses)
-    header[0] = (static_cast<uint32_t>(kSrcBusID & 0x01) << 23) |  // bit[23]: srcBusID
-                (static_cast<uint32_t>(kSpeedS400 & 0x07) << 16) | // bits[18:16]: speed
-                (static_cast<uint32_t>(tLabel) << 10) |            // bits[15:10]: tLabel
-                (static_cast<uint32_t>(kRetryX) << 8) |            // bits[9:8]: retry
-                (static_cast<uint32_t>(kTCodeWriteResponse) << 4) | // bits[7:4]: tCode
-                (static_cast<uint32_t>(kPriority) & 0xF);          // bits[3:0]: priority
-
-    // Quadlet 1: destinationId + rCode (for responses)
-    header[1] = (static_cast<uint32_t>(destID) << 16) |            // bits[31:16]: destID
-                (static_cast<uint32_t>(static_cast<uint8_t>(rcode)) << 12); // bits[15:12]: rCode
-
-    // Quadlet 2: reserved for responses
+    header[0] = BuildQ0(static_cast<uint8_t>(request.tLabel & 0x3F), /*WrResp*/ 0x2);
+    header[1] = BuildQ1(request.sourceID, rcode);
     header[2] = 0;
 
-    auto chain = builder_.BuildTransactionChain(
-        header,
-        sizeof(header),
-        /*payloadDeviceAddress*/ 0,
-        /*payloadSize*/ 0,
-        /*needsFlush*/ false);
-    if (chain.Empty()) {
-        ASFW_LOG_ERROR(Async, "ResponseSender: failed to build WrResp descriptor chain");
+    SendResponse(request,
+                 rcode,
+                 /*responseTCode*/ 0x2,
+                 header,
+                 sizeof(header),
+                 /*payloadDeviceAddress*/ 0,
+                 /*payloadLength*/ 0);
+}
+
+void ResponseSender::SendReadQuadletResponse(const ARPacketView& request,
+                                             ResponseCode rcode,
+                                             uint32_t quadletData) noexcept {
+    if (request.tCode != 0x4) {
+        ASFW_LOG_V3(Async,
+                    "ResponseSender: skip RdQuadResp for non-read-quadlet tCode=0x%x",
+                    request.tCode);
         return;
     }
 
-    const auto submitRes = submitter_.submit_tx_chain(atRspCtx, std::move(chain));
-    if (submitRes.kr != kIOReturnSuccess) {
-        ASFW_LOG_ERROR(Async, "ResponseSender: submit_tx_chain failed for WrResp (kr=0x%x)", submitRes.kr);
+    uint32_t header[4]{};
+    header[0] = BuildQ0(static_cast<uint8_t>(request.tLabel & 0x3F), /*RdQuadResp*/ 0x6);
+    header[1] = BuildQ1(request.sourceID, rcode);
+    header[2] = 0;
+    header[3] = (rcode == ResponseCode::Complete) ? quadletData : 0;
+
+    SendResponse(request,
+                 rcode,
+                 /*responseTCode*/ 0x6,
+                 header,
+                 sizeof(header),
+                 /*payloadDeviceAddress*/ 0,
+                 /*payloadLength*/ 0);
+}
+
+void ResponseSender::SendReadBlockResponse(const ARPacketView& request,
+                                           ResponseCode rcode,
+                                           uint64_t payloadDeviceAddress,
+                                           uint32_t payloadLength) noexcept {
+    if (request.tCode != 0x5) {
+        ASFW_LOG_V3(Async,
+                    "ResponseSender: skip RdBlockResp for non-read-block tCode=0x%x",
+                    request.tCode);
         return;
     }
 
-    ASFW_LOG_V2(Async, "ResponseSender: WrResp queued (tLabel=%u src=0x%04x dst=0x%04x rcode=0x%x)",
-                tLabel, srcID, destID, static_cast<unsigned>(rcode));
+    uint32_t header[4]{};
+    header[0] = BuildQ0(static_cast<uint8_t>(request.tLabel & 0x3F), /*RdBlockResp*/ 0x7);
+    header[1] = BuildQ1(request.sourceID, rcode);
+    header[2] = 0;
+
+    std::size_t responsePayloadLen = 0;
+    uint64_t responsePayloadAddress = 0;
+
+    if (rcode == ResponseCode::Complete && payloadLength > 0) {
+        header[3] = static_cast<uint32_t>(payloadLength) << 16;
+        responsePayloadLen = payloadLength;
+        responsePayloadAddress = payloadDeviceAddress;
+    } else {
+        header[3] = 0;
+    }
+
+    SendResponse(request,
+                 rcode,
+                 /*responseTCode*/ 0x7,
+                 header,
+                 sizeof(header),
+                 responsePayloadAddress,
+                 responsePayloadLen);
 }
 
 } // namespace ASFW::Async

--- a/ASFWDriver/Async/Tx/ResponseSender.hpp
+++ b/ASFWDriver/Async/Tx/ResponseSender.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 #include "../ResponseCode.hpp"
@@ -26,7 +27,26 @@ public:
     /// Skips transmission for broadcast requests (destID=0xFFFF).
     void SendWriteResponse(const ARPacketView& request, ResponseCode rcode) noexcept;
 
+    /// Build and transmit a Read Quadlet Response (tCode 0x6).
+    void SendReadQuadletResponse(const ARPacketView& request,
+                                 ResponseCode rcode,
+                                 uint32_t quadletData) noexcept;
+
+    /// Build and transmit a Read Block Response (tCode 0x7).
+    void SendReadBlockResponse(const ARPacketView& request,
+                               ResponseCode rcode,
+                               uint64_t payloadDeviceAddress,
+                               uint32_t payloadLength) noexcept;
+
 private:
+    void SendResponse(const ARPacketView& request,
+                      ResponseCode rcode,
+                      uint8_t responseTCode,
+                      const uint32_t* header,
+                      std::size_t headerBytes,
+                      uint64_t payloadDeviceAddress,
+                      std::size_t payloadLength) noexcept;
+
     DescriptorBuilder& builder_;
     Tx::Submitter& submitter_;
     Engine::ContextManager& ctxMgr_;

--- a/ASFWDriver/ConfigROM/Parse/ConfigROMParser.cpp
+++ b/ASFWDriver/ConfigROM/Parse/ConfigROMParser.cpp
@@ -111,10 +111,14 @@ void ConfigROMParser::AppendRecognizedEntry(std::vector<RomEntry>& entries, uint
         }
         return;
 
-    case 0x14: // Logical_Unit_Number
+    case 0x14: // Logical_Unit_Number or SBP-2 Management_Agent_Offset
         if (keyType == EntryType::kImmediate) {
             entries.push_back(
                 RomEntry{.key = CfgKey::Logical_Unit_Number, .value = value, .entryType = keyType});
+        } else if (keyType == EntryType::kCSROffset) {
+            entries.push_back(RomEntry{.key = CfgKey::Management_Agent_Offset,
+                                       .value = value,
+                                       .entryType = keyType});
         }
         return;
 
@@ -131,6 +135,14 @@ void ConfigROMParser::AppendRecognizedEntry(std::vector<RomEntry>& entries, uint
                                        .value = value,
                                        .entryType = keyType,
                                        .leafOffsetQuadlets = targetOffsetQuadlets});
+        }
+        return;
+
+    case 0x38: // Legacy non-standard fallback for Management_Agent_Offset
+        if (keyType == EntryType::kCSROffset) {
+            entries.push_back(RomEntry{.key = CfgKey::Management_Agent_Offset,
+                                       .value = value,
+                                       .entryType = keyType});
         }
         return;
 

--- a/ASFWDriver/Controller/ControllerCore.hpp
+++ b/ASFWDriver/Controller/ControllerCore.hpp
@@ -55,6 +55,10 @@ class IAVCDiscovery;
 class FCPResponseRouter;
 } // namespace ASFW::Protocols::AVC
 
+namespace ASFW::Protocols::SBP2 {
+class AddressSpaceManager;
+}
+
 namespace ASFW::IRM {
 class IRMClient;
 }
@@ -91,6 +95,7 @@ class ControllerCore {
 
         std::shared_ptr<ASFW::Protocols::AVC::AVCDiscovery> avcDiscovery;
         std::shared_ptr<ASFW::Protocols::AVC::FCPResponseRouter> fcpResponseRouter;
+        std::shared_ptr<ASFW::Protocols::SBP2::AddressSpaceManager> sbp2AddressSpaceManager;
 
         std::shared_ptr<ASFW::IRM::IRMClient> irmClient;
 
@@ -132,6 +137,9 @@ class ControllerCore {
     Protocols::AVC::IAVCDiscovery* GetAVCDiscovery() const;
     void SetAVCDiscovery(std::shared_ptr<Protocols::AVC::AVCDiscovery> avcDiscovery);
     void SetFCPResponseRouter(std::shared_ptr<Protocols::AVC::FCPResponseRouter> fcpResponseRouter);
+    Protocols::SBP2::AddressSpaceManager* GetSbp2AddressSpaceManager() const;
+    void SetSbp2AddressSpaceManager(
+        std::shared_ptr<Protocols::SBP2::AddressSpaceManager> sbp2AddressSpaceManager);
 
     IRM::IRMClient* GetIRMClient() const;
     void SetIRMClient(std::shared_ptr<IRM::IRMClient> client);

--- a/ASFWDriver/Controller/ControllerCoreFacades.cpp
+++ b/ASFWDriver/Controller/ControllerCoreFacades.cpp
@@ -104,6 +104,15 @@ void ControllerCore::SetFCPResponseRouter(
     deps_.fcpResponseRouter = std::move(fcpResponseRouter);
 }
 
+Protocols::SBP2::AddressSpaceManager* ControllerCore::GetSbp2AddressSpaceManager() const {
+    return deps_.sbp2AddressSpaceManager.get();
+}
+
+void ControllerCore::SetSbp2AddressSpaceManager(
+    std::shared_ptr<Protocols::SBP2::AddressSpaceManager> sbp2AddressSpaceManager) {
+    deps_.sbp2AddressSpaceManager = std::move(sbp2AddressSpaceManager);
+}
+
 IRM::IRMClient* ControllerCore::GetIRMClient() const { return deps_.irmClient.get(); }
 
 void ControllerCore::SetIRMClient(std::shared_ptr<IRM::IRMClient> client) {

--- a/ASFWDriver/Discovery/DeviceRegistry.cpp
+++ b/ASFWDriver/Discovery/DeviceRegistry.cpp
@@ -8,6 +8,12 @@ namespace ASFW::Discovery {
 
 constexpr uint32_t kUnitSpecId_TA = 0x00A02D;
 constexpr uint32_t kUnitSpecId_AVC = 0x00A02D;
+constexpr uint32_t kUnitSpecId_SBP2 = 0x00609E; // SBP-2 Unit_Spec_Id
+constexpr uint32_t kUnitSwVersion_SBP2 = 0x010483; // SBP-2 Unit_Sw_Version
+
+[[nodiscard]] constexpr bool IsSBP2Unit(const UnitDirectory& unit) noexcept {
+    return unit.unitSpecId == kUnitSpecId_SBP2 && unit.unitSwVersion == kUnitSwVersion_SBP2;
+}
 
 DeviceRegistry::DeviceRegistry() = default;
 
@@ -238,6 +244,9 @@ DeviceKind DeviceRegistry::ClassifyDevice(const ConfigROM& rom) const {
     for (const auto& unit : rom.unitDirectories) {
         if (unit.unitSpecId == kUnitSpecId_TA) {
             return DeviceKind::TA_61883;
+        }
+        if (IsSBP2Unit(unit)) {
+            return DeviceKind::Storage;
         }
     }
     

--- a/ASFWDriver/Discovery/DiscoveryTypes.hpp
+++ b/ASFWDriver/Discovery/DiscoveryTypes.hpp
@@ -87,6 +87,7 @@ enum class CfgKey : uint8_t {
     Logical_Unit_Number = 0x14,
     Node_Capabilities = 0x0C,
     Unit_Directory = 0xD1,  // IEEE 1212 Unit_Directory (keyId=0x11 when keyType=3)
+    Management_Agent_Offset = 0x54,  // SBP-2 (keyType=CSR offset, keyId=0x14)
 };
 
 struct RomEntry {

--- a/ASFWDriver/Discovery/FWDevice.cpp
+++ b/ASFWDriver/Discovery/FWDevice.cpp
@@ -116,9 +116,16 @@ std::vector<RomEntry> FWDevice::ExtractUnitDirectory(
                     entries.push_back(RomEntry{CfgKey::Unit_Sw_Version, value, keyType, 0});
                 }
                 break;
-            case 0x14:  // Logical_Unit_Number
+            case 0x14:  // Logical_Unit_Number or SBP-2 Management_Agent_Offset
                 if (keyType == 0) {  // Immediate
                     entries.push_back(RomEntry{CfgKey::Logical_Unit_Number, value, keyType, 0});
+                } else if (keyType == 1) {  // CSR offset
+                    entries.push_back(RomEntry{CfgKey::Management_Agent_Offset, value, keyType, 0});
+                }
+                break;
+            case 0x38:  // Legacy non-standard fallback for Management_Agent_Offset
+                if (keyType == 1) {
+                    entries.push_back(RomEntry{CfgKey::Management_Agent_Offset, value, keyType, 0});
                 }
                 break;
             default:

--- a/ASFWDriver/Discovery/IDeviceManager.hpp
+++ b/ASFWDriver/Discovery/IDeviceManager.hpp
@@ -123,12 +123,7 @@ public:
 
     ~ObserverGuard() noexcept {
         if (unregister_) {
-            try {
-                unregister_();
-            } catch (...) {
-                ASFW_LOG_ERROR(Discovery,
-                               "ObserverGuard: unregister callback threw during destruction");
-            }
+            unregister_();
         }
     }
 

--- a/ASFWDriver/Protocols/SBP2/AddressSpaceManager.cpp
+++ b/ASFWDriver/Protocols/SBP2/AddressSpaceManager.cpp
@@ -1,0 +1,1 @@
+#include "AddressSpaceManager.hpp"

--- a/ASFWDriver/Protocols/SBP2/AddressSpaceManager.hpp
+++ b/ASFWDriver/Protocols/SBP2/AddressSpaceManager.hpp
@@ -2,12 +2,14 @@
 
 #include <algorithm>
 #include <atomic>
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <optional>
 #include <span>
 #include <unordered_map>
 #include <vector>
+#include <functional>
 
 #ifdef ASFW_HOST_TEST
 #include "../../Testing/HostDriverKitStubs.hpp"
@@ -20,8 +22,19 @@
 
 namespace ASFW::Protocols::SBP2 {
 
+#ifdef ASFW_HOST_TEST
+#define ASFW_ADDRSPACE_LOG(fmt, ...)
+#else
+#define ASFW_ADDRSPACE_LOG(fmt, ...) ASFW_LOG_V2(Async, fmt, ##__VA_ARGS__)
+#endif
+
 class AddressSpaceManager {
 public:
+    // Callback invoked when a remote write arrives for a registered range.
+    // Parameters: handle, offset within range, payload data.
+    using RemoteWriteCallback = std::function<void(uint64_t handle,
+                                                   uint32_t offset,
+                                                   std::span<const uint8_t> payload)>;
     struct AddressRangeMeta {
         uint64_t handle{0};
         uint64_t address{0};
@@ -64,48 +77,79 @@ public:
             return kIOReturnBadArgument;
         }
 
-        const uint64_t start = ComposeAddress(addressHi, addressLo);
-        const uint64_t end = start + static_cast<uint64_t>(length);
-        if (end < start) {
+        IOLockLock(lock_);
+        const kern_return_t kr = AllocateAddressRangeLocked(
+            owner, addressHi, addressLo, length, outHandle, outMeta);
+        IOLockUnlock(lock_);
+        return kr;
+    }
+
+    kern_return_t AllocateAddressRangeAuto(void* owner,
+                                           uint16_t addressHi,
+                                           uint32_t length,
+                                           uint64_t* outHandle,
+                                           AddressRangeMeta* outMeta = nullptr) {
+        if (!lock_ || !outHandle || length == 0) {
             return kIOReturnBadArgument;
+        }
+        if (addressHi != kAutoAddressHi) {
+            return kIOReturnBadArgument;
+        }
+
+        const uint64_t windowStart = ComposeAddress(addressHi, kAutoAddressWindowStartLo);
+        const uint64_t windowEndExclusive = ComposeAddress(addressHi, kAutoAddressWindowEndLo) + 1ULL;
+        const uint64_t windowLength = windowEndExclusive - windowStart;
+        if (static_cast<uint64_t>(length) > windowLength) {
+            return kIOReturnNoSpace;
         }
 
         IOLockLock(lock_);
 
+        std::vector<std::pair<uint64_t, uint64_t>> occupied;
+        occupied.reserve(ranges_.size());
+
         for (const auto& entry : ranges_) {
-            if (RangesOverlap(start,
-                              static_cast<uint64_t>(length),
-                              entry.second.meta.address,
-                              static_cast<uint64_t>(entry.second.meta.length))) {
-                IOLockUnlock(lock_);
-                return kIOReturnNoSpace;
+            const auto& meta = entry.second.meta;
+            if (meta.addressHi != addressHi) {
+                continue;
             }
+
+            const uint64_t rangeStart = meta.address;
+            const uint64_t rangeEnd = rangeStart + static_cast<uint64_t>(meta.length);
+            if (rangeEnd <= windowStart || rangeStart >= windowEndExclusive) {
+                continue;
+            }
+
+            occupied.emplace_back(rangeStart, rangeEnd);
         }
 
-        AddressRange range{};
-        range.owner = owner;
-        range.meta.handle = nextHandle_++;
-        range.meta.address = start;
-        range.meta.addressHi = addressHi;
-        range.meta.addressLo = addressLo;
-        range.meta.length = length;
-        range.buffer.resize(length, 0);
+        std::sort(occupied.begin(), occupied.end());
 
-        const kern_return_t kr = AllocateBacking(range);
-        if (kr != kIOReturnSuccess) {
+        uint64_t candidate = AlignUp(windowStart, kAutoAddressAlignment);
+        for (const auto& [rangeStart, rangeEnd] : occupied) {
+            if (rangeEnd <= candidate) {
+                continue;
+            }
+            if (CanFitRange(candidate, length, rangeStart)) {
+                break;
+            }
+            candidate = AlignUp(rangeEnd, kAutoAddressAlignment);
+        }
+
+        if (!CanFitRange(candidate, length, windowEndExclusive)) {
             IOLockUnlock(lock_);
-            return kr;
+            return kIOReturnNoSpace;
         }
 
-        const uint64_t handle = range.meta.handle;
-        if (outMeta) {
-            *outMeta = range.meta;
-        }
-        ranges_.emplace(handle, std::move(range));
-        *outHandle = handle;
-
+        const kern_return_t kr = AllocateAddressRangeLocked(
+            owner,
+            addressHi,
+            static_cast<uint32_t>(candidate & 0xFFFF'FFFFULL),
+            length,
+            outHandle,
+            outMeta);
         IOLockUnlock(lock_);
-        return kIOReturnSuccess;
+        return kr;
     }
 
     kern_return_t DeallocateAddressRange(void* owner, uint64_t handle) {
@@ -116,14 +160,30 @@ public:
         IOLockLock(lock_);
         auto it = ranges_.find(handle);
         if (it == ranges_.end()) {
+            ASFW_ADDRSPACE_LOG("AddressSpaceManager[%p] dealloc miss owner=%p handle=0x%llx ranges=%lu",
+                               this,
+                               owner,
+                               static_cast<unsigned long long>(handle),
+                               static_cast<unsigned long>(ranges_.size()));
             IOLockUnlock(lock_);
             return kIOReturnNotFound;
         }
         if (it->second.owner != owner) {
+            ASFW_ADDRSPACE_LOG("AddressSpaceManager[%p] dealloc denied owner=%p handle=0x%llx actualOwner=%p",
+                               this,
+                               owner,
+                               static_cast<unsigned long long>(handle),
+                               it->second.owner);
             IOLockUnlock(lock_);
             return kIOReturnNotPermitted;
         }
 
+        ASFW_ADDRSPACE_LOG("AddressSpaceManager[%p] dealloc owner=%p handle=0x%llx addr=0x%012llx len=%u",
+                           this,
+                           owner,
+                           static_cast<unsigned long long>(handle),
+                           static_cast<unsigned long long>(it->second.meta.address),
+                           it->second.meta.length);
         CleanupBacking(it->second);
         ranges_.erase(it);
         IOLockUnlock(lock_);
@@ -197,16 +257,44 @@ public:
             return Async::ResponseCode::AddressError;
         }
 
-        IOLockLock(lock_);
-        auto* range = FindRangeByAddressLocked(address, static_cast<uint32_t>(payload.size()));
-        if (!range) {
+        RemoteWriteCallback callback;
+        uint64_t handle = 0;
+        uint32_t offset = 0;
+
+        {
+            IOLockLock(lock_);
+            auto* range = FindRangeByAddressLocked(address, static_cast<uint32_t>(payload.size()));
+            if (!range) {
+                LogRangesLocked("write miss", address, static_cast<uint32_t>(payload.size()));
+                IOLockUnlock(lock_);
+                return Async::ResponseCode::AddressError;
+            }
+
+            offset = static_cast<uint32_t>(address - range->meta.address);
+            ASFW_ADDRSPACE_LOG(
+                "AddressSpaceManager[%p] remote write addr=0x%012llx len=%zu src=%p "
+                "handle=0x%llx rangeAddr=0x%012llx off=%u buf=%p mapped=%p backing=%u",
+                this,
+                static_cast<unsigned long long>(address),
+                payload.size(),
+                payload.data(),
+                static_cast<unsigned long long>(range->meta.handle),
+                static_cast<unsigned long long>(range->meta.address),
+                offset,
+                range->buffer.data(),
+                range->mappedBytes,
+                range->hasBacking ? 1u : 0u);
+            WriteBytesLocked(*range, offset, payload);
+            callback = range->onRemoteWrite;
+            handle = range->meta.handle;
             IOLockUnlock(lock_);
-            return Async::ResponseCode::AddressError;
         }
 
-        const uint32_t offset = static_cast<uint32_t>(address - range->meta.address);
-        WriteBytesLocked(*range, offset, payload);
-        IOLockUnlock(lock_);
+        // Fire callback outside lock to avoid deadlock.
+        if (callback) {
+            callback(handle, offset, payload);
+        }
+
         return Async::ResponseCode::Complete;
     }
 
@@ -220,6 +308,7 @@ public:
         IOLockLock(lock_);
         auto* range = FindRangeByAddressLocked(address, length);
         if (!range) {
+            LogRangesLocked("resolve miss", address, length);
             IOLockUnlock(lock_);
             return Async::ResponseCode::AddressError;
         }
@@ -272,11 +361,33 @@ public:
         IOLockLock(lock_);
         for (auto it = ranges_.begin(); it != ranges_.end();) {
             if (it->second.owner == owner) {
+                ASFW_ADDRSPACE_LOG(
+                    "AddressSpaceManager[%p] release owner=%p handle=0x%llx addr=0x%012llx len=%u",
+                    this,
+                    owner,
+                    static_cast<unsigned long long>(it->second.meta.handle),
+                    static_cast<unsigned long long>(it->second.meta.address),
+                    it->second.meta.length);
                 CleanupBacking(it->second);
                 it = ranges_.erase(it);
             } else {
                 ++it;
             }
+        }
+        IOLockUnlock(lock_);
+    }
+
+    // Register a callback to fire when a remote write arrives for the given handle.
+    // Must be called after AllocateAddressRange. Replaces any previous callback.
+    void SetRemoteWriteCallback(uint64_t handle, RemoteWriteCallback callback) {
+        if (!lock_ || handle == 0) {
+            return;
+        }
+
+        IOLockLock(lock_);
+        auto it = ranges_.find(handle);
+        if (it != ranges_.end()) {
+            it->second.onRemoteWrite = std::move(callback);
         }
         IOLockUnlock(lock_);
     }
@@ -295,10 +406,16 @@ public:
     }
 
 private:
+    static constexpr uint16_t kAutoAddressHi = 0xFFFFu;
+    static constexpr uint32_t kAutoAddressWindowStartLo = 0x0010'0000u;
+    static constexpr uint32_t kAutoAddressWindowEndLo = 0x0FFF'FFFFu;
+    static constexpr uint64_t kAutoAddressAlignment = 8ULL;
+
     struct AddressRange {
         AddressRangeMeta meta{};
         void* owner{nullptr};
         std::vector<uint8_t> buffer;
+        RemoteWriteCallback onRemoteWrite;
 
         OSSharedPtr<IOBufferMemoryDescriptor> descriptor{};
         OSSharedPtr<IODMACommand> dmaCommand{};
@@ -310,6 +427,16 @@ private:
 
     static uint64_t ComposeAddress(uint16_t hi, uint32_t lo) {
         return (static_cast<uint64_t>(hi) << 32) | static_cast<uint64_t>(lo);
+    }
+
+    static uint64_t AlignUp(uint64_t value, uint64_t alignment) {
+        const uint64_t mask = alignment - 1ULL;
+        return (value + mask) & ~mask;
+    }
+
+    static bool CanFitRange(uint64_t start, uint32_t length, uint64_t limitExclusive) {
+        const uint64_t end = start + static_cast<uint64_t>(length);
+        return end >= start && end <= limitExclusive;
     }
 
     static bool RangesOverlap(uint64_t leftStart,
@@ -348,13 +475,84 @@ private:
         return nullptr;
     }
 
+    void LogRangesLocked(const char* reason, uint64_t address, uint32_t length) {
+        ASFW_ADDRSPACE_LOG("AddressSpaceManager[%p] %s addr=0x%012llx len=%u ranges=%lu",
+                           this,
+                           reason,
+                           static_cast<unsigned long long>(address),
+                           length,
+                           static_cast<unsigned long>(ranges_.size()));
+        for (const auto& entry : ranges_) {
+            const auto& range = entry.second;
+            ASFW_ADDRSPACE_LOG(
+                "AddressSpaceManager[%p] range handle=0x%llx owner=%p addr=0x%012llx len=%u backing=%u dma=0x%08x",
+                this,
+                static_cast<unsigned long long>(range.meta.handle),
+                range.owner,
+                static_cast<unsigned long long>(range.meta.address),
+                range.meta.length,
+                range.hasBacking ? 1u : 0u,
+                static_cast<unsigned>(range.deviceAddress));
+        }
+    }
+
+    kern_return_t AllocateAddressRangeLocked(void* owner,
+                                             uint16_t addressHi,
+                                             uint32_t addressLo,
+                                             uint32_t length,
+                                             uint64_t* outHandle,
+                                             AddressRangeMeta* outMeta) {
+        const uint64_t start = ComposeAddress(addressHi, addressLo);
+        const uint64_t end = start + static_cast<uint64_t>(length);
+        if (end < start) {
+            return kIOReturnBadArgument;
+        }
+
+        for (const auto& entry : ranges_) {
+            if (RangesOverlap(start,
+                              static_cast<uint64_t>(length),
+                              entry.second.meta.address,
+                              static_cast<uint64_t>(entry.second.meta.length))) {
+                return kIOReturnNoSpace;
+            }
+        }
+
+        AddressRange range{};
+        range.owner = owner;
+        range.meta.handle = nextHandle_++;
+        range.meta.address = start;
+        range.meta.addressHi = addressHi;
+        range.meta.addressLo = addressLo;
+        range.meta.length = length;
+        range.buffer.resize(length, 0);
+
+        const kern_return_t kr = AllocateBacking(range);
+        if (kr != kIOReturnSuccess) {
+            return kr;
+        }
+
+        const uint64_t handle = range.meta.handle;
+        if (outMeta) {
+            *outMeta = range.meta;
+        }
+        ranges_.emplace(handle, std::move(range));
+        ASFW_ADDRSPACE_LOG("AddressSpaceManager[%p] alloc owner=%p handle=0x%llx addr=0x%012llx len=%u ranges=%lu",
+                           this,
+                           owner,
+                           static_cast<unsigned long long>(handle),
+                           static_cast<unsigned long long>(start),
+                           length,
+                           static_cast<unsigned long>(ranges_.size()));
+        *outHandle = handle;
+        return kIOReturnSuccess;
+    }
+
     kern_return_t AllocateBacking(AddressRange& range) {
         const std::size_t size = static_cast<std::size_t>(range.meta.length);
 
-        const uint64_t options =
-            static_cast<uint64_t>(kIOMemoryDirectionOut) |
-            static_cast<uint64_t>(kIOMemoryDirectionIn) |
-            static_cast<uint64_t>(kIOMemoryMapCacheModeInhibit);
+        // IOBufferMemoryDescriptor::Create expects memory-direction options only.
+        // Cache policy is set at CreateMapping time, not in allocation options.
+        const uint64_t options = static_cast<uint64_t>(kIOMemoryDirectionInOut);
 
         std::optional<ASFW::Driver::HardwareInterface::DMABuffer> dma;
         if (hardware_) {
@@ -375,7 +573,7 @@ private:
 
         IOMemoryMap* mapping = nullptr;
         const kern_return_t kr = dma->descriptor->CreateMapping(
-            0,
+            kIOMemoryMapCacheModeInhibit,
             0,
             0,
             size,
@@ -449,17 +647,49 @@ private:
         OSSynchronizeIO();
     }
 
+    static void CopyPayloadBytes(uint8_t* destination,
+                                 std::span<const uint8_t> source) {
+        if (!destination || source.empty()) {
+            return;
+        }
+
+        const auto sourceAddr = reinterpret_cast<uintptr_t>(source.data());
+        const auto destAddr = reinterpret_cast<uintptr_t>(destination);
+        const bool quadletAligned = ((sourceAddr | destAddr) & 0x3u) == 0;
+
+        std::size_t index = 0;
+        if (quadletAligned) {
+            for (; index + sizeof(uint32_t) <= source.size(); index += sizeof(uint32_t)) {
+                uint32_t quadlet = 0;
+                __builtin_memcpy(&quadlet, source.data() + index, sizeof(uint32_t));
+                __builtin_memcpy(destination + index, &quadlet, sizeof(uint32_t));
+            }
+        }
+
+        for (; index < source.size(); ++index) {
+            destination[index] = source[index];
+        }
+    }
+
     static void WriteBytesLocked(AddressRange& range,
                                  uint32_t offset,
                                  std::span<const uint8_t> data) {
-        std::memcpy(range.buffer.data() + static_cast<std::size_t>(offset),
-                    data.data(),
-                    data.size());
+        ASFW_ADDRSPACE_LOG(
+            "AddressSpaceManager write handle=0x%llx off=%u len=%zu src=%p buf=%p mapped=%p "
+            "srcAlign=%zu bufAlign=%zu mappedAlign=%zu",
+            static_cast<unsigned long long>(range.meta.handle),
+            offset,
+            data.size(),
+            data.data(),
+            range.buffer.data(),
+            range.mappedBytes,
+            static_cast<unsigned long>(reinterpret_cast<uintptr_t>(data.data()) & 0x7ULL),
+            static_cast<unsigned long>(reinterpret_cast<uintptr_t>(range.buffer.data()) & 0x7ULL),
+            static_cast<unsigned long>(reinterpret_cast<uintptr_t>(range.mappedBytes) & 0x7ULL));
+        CopyPayloadBytes(range.buffer.data() + static_cast<std::size_t>(offset), data);
 
         if (range.hasBacking && range.mappedBytes) {
-            std::memcpy(range.mappedBytes + static_cast<std::size_t>(offset),
-                        data.data(),
-                        data.size());
+            CopyPayloadBytes(range.mappedBytes + static_cast<std::size_t>(offset), data);
             std::atomic_thread_fence(std::memory_order_release);
             SyncRange(range, offset, data.size());
         }
@@ -470,5 +700,7 @@ private:
     uint64_t nextHandle_{1};
     std::unordered_map<uint64_t, AddressRange> ranges_;
 };
+
+#undef ASFW_ADDRSPACE_LOG
 
 } // namespace ASFW::Protocols::SBP2

--- a/ASFWDriver/Protocols/SBP2/AddressSpaceManager.hpp
+++ b/ASFWDriver/Protocols/SBP2/AddressSpaceManager.hpp
@@ -1,0 +1,474 @@
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <span>
+#include <unordered_map>
+#include <vector>
+
+#ifdef ASFW_HOST_TEST
+#include "../../Testing/HostDriverKitStubs.hpp"
+#endif
+#include <DriverKit/IOLib.h>
+
+#include "../../Async/ResponseCode.hpp"
+#include "../../Hardware/HardwareInterface.hpp"
+#include "../../Logging/Logging.hpp"
+
+namespace ASFW::Protocols::SBP2 {
+
+class AddressSpaceManager {
+public:
+    struct AddressRangeMeta {
+        uint64_t handle{0};
+        uint64_t address{0};
+        uint16_t addressHi{0};
+        uint32_t addressLo{0};
+        uint32_t length{0};
+    };
+
+    struct ReadSlice {
+        uint64_t payloadDeviceAddress{0};
+        uint32_t payloadLength{0};
+    };
+
+    explicit AddressSpaceManager(ASFW::Driver::HardwareInterface* hardware) noexcept
+        : hardware_(hardware)
+        , lock_(IOLockAlloc()) {}
+
+    ~AddressSpaceManager() {
+        ClearAll();
+        if (lock_) {
+            IOLockFree(lock_);
+            lock_ = nullptr;
+        }
+    }
+
+    AddressSpaceManager(const AddressSpaceManager&) = delete;
+    AddressSpaceManager& operator=(const AddressSpaceManager&) = delete;
+
+    [[nodiscard]] bool IsReady() const noexcept {
+        return lock_ != nullptr;
+    }
+
+    kern_return_t AllocateAddressRange(void* owner,
+                                       uint16_t addressHi,
+                                       uint32_t addressLo,
+                                       uint32_t length,
+                                       uint64_t* outHandle,
+                                       AddressRangeMeta* outMeta = nullptr) {
+        if (!lock_ || !outHandle || length == 0) {
+            return kIOReturnBadArgument;
+        }
+
+        const uint64_t start = ComposeAddress(addressHi, addressLo);
+        const uint64_t end = start + static_cast<uint64_t>(length);
+        if (end < start) {
+            return kIOReturnBadArgument;
+        }
+
+        IOLockLock(lock_);
+
+        for (const auto& entry : ranges_) {
+            if (RangesOverlap(start,
+                              static_cast<uint64_t>(length),
+                              entry.second.meta.address,
+                              static_cast<uint64_t>(entry.second.meta.length))) {
+                IOLockUnlock(lock_);
+                return kIOReturnNoSpace;
+            }
+        }
+
+        AddressRange range{};
+        range.owner = owner;
+        range.meta.handle = nextHandle_++;
+        range.meta.address = start;
+        range.meta.addressHi = addressHi;
+        range.meta.addressLo = addressLo;
+        range.meta.length = length;
+        range.buffer.resize(length, 0);
+
+        const kern_return_t kr = AllocateBacking(range);
+        if (kr != kIOReturnSuccess) {
+            IOLockUnlock(lock_);
+            return kr;
+        }
+
+        const uint64_t handle = range.meta.handle;
+        if (outMeta) {
+            *outMeta = range.meta;
+        }
+        ranges_.emplace(handle, std::move(range));
+        *outHandle = handle;
+
+        IOLockUnlock(lock_);
+        return kIOReturnSuccess;
+    }
+
+    kern_return_t DeallocateAddressRange(void* owner, uint64_t handle) {
+        if (!lock_ || handle == 0) {
+            return kIOReturnBadArgument;
+        }
+
+        IOLockLock(lock_);
+        auto it = ranges_.find(handle);
+        if (it == ranges_.end()) {
+            IOLockUnlock(lock_);
+            return kIOReturnNotFound;
+        }
+        if (it->second.owner != owner) {
+            IOLockUnlock(lock_);
+            return kIOReturnNotPermitted;
+        }
+
+        CleanupBacking(it->second);
+        ranges_.erase(it);
+        IOLockUnlock(lock_);
+        return kIOReturnSuccess;
+    }
+
+    kern_return_t ReadIncomingData(void* owner,
+                                   uint64_t handle,
+                                   uint32_t offset,
+                                   uint32_t length,
+                                   std::vector<uint8_t>* outData) {
+        if (!lock_ || !outData) {
+            return kIOReturnBadArgument;
+        }
+
+        IOLockLock(lock_);
+        auto it = ranges_.find(handle);
+        if (it == ranges_.end()) {
+            IOLockUnlock(lock_);
+            return kIOReturnNotFound;
+        }
+        if (it->second.owner != owner) {
+            IOLockUnlock(lock_);
+            return kIOReturnNotPermitted;
+        }
+
+        const auto& range = it->second;
+        if (!WithinRange(range, offset, length)) {
+            IOLockUnlock(lock_);
+            return kIOReturnNoSpace;
+        }
+
+        outData->assign(range.buffer.begin() + static_cast<std::size_t>(offset),
+                        range.buffer.begin() + static_cast<std::size_t>(offset + length));
+        IOLockUnlock(lock_);
+        return kIOReturnSuccess;
+    }
+
+    kern_return_t WriteLocalData(void* owner,
+                                 uint64_t handle,
+                                 uint32_t offset,
+                                 std::span<const uint8_t> data) {
+        if (!lock_) {
+            return kIOReturnBadArgument;
+        }
+
+        IOLockLock(lock_);
+        auto it = ranges_.find(handle);
+        if (it == ranges_.end()) {
+            IOLockUnlock(lock_);
+            return kIOReturnNotFound;
+        }
+        if (it->second.owner != owner) {
+            IOLockUnlock(lock_);
+            return kIOReturnNotPermitted;
+        }
+
+        if (!WithinRange(it->second, offset, static_cast<uint32_t>(data.size()))) {
+            IOLockUnlock(lock_);
+            return kIOReturnNoSpace;
+        }
+
+        WriteBytesLocked(it->second, offset, data);
+        IOLockUnlock(lock_);
+        return kIOReturnSuccess;
+    }
+
+    Async::ResponseCode ApplyRemoteWrite(uint64_t address,
+                                         std::span<const uint8_t> payload) {
+        if (!lock_ || payload.empty()) {
+            return Async::ResponseCode::AddressError;
+        }
+
+        IOLockLock(lock_);
+        auto* range = FindRangeByAddressLocked(address, static_cast<uint32_t>(payload.size()));
+        if (!range) {
+            IOLockUnlock(lock_);
+            return Async::ResponseCode::AddressError;
+        }
+
+        const uint32_t offset = static_cast<uint32_t>(address - range->meta.address);
+        WriteBytesLocked(*range, offset, payload);
+        IOLockUnlock(lock_);
+        return Async::ResponseCode::Complete;
+    }
+
+    Async::ResponseCode ResolveReadSlice(uint64_t address,
+                                         uint32_t length,
+                                         ReadSlice* outSlice) {
+        if (!lock_ || !outSlice || length == 0) {
+            return Async::ResponseCode::AddressError;
+        }
+
+        IOLockLock(lock_);
+        auto* range = FindRangeByAddressLocked(address, length);
+        if (!range) {
+            IOLockUnlock(lock_);
+            return Async::ResponseCode::AddressError;
+        }
+
+        if (!range->hasBacking || range->deviceAddress == 0) {
+            IOLockUnlock(lock_);
+            return Async::ResponseCode::DataError;
+        }
+
+        const uint64_t offset = address - range->meta.address;
+        const uint64_t payloadAddress = range->deviceAddress + offset;
+        if (payloadAddress > 0xFFFF'FFFFULL) {
+            IOLockUnlock(lock_);
+            return Async::ResponseCode::DataError;
+        }
+
+        outSlice->payloadDeviceAddress = payloadAddress;
+        outSlice->payloadLength = length;
+
+        IOLockUnlock(lock_);
+        return Async::ResponseCode::Complete;
+    }
+
+    Async::ResponseCode ReadQuadlet(uint64_t address, uint32_t* outValue) {
+        if (!lock_ || !outValue) {
+            return Async::ResponseCode::AddressError;
+        }
+
+        IOLockLock(lock_);
+        auto* range = FindRangeByAddressLocked(address, sizeof(uint32_t));
+        if (!range) {
+            IOLockUnlock(lock_);
+            return Async::ResponseCode::AddressError;
+        }
+
+        const uint32_t offset = static_cast<uint32_t>(address - range->meta.address);
+        std::memcpy(outValue,
+                    range->buffer.data() + static_cast<std::size_t>(offset),
+                    sizeof(uint32_t));
+
+        IOLockUnlock(lock_);
+        return Async::ResponseCode::Complete;
+    }
+
+    void ReleaseOwner(void* owner) {
+        if (!lock_) {
+            return;
+        }
+
+        IOLockLock(lock_);
+        for (auto it = ranges_.begin(); it != ranges_.end();) {
+            if (it->second.owner == owner) {
+                CleanupBacking(it->second);
+                it = ranges_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        IOLockUnlock(lock_);
+    }
+
+    void ClearAll() {
+        if (!lock_) {
+            return;
+        }
+
+        IOLockLock(lock_);
+        for (auto& entry : ranges_) {
+            CleanupBacking(entry.second);
+        }
+        ranges_.clear();
+        IOLockUnlock(lock_);
+    }
+
+private:
+    struct AddressRange {
+        AddressRangeMeta meta{};
+        void* owner{nullptr};
+        std::vector<uint8_t> buffer;
+
+        OSSharedPtr<IOBufferMemoryDescriptor> descriptor{};
+        OSSharedPtr<IODMACommand> dmaCommand{};
+        IOMemoryMap* mapping{nullptr};
+        uint8_t* mappedBytes{nullptr};
+        uint64_t deviceAddress{0};
+        bool hasBacking{false};
+    };
+
+    static uint64_t ComposeAddress(uint16_t hi, uint32_t lo) {
+        return (static_cast<uint64_t>(hi) << 32) | static_cast<uint64_t>(lo);
+    }
+
+    static bool RangesOverlap(uint64_t leftStart,
+                              uint64_t leftLength,
+                              uint64_t rightStart,
+                              uint64_t rightLength) {
+        const uint64_t leftEnd = leftStart + leftLength;
+        const uint64_t rightEnd = rightStart + rightLength;
+        return leftStart < rightEnd && rightStart < leftEnd;
+    }
+
+    static bool WithinRange(const AddressRange& range, uint32_t offset, uint32_t length) {
+        const uint64_t end = static_cast<uint64_t>(offset) + static_cast<uint64_t>(length);
+        return end <= static_cast<uint64_t>(range.meta.length);
+    }
+
+    AddressRange* FindRangeByAddressLocked(uint64_t address, uint32_t length) {
+        const uint64_t end = address + static_cast<uint64_t>(length);
+        if (end < address) {
+            return nullptr;
+        }
+
+        for (auto& entry : ranges_) {
+            auto& range = entry.second;
+            const uint64_t rangeStart = range.meta.address;
+            const uint64_t rangeEnd = rangeStart + static_cast<uint64_t>(range.meta.length);
+            if (rangeEnd < rangeStart) {
+                continue;
+            }
+
+            if (address >= rangeStart && end <= rangeEnd) {
+                return &range;
+            }
+        }
+
+        return nullptr;
+    }
+
+    kern_return_t AllocateBacking(AddressRange& range) {
+        const std::size_t size = static_cast<std::size_t>(range.meta.length);
+
+        const uint64_t options =
+            static_cast<uint64_t>(kIOMemoryDirectionOut) |
+            static_cast<uint64_t>(kIOMemoryDirectionIn) |
+            static_cast<uint64_t>(kIOMemoryMapCacheModeInhibit);
+
+        std::optional<ASFW::Driver::HardwareInterface::DMABuffer> dma;
+        if (hardware_) {
+            dma = hardware_->AllocateDMA(size, options, 16);
+        }
+
+        if (!dma.has_value()) {
+#ifdef ASFW_HOST_TEST
+            range.hasBacking = false;
+            return kIOReturnSuccess;
+#else
+            ASFW_LOG(UserClient,
+                     "AddressSpaceManager: DMA allocation failed for len=%u",
+                     range.meta.length);
+            return kIOReturnNoMemory;
+#endif
+        }
+
+        IOMemoryMap* mapping = nullptr;
+        const kern_return_t kr = dma->descriptor->CreateMapping(
+            0,
+            0,
+            0,
+            size,
+            0,
+            &mapping);
+        if (kr != kIOReturnSuccess || !mapping) {
+            if (dma->dmaCommand) {
+                dma->dmaCommand->CompleteDMA(kIODMACommandCompleteDMANoOptions);
+                dma->dmaCommand.reset();
+            }
+            return kr != kIOReturnSuccess ? kr : kIOReturnError;
+        }
+
+        auto* mapped = reinterpret_cast<uint8_t*>(mapping->GetAddress());
+        if (!mapped) {
+            mapping->release();
+            if (dma->dmaCommand) {
+                dma->dmaCommand->CompleteDMA(kIODMACommandCompleteDMANoOptions);
+                dma->dmaCommand.reset();
+            }
+            return kIOReturnNoMemory;
+        }
+
+        std::memset(mapped, 0, size);
+        OSSynchronizeIO();
+
+        range.descriptor = std::move(dma->descriptor);
+        range.dmaCommand = std::move(dma->dmaCommand);
+        range.mapping = mapping;
+        range.mappedBytes = mapped;
+        range.deviceAddress = dma->deviceAddress;
+        range.hasBacking = true;
+
+        return kIOReturnSuccess;
+    }
+
+    static void CleanupBacking(AddressRange& range) {
+        if (range.mapping) {
+            range.mapping->release();
+            range.mapping = nullptr;
+        }
+
+        if (range.dmaCommand) {
+            range.dmaCommand->CompleteDMA(kIODMACommandCompleteDMANoOptions);
+            range.dmaCommand.reset();
+        }
+
+        range.descriptor.reset();
+        range.mappedBytes = nullptr;
+        range.deviceAddress = 0;
+        range.hasBacking = false;
+    }
+
+    static void SyncRange(AddressRange& range, uint64_t offset, uint64_t length) {
+        if (!range.hasBacking) {
+            return;
+        }
+
+#if defined(IODMACommand_Synchronize_ID)
+        if (range.dmaCommand) {
+            const kern_return_t syncKr = range.dmaCommand->Synchronize(
+                0,
+                offset,
+                length);
+            if (syncKr != kIOReturnSuccess) {
+                OSSynchronizeIO();
+            }
+            return;
+        }
+#endif
+        OSSynchronizeIO();
+    }
+
+    static void WriteBytesLocked(AddressRange& range,
+                                 uint32_t offset,
+                                 std::span<const uint8_t> data) {
+        std::memcpy(range.buffer.data() + static_cast<std::size_t>(offset),
+                    data.data(),
+                    data.size());
+
+        if (range.hasBacking && range.mappedBytes) {
+            std::memcpy(range.mappedBytes + static_cast<std::size_t>(offset),
+                        data.data(),
+                        data.size());
+            std::atomic_thread_fence(std::memory_order_release);
+            SyncRange(range, offset, data.size());
+        }
+    }
+
+    ASFW::Driver::HardwareInterface* hardware_{nullptr};
+    IOLock* lock_{nullptr};
+    uint64_t nextHandle_{1};
+    std::unordered_map<uint64_t, AddressRange> ranges_;
+};
+
+} // namespace ASFW::Protocols::SBP2

--- a/ASFWDriver/Protocols/SBP2/SBP2CommandORB.cpp
+++ b/ASFWDriver/Protocols/SBP2/SBP2CommandORB.cpp
@@ -1,0 +1,240 @@
+// SBP-2 Normal Command ORB implementation.
+// Ref: SBP-2 §5.1.1 (Normal Command ORB format)
+
+#include "SBP2CommandORB.hpp"
+#include "SBP2DelayedDispatch.hpp"
+#include "../../Common/FWCommon.hpp"
+
+#include <algorithm>
+
+namespace ASFW::Protocols::SBP2 {
+
+// ---------------------------------------------------------------------------
+// Construction / Destruction
+// ---------------------------------------------------------------------------
+
+SBP2CommandORB::SBP2CommandORB(AddressSpaceManager& addrMgr, void* owner,
+                               uint32_t maxCommandBlockSize)
+    : addrMgr_(addrMgr)
+    , owner_(owner)
+    , maxCommandBlockSize_(maxCommandBlockSize)
+{
+    AllocateResources();
+}
+
+SBP2CommandORB::~SBP2CommandORB() {
+    CancelTimer();
+    lifetimeToken_.reset();
+    DeallocateResources();
+}
+
+// ---------------------------------------------------------------------------
+// Resource allocation
+// ---------------------------------------------------------------------------
+
+bool SBP2CommandORB::AllocateResources() noexcept {
+    const uint32_t orbSize = Wire::NormalORB::kHeaderSize + maxCommandBlockSize_;
+
+    orbStorage_.resize(orbSize, 0);
+
+    const kern_return_t kr = addrMgr_.AllocateAddressRangeAuto(
+        owner_, 0xFFFF, orbSize,
+        &orbHandle_, &orbMeta_);
+    if (kr != kIOReturnSuccess) {
+        ASFW_LOG(Async, "SBP2CommandORB: failed to allocate ORB address space: 0x%08x", kr);
+        return false;
+    }
+
+    ASFW_LOG(Async, "SBP2CommandORB: allocated %u-byte ORB at %04x:%08x",
+             orbSize, orbMeta_.addressHi, orbMeta_.addressLo);
+    return true;
+}
+
+void SBP2CommandORB::DeallocateResources() noexcept {
+    if (orbHandle_ != 0) {
+        addrMgr_.DeallocateAddressRange(owner_, orbHandle_);
+        orbHandle_ = 0;
+    }
+    orbMeta_ = {};
+    orbStorage_.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Command block (CDB)
+// ---------------------------------------------------------------------------
+
+void SBP2CommandORB::SetCommandBlock(std::span<const uint8_t> cdb) noexcept {
+    const uint32_t copyLen = static_cast<uint32_t>(
+        std::min(cdb.size(), static_cast<size_t>(maxCommandBlockSize_)));
+
+    if (copyLen > 0) {
+        std::memcpy(orbStorage_.data() + Wire::NormalORB::kHeaderSize,
+                     cdb.data(), copyLen);
+    }
+
+    // Zero remaining command block area
+    if (copyLen < maxCommandBlockSize_) {
+        std::memset(orbStorage_.data() + Wire::NormalORB::kHeaderSize + copyLen,
+                     0, maxCommandBlockSize_ - copyLen);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Prepare for execution (fills in dynamic fields)
+// ---------------------------------------------------------------------------
+
+void SBP2CommandORB::PrepareForExecution(uint16_t localNodeID,
+                                         FW::FwSpeed speed,
+                                         uint16_t maxPayloadLog) noexcept {
+    auto* orb = reinterpret_cast<Wire::NormalORB*>(orbStorage_.data());
+    const uint16_t busNodeID = Wire::NormalizeBusNodeID(localNodeID);
+
+    // Null next-ORB pointer (bit 31 set = null terminator)
+    orb->nextORBAddressHi = Wire::ToBE32(Wire::NormalORB::kNextORBNull);
+    orb->nextORBAddressLo = 0;
+
+    // Data descriptor: fill in localNodeID in the hi word
+    if (dataDescriptor_.isDirect) {
+        // Direct mode: preserve addressHi and inject local node ID.
+        orb->dataDescriptorHi = Wire::ToBE32(
+            Wire::ComposeBusAddressHi(
+                busNodeID,
+                static_cast<uint16_t>(Wire::FromBE32(dataDescriptor_.dataDescriptorHi) & 0xFFFFu)));
+        orb->dataDescriptorLo = dataDescriptor_.dataDescriptorLo;
+    } else {
+        // Page table mode: dataDescriptorHi already has nodeID + addressHi from Build()
+        orb->dataDescriptorHi = dataDescriptor_.dataDescriptorHi;
+        orb->dataDescriptorLo = dataDescriptor_.dataDescriptorLo;
+    }
+
+    // Build options word from flags + negotiated parameters
+    uint16_t options = 0;
+
+    // ORB format: Normal = 0x0000, Reserved = 0x2000, Vendor = 0x4000, Dummy = 0x6000
+    if (flags_ & kDummyORB) {
+        options |= Wire::ToBE16(0x6000);
+    } else if (flags_ & kVendorORB) {
+        options |= Wire::ToBE16(0x4000);
+    } else if (flags_ & kReservedORB) {
+        options |= Wire::ToBE16(0x2000);
+    }
+    // kNormalORB (default) → 0x0000, no bits needed
+
+    // Notify bit
+    if (flags_ & kNotify) {
+        options |= Wire::Options::kNotify;
+    }
+
+    // Direction: data from target (read)
+    if (flags_ & kDataFromTarget) {
+        options |= Wire::Options::kDirectionRead;
+    }
+
+    // Speed
+    switch (speed) {
+        case FW::FwSpeed::S200: options |= Wire::Options::kSpeed200; break;
+        case FW::FwSpeed::S400: options |= Wire::Options::kSpeed400; break;
+        case FW::FwSpeed::S800: options |= Wire::Options::kSpeed800; break;
+        default: break; // S100 = 0
+    }
+
+    // Max payload size (log2 of max payload in quadlets, shifted left by 4)
+    options |= Wire::ToBE16(
+        static_cast<uint16_t>(maxPayloadLog << Wire::Options::kMaxPayloadShift));
+
+    // Page table format bits from data descriptor
+    options |= dataDescriptor_.options;
+
+    orb->options = options;
+
+    // Data size: byte count (direct) or PTE count (page table)
+    orb->dataSize = dataDescriptor_.dataSize;
+
+    // Flush ORB to address space
+    WriteORBToAddressSpace();
+}
+
+// ---------------------------------------------------------------------------
+// Write ORB buffer to DMA-backed address space
+// ---------------------------------------------------------------------------
+
+void SBP2CommandORB::WriteORBToAddressSpace() noexcept {
+    const auto span = std::span<const uint8_t>(orbStorage_.data(), orbStorage_.size());
+    const kern_return_t kr = addrMgr_.WriteLocalData(
+        owner_, orbHandle_, 0, span);
+    if (kr != kIOReturnSuccess) {
+        ASFW_LOG(Async, "SBP2CommandORB: failed to write ORB to address space: 0x%08x", kr);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ORB address / chaining
+// ---------------------------------------------------------------------------
+
+Async::FWAddress SBP2CommandORB::GetORBAddress() const noexcept {
+    Async::FWAddress::QualifiedAddressParts parts{};
+    parts.addressHi = orbMeta_.addressHi;
+    parts.addressLo = orbMeta_.addressLo;
+    parts.nodeID = 0; // filled in by login session with localNodeID
+    return Async::FWAddress(parts);
+}
+
+void SBP2CommandORB::SetNextORBAddress(uint32_t hi, uint32_t lo) noexcept {
+    auto* orb = reinterpret_cast<Wire::NormalORB*>(orbStorage_.data());
+    orb->nextORBAddressHi = hi;
+    orb->nextORBAddressLo = lo;
+    WriteORBToAddressSpace();
+}
+
+void SBP2CommandORB::SetToDummy() noexcept {
+    // Set rq_fmt=3 (bits [13:12] = 11) to make device skip this ORB
+    auto* orb = reinterpret_cast<Wire::NormalORB*>(orbStorage_.data());
+    uint16_t hostOptions = Wire::FromBE16(orb->options);
+    hostOptions = (hostOptions & ~0x3000u) | 0x6000u;
+    orb->options = Wire::ToBE16(hostOptions);
+    WriteORBToAddressSpace();
+}
+
+// ---------------------------------------------------------------------------
+// Timer management
+// ---------------------------------------------------------------------------
+
+void SBP2CommandORB::StartTimer(IODispatchQueue* queue) noexcept {
+    CancelTimer();
+
+    if (queue == nullptr || timeoutDuration_ == 0) {
+        return;
+    }
+
+    timerQueue_ = queue;
+    inProgress_.store(true, std::memory_order_relaxed);
+    const uint32_t timeout = timeoutDuration_;
+    const uint64_t expectedGeneration =
+        timerGeneration_.fetch_add(1, std::memory_order_acq_rel) + 1ULL;
+    const std::weak_ptr<int> weakLifetime = lifetimeToken_;
+    const uint64_t delayNs = static_cast<uint64_t>(timeout) * 1'000'000ULL;
+
+    DispatchAfterCompat(queue, delayNs, [this, weakLifetime, expectedGeneration, timeout]() {
+        if (weakLifetime.expired()) {
+            return;
+        }
+        if (timerGeneration_.load(std::memory_order_acquire) != expectedGeneration ||
+            !inProgress_.load(std::memory_order_relaxed) ||
+            !completionCallback_) {
+            return;
+        }
+
+        ASFW_LOG(Async, "SBP2CommandORB: ORB timeout after %u ms", timeout);
+        inProgress_.store(false, std::memory_order_relaxed);
+        timerGeneration_.fetch_add(1, std::memory_order_acq_rel);
+        completionCallback_(-1, Wire::SBPStatus::kUnspecifiedError);
+    });
+}
+
+void SBP2CommandORB::CancelTimer() noexcept {
+    inProgress_.store(false, std::memory_order_relaxed);
+    timerQueue_ = nullptr;
+    timerGeneration_.fetch_add(1, std::memory_order_acq_rel);
+}
+
+} // namespace ASFW::Protocols::SBP2

--- a/ASFWDriver/Protocols/SBP2/SBP2CommandORB.hpp
+++ b/ASFWDriver/Protocols/SBP2/SBP2CommandORB.hpp
@@ -1,0 +1,123 @@
+#pragma once
+
+// SBP-2 Normal Command ORB.
+// Represents a single SCSI command submitted to the device after login.
+//
+// Ref: SBP-2 §5.1.1 (Normal Command ORB format)
+
+#include "AddressSpaceManager.hpp"
+#include "SBP2PageTable.hpp"
+#include "SBP2WireFormats.hpp"
+#include "../../Async/AsyncTypes.hpp"
+#include "../../Common/FWCommon.hpp"
+#include "../../Logging/Logging.hpp"
+
+#include <DriverKit/IOLib.h>
+#ifdef ASFW_HOST_TEST
+#include "../../Testing/HostDriverKitStubs.hpp"
+#else
+#include <DriverKit/IODispatchQueue.h>
+#endif
+
+#include <atomic>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <span>
+
+namespace ASFW::Protocols::SBP2 {
+
+class SBP2CommandORB {
+public:
+    enum Flags : uint32_t {
+        kNotify         = (1 << 0),
+        kDataFromTarget = (1 << 1),
+        kImmediate      = (1 << 2),
+        kNormalORB      = (1 << 5),
+        kReservedORB    = (1 << 6),
+        kVendorORB      = (1 << 7),
+        kDummyORB       = (1 << 8),
+    };
+
+    using CompletionCallback = std::function<void(int transportStatus, uint8_t sbpStatus)>;
+
+    SBP2CommandORB(AddressSpaceManager& addrMgr, void* owner,
+                   uint32_t maxCommandBlockSize);
+    ~SBP2CommandORB();
+
+    SBP2CommandORB(const SBP2CommandORB&) = delete;
+    SBP2CommandORB& operator=(const SBP2CommandORB&) = delete;
+
+    // Configuration (call before submit)
+    void SetCommandBlock(std::span<const uint8_t> cdb) noexcept;
+    void SetFlags(uint32_t flags) noexcept { flags_ = flags; }
+    void SetMaxPayloadSize(uint16_t bytes) noexcept { maxPayloadSize_ = bytes; }
+    void SetTimeout(uint32_t ms) noexcept { timeoutDuration_ = ms; }
+    void SetCompletionCallback(CompletionCallback cb) noexcept { completionCallback_ = std::move(cb); }
+
+    // Bind page table result from SBP2PageTable::Build.
+    void SetDataDescriptor(const SBP2PageTable::Result& ptResult) noexcept {
+        dataDescriptor_ = ptResult;
+    }
+
+    // Internal: called by the session layer before submission.
+    void PrepareForExecution(uint16_t localNodeID, FW::FwSpeed speed,
+                             uint16_t maxPayloadLog) noexcept;
+
+    // Internal: ORB address for fetch agent / chaining.
+    [[nodiscard]] Async::FWAddress GetORBAddress() const noexcept;
+
+    // Internal: set the next ORB pointer (big-endian values).
+    void SetNextORBAddress(uint32_t hi, uint32_t lo) noexcept;
+
+    // Set rq_fmt=3 (NOP dummy) so device skips this ORB if already fetched.
+    void SetToDummy() noexcept;
+
+    // Internal: timer management.
+    void StartTimer(IODispatchQueue* queue) noexcept;
+    void CancelTimer() noexcept;
+
+    // State tracking.
+    [[nodiscard]] bool IsAppended() const noexcept { return isAppended_; }
+    void SetAppended(bool state) noexcept { isAppended_ = state; }
+
+    [[nodiscard]] uint32_t GetFetchAgentWriteRetries() const noexcept { return fetchAgentWriteRetries_; }
+    void SetFetchAgentWriteRetries(uint32_t retries) noexcept { fetchAgentWriteRetries_ = retries; }
+
+    [[nodiscard]] uint32_t GetFlags() const noexcept { return flags_; }
+    [[nodiscard]] CompletionCallback& GetCompletionCallback() noexcept { return completionCallback_; }
+
+private:
+    bool AllocateResources() noexcept;
+    void DeallocateResources() noexcept;
+    void WriteORBToAddressSpace() noexcept;
+
+    AddressSpaceManager& addrMgr_;
+    void* owner_;
+    uint32_t maxCommandBlockSize_;
+
+    uint32_t flags_{0};
+    uint16_t maxPayloadSize_{0};
+    uint32_t timeoutDuration_{0};
+    CompletionCallback completionCallback_;
+
+    // ORB buffer — local copy, written to address space before submission.
+    uint64_t orbHandle_{0};
+    AddressSpaceManager::AddressRangeMeta orbMeta_;
+    std::vector<uint8_t> orbStorage_;
+
+    // Page table binding.
+    SBP2PageTable::Result dataDescriptor_{};
+
+    // State.
+    bool isAppended_{false};
+    std::atomic<bool> inProgress_{false};
+    uint32_t fetchAgentWriteRetries_{20};
+
+    // Timer.
+    IODispatchQueue* timerQueue_{nullptr};
+    std::atomic<uint64_t> timerGeneration_{0};
+    std::shared_ptr<int> lifetimeToken_{std::make_shared<int>(0)};
+};
+
+} // namespace ASFW::Protocols::SBP2

--- a/ASFWDriver/Protocols/SBP2/SBP2DelayedDispatch.hpp
+++ b/ASFWDriver/Protocols/SBP2/SBP2DelayedDispatch.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+#ifdef ASFW_HOST_TEST
+#include "../../Testing/HostDriverKitStubs.hpp"
+#else
+#include <DriverKit/IODispatchQueue.h>
+#include <DriverKit/IOLib.h>
+#endif
+
+namespace ASFW::Protocols::SBP2 {
+
+inline void DispatchAfterCompat(IODispatchQueue* queue,
+                                uint64_t delayNs,
+                                std::function<void()> callback) noexcept {
+    if (queue == nullptr || !callback) {
+        return;
+    }
+
+#ifdef ASFW_HOST_TEST
+    queue->DispatchAsyncAfter(delayNs, std::move(callback));
+#else
+    const uint64_t delayMs = delayNs / 1'000'000ULL;
+    const uint64_t trailingNs = delayNs % 1'000'000ULL;
+    auto work = std::move(callback);
+    queue->DispatchAsync(^{
+        if (delayMs > 0) {
+            IOSleep(delayMs);
+        }
+        if (trailingNs > 0) {
+            IODelay((trailingNs + 999ULL) / 1000ULL);
+        }
+        work();
+    });
+#endif
+}
+
+} // namespace ASFW::Protocols::SBP2

--- a/ASFWDriver/Protocols/SBP2/SBP2ManagementORB.cpp
+++ b/ASFWDriver/Protocols/SBP2/SBP2ManagementORB.cpp
@@ -1,0 +1,249 @@
+// SBP-2 Management ORB implementation.
+// Ref: SBP-2 §6 (Task Management)
+
+#include "SBP2ManagementORB.hpp"
+#include "SBP2DelayedDispatch.hpp"
+
+#include "../../Async/Interfaces/IFireWireBus.hpp"
+#include "../../Async/Interfaces/IFireWireBusInfo.hpp"
+#include "../../Common/FWCommon.hpp"
+
+namespace ASFW::Protocols::SBP2 {
+
+using namespace ASFW::Protocols::SBP2::Wire;
+
+// ---------------------------------------------------------------------------
+// Construction / Destruction
+// ---------------------------------------------------------------------------
+
+SBP2ManagementORB::SBP2ManagementORB(Async::IFireWireBus& bus,
+                                     Async::IFireWireBusInfo& busInfo,
+                                     AddressSpaceManager& addrMgr, void* owner)
+    : bus_(bus)
+    , busInfo_(busInfo)
+    , addrMgr_(addrMgr)
+    , owner_(owner) {}
+
+SBP2ManagementORB::~SBP2ManagementORB() {
+    timerGeneration_.fetch_add(1, std::memory_order_acq_rel);
+    lifetimeToken_.reset();
+    DeallocateResources();
+}
+
+// ---------------------------------------------------------------------------
+// Resource allocation
+// ---------------------------------------------------------------------------
+
+bool SBP2ManagementORB::AllocateResources() noexcept {
+    if (orbHandle_ != 0) {
+        return true; // Already allocated
+    }
+
+    // Allocate ORB address space (32 bytes)
+    auto kr = addrMgr_.AllocateAddressRangeAuto(
+        owner_, 0xFFFF, Wire::TaskManagementORB::kSize,
+        &orbHandle_, &orbMeta_);
+    if (kr != kIOReturnSuccess) {
+        ASFW_LOG(Async, "SBP2ManagementORB: failed to allocate ORB: 0x%08x", kr);
+        return false;
+    }
+
+    // Allocate per-ORB status block address space (32 bytes)
+    kr = addrMgr_.AllocateAddressRangeAuto(
+        owner_, 0xFFFF, Wire::StatusBlock::kMaxSize,
+        &statusBlockHandle_, &statusBlockMeta_);
+    if (kr != kIOReturnSuccess) {
+        ASFW_LOG(Async, "SBP2ManagementORB: failed to allocate status block: 0x%08x", kr);
+        addrMgr_.DeallocateAddressRange(owner_, orbHandle_);
+        orbHandle_ = 0;
+        return false;
+    }
+
+    // Register remote-write callback for the per-ORB status block
+    addrMgr_.SetRemoteWriteCallback(
+        statusBlockHandle_,
+        [this](uint64_t /*handle*/, uint32_t offset, std::span<const uint8_t> payload) {
+            OnStatusBlockWrite(offset, payload);
+        });
+
+    return true;
+}
+
+void SBP2ManagementORB::DeallocateResources() noexcept {
+    if (statusBlockHandle_ != 0) {
+        addrMgr_.DeallocateAddressRange(owner_, statusBlockHandle_);
+        statusBlockHandle_ = 0;
+    }
+    if (orbHandle_ != 0) {
+        addrMgr_.DeallocateAddressRange(owner_, orbHandle_);
+        orbHandle_ = 0;
+    }
+    orbMeta_ = {};
+    statusBlockMeta_ = {};
+}
+
+// ---------------------------------------------------------------------------
+// ORB construction
+// ---------------------------------------------------------------------------
+
+void SBP2ManagementORB::BuildManagementORB() noexcept {
+    std::memset(&orbBuffer_, 0, sizeof(orbBuffer_));
+
+    const uint16_t localNode =
+        NormalizeBusNodeID(static_cast<uint16_t>(busInfo_.GetLocalNodeID().value));
+
+    // Options: notify (bit 15) | function code (low nibble)
+    const auto fn = static_cast<uint16_t>(function_);
+    orbBuffer_.options = ToBE16(static_cast<uint16_t>(0x8000u | fn));
+    orbBuffer_.loginID = ToBE16(loginID_);
+
+    // For AbortTask: set target ORB address (quadlet-aligned, big-endian)
+    if (function_ == Function::AbortTask) {
+        orbBuffer_.orbOffsetHi = ToBE32(targetORBAddressHi_);
+        orbBuffer_.orbOffsetLo = ToBE32(targetORBAddressLo_ & 0xFFFFFFFCu);
+    }
+
+    // Status FIFO address
+    orbBuffer_.statusFIFOAddressHi = ToBE32(
+        ComposeBusAddressHi(localNode, statusBlockMeta_.addressHi));
+    orbBuffer_.statusFIFOAddressLo = ToBE32(statusBlockMeta_.addressLo);
+
+    // Write ORB to address space
+    addrMgr_.WriteLocalData(
+        owner_, orbHandle_, 0,
+        std::span<const uint8_t>{reinterpret_cast<const uint8_t*>(&orbBuffer_),
+                                  sizeof(orbBuffer_)});
+
+    // Build 8-byte management agent write payload: ORB address in BE
+    orbAddressBE_[0] = static_cast<uint8_t>(localNode >> 8);
+    orbAddressBE_[1] = static_cast<uint8_t>(localNode & 0xFF);
+    orbAddressBE_[2] = static_cast<uint8_t>(orbMeta_.addressHi >> 8);
+    orbAddressBE_[3] = static_cast<uint8_t>(orbMeta_.addressHi & 0xFF);
+    const uint32_t addrLoBE = ToBE32(orbMeta_.addressLo);
+    std::memcpy(&orbAddressBE_[4], &addrLoBE, sizeof(uint32_t));
+
+    ASFW_LOG(Async,
+             "SBP2ManagementORB: built function=%u loginID=%u ORB at %04x:%08x status at %04x:%08x",
+             fn, loginID_,
+             localNode, orbMeta_.addressLo,
+             localNode, statusBlockMeta_.addressLo);
+}
+
+// ---------------------------------------------------------------------------
+// Execution
+// ---------------------------------------------------------------------------
+
+bool SBP2ManagementORB::Execute() noexcept {
+    if (inProgress_.load(std::memory_order_relaxed)) {
+        ASFW_LOG(Async, "SBP2ManagementORB::Execute: already in progress");
+        return false;
+    }
+
+    if (!AllocateResources()) {
+        return false;
+    }
+
+    BuildManagementORB();
+
+    inProgress_.store(true, std::memory_order_relaxed);
+
+    // Write ORB address to management agent
+    const FW::Generation gen{generation_};
+    const FW::NodeId node{static_cast<uint8_t>(nodeID_ & 0x3Fu)};
+    const Async::FWAddress mgmtAddr{
+        Async::FWAddress::QualifiedAddressParts{
+            .addressHi = 0xFFFF,
+            .addressLo = ManagementAgentAddressLo(managementAgentOffset_),
+            .nodeID = nodeID_
+        }
+    };
+    const FW::FwSpeed speed = busInfo_.GetSpeed(node);
+
+    writeHandle_ = bus_.WriteBlock(
+        gen, node, mgmtAddr,
+        std::span<const uint8_t>{orbAddressBE_.data(), orbAddressBE_.size()},
+        speed,
+        [this](Async::AsyncStatus status, std::span<const uint8_t> response) {
+            OnWriteComplete(status, response);
+        });
+
+    if (!writeHandle_) {
+        ASFW_LOG(Async, "SBP2ManagementORB::Execute: WriteBlock failed");
+        inProgress_.store(false, std::memory_order_relaxed);
+        return false;
+    }
+
+    ASFW_LOG(Async, "SBP2ManagementORB::Execute: wrote management ORB to agent");
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Completion handlers
+// ---------------------------------------------------------------------------
+
+void SBP2ManagementORB::OnWriteComplete(Async::AsyncStatus status,
+                                         std::span<const uint8_t> response) noexcept {
+    if (status != Async::AsyncStatus::kSuccess) {
+        ASFW_LOG(Async, "SBP2ManagementORB::OnWriteComplete: status=%s",
+                 Async::ToString(status));
+        Complete(-1);
+        return;
+    }
+
+    // Management agent write ACK'd. Start timeout, wait for status block.
+    timerActive_.store(true, std::memory_order_relaxed);
+    ASFW_LOG(Async, "SBP2ManagementORB: mgmt agent ACK'd, waiting for status block (timeout=%ums)",
+             timeoutMs_);
+
+    if (workQueue_ && timeoutMs_ > 0) {
+        const uint32_t timeout = timeoutMs_;
+        const uint64_t expectedGeneration =
+            timerGeneration_.fetch_add(1, std::memory_order_acq_rel) + 1ULL;
+        const std::weak_ptr<int> weakLifetime = lifetimeToken_;
+        const uint64_t delayNs = static_cast<uint64_t>(timeout) * 1'000'000ULL;
+
+        DispatchAfterCompat(workQueue_, delayNs, [this, weakLifetime, expectedGeneration]() {
+            if (weakLifetime.expired()) {
+                return;
+            }
+            if (timerGeneration_.load(std::memory_order_acquire) != expectedGeneration ||
+                !timerActive_.load(std::memory_order_relaxed) ||
+                !inProgress_.load(std::memory_order_relaxed)) {
+                return;
+            }
+            OnTimeout();
+        });
+    }
+}
+
+void SBP2ManagementORB::OnStatusBlockWrite(uint32_t offset,
+                                             std::span<const uint8_t> payload) noexcept {
+    if (!inProgress_.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    ASFW_LOG(Async, "SBP2ManagementORB: received status block (offset=%u len=%zu)",
+             offset, payload.size());
+
+    Complete(0);
+}
+
+void SBP2ManagementORB::OnTimeout() noexcept {
+    if (!inProgress_.load(std::memory_order_relaxed)) {
+        return;
+    }
+    ASFW_LOG(Async, "SBP2ManagementORB: timeout");
+    Complete(-2);
+}
+
+void SBP2ManagementORB::Complete(int status) noexcept {
+    inProgress_.store(false, std::memory_order_relaxed);
+    timerActive_.store(false, std::memory_order_relaxed);
+    timerGeneration_.fetch_add(1, std::memory_order_acq_rel);
+
+    if (completionCallback_) {
+        completionCallback_(status);
+    }
+}
+
+} // namespace ASFW::Protocols::SBP2

--- a/ASFWDriver/Protocols/SBP2/SBP2ManagementORB.hpp
+++ b/ASFWDriver/Protocols/SBP2/SBP2ManagementORB.hpp
@@ -1,0 +1,133 @@
+#pragma once
+
+// SBP-2 Management ORB — task abort, logical unit reset, target reset.
+// Written to the management agent address (same as login/reconnect/logout).
+// Has its own per-ORB status FIFO address space.
+//
+// Ref: SBP-2 §6 (Task Management)
+
+#include "AddressSpaceManager.hpp"
+#include "SBP2WireFormats.hpp"
+#include "../../Async/AsyncTypes.hpp"
+#include "../../Logging/Logging.hpp"
+
+#include <DriverKit/IOLib.h>
+#ifdef ASFW_HOST_TEST
+#include "../../Testing/HostDriverKitStubs.hpp"
+#else
+#include <DriverKit/IODispatchQueue.h>
+#endif
+
+#include <array>
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <span>
+
+namespace ASFW::Async {
+class IFireWireBus;
+class IFireWireBusInfo;
+}
+
+namespace ASFW::Protocols::SBP2 {
+
+class SBP2ManagementORB {
+public:
+    using CompletionCallback = std::function<void(int status)>;
+
+    enum class Function : uint16_t {
+        QueryLogins      = 1,
+        AbortTask        = 0xB,
+        AbortTaskSet     = 0xC,
+        LogicalUnitReset = 0xE,
+        TargetReset      = 0xF,
+    };
+
+    SBP2ManagementORB(Async::IFireWireBus& bus,
+                      Async::IFireWireBusInfo& busInfo,
+                      AddressSpaceManager& addrMgr, void* owner);
+    ~SBP2ManagementORB();
+
+    SBP2ManagementORB(const SBP2ManagementORB&) = delete;
+    SBP2ManagementORB& operator=(const SBP2ManagementORB&) = delete;
+
+    // Configuration (call before Execute)
+    void SetFunction(Function fn) noexcept { function_ = fn; }
+    void SetLoginID(uint16_t loginID) noexcept { loginID_ = loginID; }
+    void SetTargetORBAddress(uint32_t hi, uint32_t lo) noexcept {
+        targetORBAddressHi_ = hi;
+        targetORBAddressLo_ = lo;
+    }
+    void SetManagementAgentOffset(uint32_t offset) noexcept { managementAgentOffset_ = offset; }
+    void SetTimeout(uint32_t ms) noexcept { timeoutMs_ = ms; }
+    void SetCompletionCallback(CompletionCallback cb) noexcept { completionCallback_ = std::move(cb); }
+
+    // Set node targeting before Execute.
+    void SetTargetNode(uint16_t generation, uint16_t nodeID) noexcept {
+        generation_ = generation;
+        nodeID_ = nodeID;
+    }
+
+    void SetWorkQueue(IODispatchQueue* queue) noexcept { workQueue_ = queue; }
+
+    // Lifecycle
+    [[nodiscard]] bool Execute() noexcept;
+
+    [[nodiscard]] Function GetFunction() const noexcept { return function_; }
+    [[nodiscard]] bool InProgress() const noexcept { return inProgress_.load(std::memory_order_relaxed); }
+
+private:
+    bool AllocateResources() noexcept;
+    void DeallocateResources() noexcept;
+    void BuildManagementORB() noexcept;
+
+    void OnWriteComplete(Async::AsyncStatus status, std::span<const uint8_t> response) noexcept;
+    void OnStatusBlockWrite(uint32_t offset, std::span<const uint8_t> payload) noexcept;
+    void OnTimeout() noexcept;
+    void Complete(int status) noexcept;
+
+    // Dependencies
+    Async::IFireWireBus& bus_;
+    Async::IFireWireBusInfo& busInfo_;
+    AddressSpaceManager& addrMgr_;
+    void* owner_;
+
+    // Configuration
+    Function function_{Function::AbortTaskSet};
+    uint16_t loginID_{0};
+    uint32_t managementAgentOffset_{0};
+    uint32_t timeoutMs_{2000};
+    CompletionCallback completionCallback_;
+
+    // Target ORB (AbortTask only)
+    uint32_t targetORBAddressHi_{0};
+    uint32_t targetORBAddressLo_{0};
+
+    // ORB buffer + address space
+    uint64_t orbHandle_{0};
+    AddressSpaceManager::AddressRangeMeta orbMeta_{};
+    Wire::TaskManagementORB orbBuffer_{};
+
+    // Per-ORB status block address space
+    uint64_t statusBlockHandle_{0};
+    AddressSpaceManager::AddressRangeMeta statusBlockMeta_{};
+
+    // Management agent write payload (8-byte BE ORB address)
+    std::array<uint8_t, 8> orbAddressBE_{};
+    Async::AsyncHandle writeHandle_{};
+
+    // State
+    std::atomic<bool> inProgress_{false};
+    std::atomic<bool> timerActive_{false};
+
+    // Node targeting
+    uint16_t generation_{0};
+    uint16_t nodeID_{0xFFFF};
+
+    // Timer infrastructure
+    IODispatchQueue* workQueue_{nullptr};
+    std::atomic<uint64_t> timerGeneration_{0};
+    std::shared_ptr<int> lifetimeToken_{std::make_shared<int>(0)};
+};
+
+} // namespace ASFW::Protocols::SBP2

--- a/ASFWDriver/Protocols/SBP2/SBP2PageTable.hpp
+++ b/ASFWDriver/Protocols/SBP2/SBP2PageTable.hpp
@@ -1,0 +1,163 @@
+#pragma once
+
+// SBP-2 Page Table builder.
+// Converts scatter-gather DMA segments into SBP-2 Page Table Entries (PTEs)
+// or a single direct-address descriptor when possible.
+//
+// Ref: SBP-2 §5.1.2 (Page Table Entry format)
+
+#include "AddressSpaceManager.hpp"
+#include "SBP2WireFormats.hpp"
+#include "../../Logging/Logging.hpp"
+
+#include <cstring>
+#include <span>
+#include <vector>
+
+namespace ASFW::Protocols::SBP2 {
+
+class SBP2PageTable {
+public:
+    struct Segment {
+        uint64_t address;   // Physical / DMA address of data buffer
+        uint32_t length;    // Length in bytes
+    };
+
+    struct Result {
+        uint32_t dataDescriptorHi{0};
+        uint32_t dataDescriptorLo{0};
+        uint16_t options{0};    // Page table format bits to OR into ORB options
+        uint16_t dataSize{0};   // PTE count for page table, or byte count for direct
+        bool isDirect{false};
+    };
+
+    explicit SBP2PageTable(AddressSpaceManager& addrMgr, void* owner) noexcept
+        : addrMgr_(addrMgr), owner_(owner) {}
+
+    SBP2PageTable(const SBP2PageTable&) = delete;
+    SBP2PageTable& operator=(const SBP2PageTable&) = delete;
+
+    /// Build page table from scatter-gather segments.
+    /// @param segments       DMA segments describing the data buffer
+    /// @param localNodeID    Local node ID for address fields
+    /// @param maxPageClipSize Max bytes per PTE entry (default 0xF000 = 60 KiB)
+    /// @return true on success
+    [[nodiscard]] bool Build(std::span<const Segment> segments,
+                             uint16_t localNodeID,
+                             uint32_t maxPageClipSize = 0xF000) noexcept {
+        Clear();
+        const uint16_t busNodeID = Wire::NormalizeBusNodeID(localNodeID);
+
+        if (segments.empty()) {
+            result_ = {};
+            return true;
+        }
+
+        // Clamp max page clip size.
+        if (maxPageClipSize == 0 || maxPageClipSize > 0xF000) {
+            maxPageClipSize = 0xF000;
+        }
+
+        // Build PTE entries into local buffer.
+        std::vector<Wire::PageTableEntry> ptes;
+
+        for (const auto& seg : segments) {
+            if (seg.length == 0) {
+                continue;
+            }
+
+            uint64_t phys = seg.address;
+            uint32_t remaining = seg.length;
+
+            while (remaining > 0) {
+                uint32_t chunk = (remaining > maxPageClipSize) ? maxPageClipSize : remaining;
+
+                Wire::PageTableEntry pte{};
+                pte.segmentLength = Wire::ToBE16(static_cast<uint16_t>(chunk));
+                pte.segmentBaseAddressHi = Wire::ToBE16(
+                    static_cast<uint16_t>((phys >> 32) & 0xFFFFULL));
+                pte.segmentBaseAddressLo = Wire::ToBE32(
+                    static_cast<uint32_t>(phys & 0xFFFFFFFFULL));
+
+                ptes.push_back(pte);
+
+                phys += chunk;
+                remaining -= chunk;
+            }
+        }
+
+        if (ptes.empty()) {
+            result_ = {};
+            return true;
+        }
+
+        pteCount_ = static_cast<uint32_t>(ptes.size());
+
+        // Optimization: single PTE with quadlet-aligned address → direct mode.
+        if (pteCount_ == 1 && (ptes[0].segmentBaseAddressLo & Wire::ToBE32(0x3u)) == 0) {
+            result_.dataDescriptorHi = Wire::ToBE32(
+                static_cast<uint32_t>(segments.front().address >> 32) & 0xFFFFu);
+            result_.dataDescriptorLo = ptes[0].segmentBaseAddressLo;
+            result_.dataSize = ptes[0].segmentLength;  // still BE, ORB reads it BE
+            result_.options = 0;  // no page table
+            result_.isDirect = true;
+            return true;
+        }
+
+        // Multi-PTE: allocate address space for the page table.
+        const uint32_t ptSize = pteCount_ * sizeof(Wire::PageTableEntry);
+
+        auto kr = addrMgr_.AllocateAddressRangeAuto(
+            owner_, 0xFFFF, ptSize,
+            &pageTableHandle_, &pageTableMeta_);
+        if (kr != kIOReturnSuccess) {
+            ASFW_LOG(Async, "SBP2PageTable: failed to allocate page table: 0x%08x", kr);
+            return false;
+        }
+
+        // Write PTEs into the address space.
+        auto pteSpan = std::span<const uint8_t>(
+            reinterpret_cast<const uint8_t*>(ptes.data()), ptSize);
+        kr = addrMgr_.WriteLocalData(owner_, pageTableHandle_, 0, pteSpan);
+        if (kr != kIOReturnSuccess) {
+            ASFW_LOG(Async, "SBP2PageTable: failed to write page table: 0x%08x", kr);
+            Clear();
+            return false;
+        }
+
+        result_.dataDescriptorHi = Wire::ToBE32(
+            Wire::ComposeBusAddressHi(busNodeID, pageTableMeta_.addressHi));
+        result_.dataDescriptorLo = Wire::ToBE32(pageTableMeta_.addressLo);
+        result_.dataSize = Wire::ToBE16(static_cast<uint16_t>(pteCount_));
+        result_.options = Wire::Options::kPageTableUnrestricted;
+        result_.isDirect = false;
+
+        ASFW_LOG(Async, "SBP2PageTable: built %u PTEs (%u bytes) at %04x:%08x",
+                 pteCount_, ptSize, pageTableMeta_.addressHi, pageTableMeta_.addressLo);
+        return true;
+    }
+
+    void Clear() noexcept {
+        if (pageTableHandle_ != 0) {
+            addrMgr_.DeallocateAddressRange(owner_, pageTableHandle_);
+            pageTableHandle_ = 0;
+        }
+        pageTableMeta_ = {};
+        result_ = {};
+        pteCount_ = 0;
+    }
+
+    [[nodiscard]] const Result& GetResult() const noexcept { return result_; }
+    [[nodiscard]] uint32_t EntryCount() const noexcept { return pteCount_; }
+
+private:
+    AddressSpaceManager& addrMgr_;
+    void* owner_;
+
+    uint64_t pageTableHandle_{0};
+    AddressSpaceManager::AddressRangeMeta pageTableMeta_{};
+    Result result_{};
+    uint32_t pteCount_{0};
+};
+
+} // namespace ASFW::Protocols::SBP2

--- a/ASFWDriver/Protocols/SBP2/SBP2WireFormats.hpp
+++ b/ASFWDriver/Protocols/SBP2/SBP2WireFormats.hpp
@@ -1,0 +1,310 @@
+#pragma once
+
+// SBP-2 (Serial Bus Protocol 2) wire-format definitions.
+// Based on ANSI INCITS 335-1999 (SBP-2).
+// All multi-byte fields are stored in **big-endian** (bus/wire) order.
+// Use ToBusOrder / FromBusOrder from Core/PhyPackets.hpp or std::byteswap for conversion.
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+
+namespace ASFW::Protocols::SBP2::Wire {
+
+// ---------------------------------------------------------------------------
+// Big-endian helpers (inline, constexpr)
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] inline constexpr uint16_t ToBE16(uint16_t v) noexcept {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    return __builtin_bswap16(v);
+#else
+    return v;
+#endif
+}
+
+[[nodiscard]] inline constexpr uint32_t ToBE32(uint32_t v) noexcept {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    return __builtin_bswap32(v);
+#else
+    return v;
+#endif
+}
+
+[[nodiscard]] inline constexpr uint16_t FromBE16(uint16_t v) noexcept { return ToBE16(v); }
+[[nodiscard]] inline constexpr uint32_t FromBE32(uint32_t v) noexcept { return ToBE32(v); }
+
+// ---------------------------------------------------------------------------
+// SBP-2 Management Agent ORB types
+// ---------------------------------------------------------------------------
+
+// Login ORB — written to the management agent address to initiate login.
+// Ref: SBP-2 §5.3.1
+struct LoginORB {
+    // Quadlet 0: password address (hi)
+    uint32_t passwordAddressHi{0};
+    // Quadlet 1: password address (lo)
+    uint32_t passwordAddressLo{0};
+
+    // Quadlet 2: login response address (hi)
+    // [31:16] nodeID of response buffer, [15:0] addressHi
+    uint32_t loginResponseAddressHi{0};
+    // Quadlet 3: login response address (lo)
+    uint32_t loginResponseAddressLo{0};
+
+    // Quadlet 4: options + LUN
+    // [31:16] options (notify/reconnect/exclusive), [15:0] LUN
+    uint16_t options{0};
+    uint16_t lun{0};
+
+    // Quadlet 5: password length + login response length
+    uint16_t passwordLength{0};
+    uint16_t loginResponseLength{0};
+
+    // Quadlet 6: status FIFO address (hi)
+    uint32_t statusFIFOAddressHi{0};
+    // Quadlet 7: status FIFO address (lo)
+    uint32_t statusFIFOAddressLo{0};
+
+    static constexpr uint32_t kSize = 32; // 8 quadlets
+};
+
+static_assert(sizeof(LoginORB) == LoginORB::kSize, "LoginORB must be 32 bytes");
+
+// Login Response — device writes this after successful login.
+// Ref: SBP-2 §5.3.2
+struct LoginResponse {
+    uint16_t length{0};       // [31:16] length
+    uint16_t loginID{0};      // [15:0] login ID assigned by device
+    uint32_t commandBlockAgentAddressHi{0};
+    uint32_t commandBlockAgentAddressLo{0};
+    uint16_t reserved{0};
+    uint16_t reconnectHold{0}; // 2^reconnectHold seconds
+
+    static constexpr uint32_t kSize = 16; // 4 quadlets
+};
+
+static_assert(sizeof(LoginResponse) == LoginResponse::kSize, "LoginResponse must be 16 bytes");
+
+// Reconnect ORB — written to management agent to reconnect after bus reset.
+// Ref: SBP-2 §5.3.4
+struct ReconnectORB {
+    uint32_t reserved1{0};
+    uint32_t reserved2{0};
+    uint32_t reserved3{0};
+    uint32_t reserved4{0};
+
+    // [31:16] options, [15:0] loginID
+    uint16_t options{0};
+    uint16_t loginID{0};
+
+    uint32_t reserved5{0};
+
+    uint32_t statusFIFOAddressHi{0};
+    uint32_t statusFIFOAddressLo{0};
+
+    static constexpr uint32_t kSize = 32; // 8 quadlets
+};
+
+static_assert(sizeof(ReconnectORB) == ReconnectORB::kSize, "ReconnectORB must be 32 bytes");
+
+// Logout ORB — written to management agent to terminate login session.
+// Ref: SBP-2 §5.3.5
+struct LogoutORB {
+    uint32_t reserved1{0};
+    uint32_t reserved2{0};
+    uint32_t reserved3{0};
+    uint32_t reserved4{0};
+
+    // [31:16] options, [15:0] loginID
+    uint16_t options{0};
+    uint16_t loginID{0};
+
+    uint32_t reserved5{0};
+
+    uint32_t statusFIFOAddressHi{0};
+    uint32_t statusFIFOAddressLo{0};
+
+    static constexpr uint32_t kSize = 32; // 8 quadlets
+};
+
+static_assert(sizeof(LogoutORB) == LogoutORB::kSize, "LogoutORB must be 32 bytes");
+
+// ---------------------------------------------------------------------------
+// SBP-2 Normal Command ORB
+// Ref: SBP-2 §5.1.1
+// ---------------------------------------------------------------------------
+
+struct NormalORB {
+    // Quadlet 0-1: next ORB pointer
+    uint32_t nextORBAddressHi{0};  // [31] = 1 => null (no next ORB)
+    uint32_t nextORBAddressLo{0};
+
+    // Quadlet 2-3: data descriptor (page table or direct buffer)
+    uint32_t dataDescriptorHi{0};
+    uint32_t dataDescriptorLo{0};
+
+    // Quadlet 4: options + data size
+    // [15] notify, [13:12] rq_fmt, [11] direction, [9:8] speed,
+    // [7:4] max payload size (log2 in quadlets), [3:2] page table format, [1:0] reserved
+    uint16_t options{0};
+    uint16_t dataSize{0};
+
+    // Command block follows (variable length, up to maxCommandBlockSize)
+    // Access via CommandBlock() helper.
+
+    [[nodiscard]] uint32_t* CommandBlock() noexcept {
+        return reinterpret_cast<uint32_t*>(reinterpret_cast<uint8_t*>(this) + 16);
+    }
+    [[nodiscard]] const uint32_t* CommandBlock() const noexcept {
+        return reinterpret_cast<const uint32_t*>(reinterpret_cast<const uint8_t*>(this) + 16);
+    }
+
+    // Minimum ORB size (no command block)
+    static constexpr uint32_t kHeaderSize = 16;
+    // Null next-ORB indicator (bit 31 set in hi address)
+    static constexpr uint32_t kNextORBNull = 0x80000000u;
+};
+
+// Page Table Entry — maps data buffer for DMA.
+// Ref: SBP-2 §5.1.2
+struct PageTableEntry {
+    uint16_t segmentLength{0};
+    uint16_t segmentBaseAddressHi{0};
+    uint32_t segmentBaseAddressLo{0};
+
+    static constexpr uint32_t kSize = 8;
+};
+
+static_assert(sizeof(PageTableEntry) == PageTableEntry::kSize, "PTE must be 8 bytes");
+
+// ---------------------------------------------------------------------------
+// SBP-2 Status Block
+// Ref: SBP-2 §5.2
+// ---------------------------------------------------------------------------
+
+struct StatusBlock {
+    uint8_t  details{0};     // [7] Src, [6:4] Resp, [3:2] D, [1:0] Len
+    uint8_t  sbpStatus{0};   // SBP-2 specific status code
+    uint16_t orbOffsetHi{0};
+    uint32_t orbOffsetLo{0};
+    uint32_t status[6]{};    // Up to 24 additional bytes of status
+
+    static constexpr uint32_t kMaxSize = 32; // header (8) + max status (24)
+
+    [[nodiscard]] uint8_t Source() const noexcept { return (details >> 7) & 0x1; }
+    [[nodiscard]] uint8_t Response() const noexcept { return (details >> 4) & 0x7; }
+    [[nodiscard]] uint8_t DeadBit() const noexcept { return (details >> 2) & 0x1; }
+    [[nodiscard]] uint8_t Length() const noexcept { return details & 0x3; }
+};
+
+static_assert(sizeof(StatusBlock) == 32, "StatusBlock must be 32 bytes");
+
+// ---------------------------------------------------------------------------
+// SBP-2 Management ORB (Task Management)
+// Ref: SBP-2 §6.2
+// ---------------------------------------------------------------------------
+
+struct TaskManagementORB {
+    uint32_t orbOffsetHi{0};
+    uint32_t orbOffsetLo{0};
+    uint32_t reserved1[2]{};
+    uint16_t options{0};
+    uint16_t loginID{0};
+    uint32_t reserved2{0};
+    uint32_t statusFIFOAddressHi{0};
+    uint32_t statusFIFOAddressLo{0};
+
+    static constexpr uint32_t kSize = 32;
+};
+
+static_assert(sizeof(TaskManagementORB) == TaskManagementORB::kSize);
+
+// ---------------------------------------------------------------------------
+// Management Agent address calculation
+// ---------------------------------------------------------------------------
+
+// Management Agent registers start at 0xF0000000 + (managementOffset << 2).
+// The management offset comes from the Config ROM Unit_Directory entry.
+[[nodiscard]] inline constexpr uint32_t ManagementAgentAddressLo(uint32_t managementOffset) noexcept {
+    return 0xF0000000u + (managementOffset << 2);
+}
+
+// SBP-2 ORBs embed a full 16-bit node ID in bus addresses. ASFW's generic
+// bus-info path may expose only the local 6-bit physical node number, so expand
+// it to the local-bus form (0xffc0 | phyId) before writing ORBs.
+[[nodiscard]] inline constexpr uint16_t NormalizeBusNodeID(uint16_t nodeID) noexcept {
+    if ((nodeID & 0xFFC0u) == 0xFFC0u) {
+        return nodeID;
+    }
+    return static_cast<uint16_t>(0xFFC0u | (nodeID & 0x003Fu));
+}
+
+[[nodiscard]] inline constexpr uint32_t ComposeBusAddressHi(uint16_t nodeID,
+                                                            uint16_t addressHi) noexcept {
+    return (static_cast<uint32_t>(NormalizeBusNodeID(nodeID)) << 16) |
+           static_cast<uint32_t>(addressHi);
+}
+
+// Command Block Agent register offsets (relative to agent base from login response).
+struct CommandBlockAgentOffsets {
+    static constexpr uint32_t kAgentReset               = 0x04; // Fetch agent reset (quadlet write)
+    static constexpr uint32_t kFetchAgent               = 0x08; // ORB pointer write (fetch agent, non-fast-start)
+    static constexpr uint32_t kDoorbell                  = 0x10; // Doorbell ring (quadlet write)
+    static constexpr uint32_t kUnsolicitedStatusEnable   = 0x14; // Re-enable unsolicited status
+};
+
+// ---------------------------------------------------------------------------
+// SBP-2 ORB options bit helpers (big-endian accessors)
+// ---------------------------------------------------------------------------
+
+namespace Options {
+    // Login ORB options
+    static constexpr uint16_t kLoginNotify    = ToBE16(0x8000);
+    static constexpr uint16_t kExclusiveLogin = ToBE16(0x1000);
+
+    // Reconnect ORB options
+    static constexpr uint16_t kReconnectNotify = ToBE16(0x8003); // reconnect + notify
+
+    // Logout ORB options
+    static constexpr uint16_t kLogoutNotify = ToBE16(0x8007); // logout + notify
+
+    // Normal ORB options
+    static constexpr uint16_t kNotify         = ToBE16(0x8000);
+    static constexpr uint16_t kDirectionRead  = ToBE16(0x0800); // data from target
+    static constexpr uint16_t kSpeedShift     = 8;
+    static constexpr uint16_t kSpeed100       = ToBE16(0x0000);
+    static constexpr uint16_t kSpeed200       = ToBE16(0x0100);
+    static constexpr uint16_t kSpeed400       = ToBE16(0x0200);
+    static constexpr uint16_t kSpeed800       = ToBE16(0x0300);
+    static constexpr uint16_t kMaxPayloadShift = 4;
+    static constexpr uint16_t kPageTableUnrestricted = ToBE16(0x0008);
+
+    // Management ORB function codes
+    static constexpr uint32_t kFunctionQueryLogins    = 1;
+    static constexpr uint32_t kFunctionAbortTask      = 0xB;
+    static constexpr uint32_t kFunctionAbortTaskSet   = 0xC;
+    static constexpr uint32_t kFunctionLogicalUnitReset = 0xE;
+    static constexpr uint32_t kFunctionTargetReset    = 0xF;
+}
+
+// SBP-2 status codes (from sbpStatus field)
+namespace SBPStatus {
+    static constexpr uint8_t kNoAdditionalInfo   = 0;
+    static constexpr uint8_t kReqTypeNotSupported = 1;
+    static constexpr uint8_t kSpeedNotSupported   = 2;
+    static constexpr uint8_t kPageSizeNotSupported = 3;
+    static constexpr uint8_t kAccessDenied        = 4;
+    static constexpr uint8_t kResourceUnavailable = 5;
+    static constexpr uint8_t kFunctionRejected    = 6;
+    static constexpr uint8_t kLoginIDNotRecognized = 7;
+    static constexpr uint8_t kDummyORBCompleted   = 8;
+    static constexpr uint8_t kRequestAborted      = 0xB;
+    static constexpr uint8_t kUnspecifiedError    = 0xFF;
+}
+
+// Busy timeout register (CSR address 0xFFFFF0000210)
+static constexpr uint32_t kBusyTimeoutAddressHi = 0x0000FFFFu;
+static constexpr uint32_t kBusyTimeoutAddressLo = 0xF0000210u;
+
+} // namespace ASFW::Protocols::SBP2::Wire

--- a/ASFWDriver/Protocols/SBP2/SCSICommandSet.hpp
+++ b/ASFWDriver/Protocols/SBP2/SCSICommandSet.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "SBP2WireFormats.hpp"
+
+#include <array>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace ASFW::Protocols::SBP2::SCSI {
+
+enum class DataDirection : uint8_t {
+    None = 0,
+    FromTarget = 1,
+    ToTarget = 2,
+};
+
+struct CommandRequest {
+    std::vector<uint8_t> cdb{};
+    DataDirection direction{DataDirection::None};
+    uint32_t transferLength{0};
+    std::vector<uint8_t> outgoingPayload{};
+    uint32_t timeoutMs{2000};
+    bool captureSenseData{false};
+
+    [[nodiscard]] bool HasTransferBuffer() const noexcept {
+        return transferLength > 0;
+    }
+};
+
+struct CommandResult {
+    int transportStatus{0};
+    uint8_t sbpStatus{Wire::SBPStatus::kNoAdditionalInfo};
+    std::vector<uint8_t> payload{};
+    std::vector<uint8_t> senseData{};
+};
+
+inline CommandRequest BuildRawCDBRequest(std::span<const uint8_t> cdb,
+                                        DataDirection direction,
+                                        uint32_t transferLength = 0,
+                                        std::span<const uint8_t> outgoingPayload = {},
+                                        uint32_t timeoutMs = 2000,
+                                        bool captureSenseData = false) {
+    CommandRequest request{};
+    request.cdb.assign(cdb.begin(), cdb.end());
+    request.direction = direction;
+    request.transferLength = transferLength;
+    request.outgoingPayload.assign(outgoingPayload.begin(), outgoingPayload.end());
+    request.timeoutMs = timeoutMs;
+    request.captureSenseData = captureSenseData;
+    return request;
+}
+
+inline CommandRequest BuildInquiryRequest(uint8_t allocationLength = 96) {
+    return BuildRawCDBRequest(
+        std::array<uint8_t, 6>{0x12, 0x00, 0x00, allocationLength, 0x00, 0x00},
+        DataDirection::FromTarget,
+        allocationLength);
+}
+
+inline CommandRequest BuildTestUnitReadyRequest() {
+    return BuildRawCDBRequest(
+        std::array<uint8_t, 6>{0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+        DataDirection::None,
+        0);
+}
+
+inline CommandRequest BuildRequestSenseRequest(uint8_t allocationLength = 18) {
+    return BuildRawCDBRequest(
+        std::array<uint8_t, 6>{0x03, 0x00, 0x00, allocationLength, 0x00, 0x00},
+        DataDirection::FromTarget,
+        allocationLength,
+        {},
+        2000,
+        true);
+}
+
+} // namespace ASFW::Protocols::SBP2::SCSI

--- a/ASFWDriver/Service/DriverContext.cpp
+++ b/ASFWDriver/Service/DriverContext.cpp
@@ -5,6 +5,10 @@
 #include <PCIDriverKit/IOPCIFamilyDefinitions.h>
 
 #include "../Async/AsyncSubsystem.hpp"
+#include "../Async/Interfaces/IFireWireBus.hpp"
+#include "../Async/PacketHelpers.hpp"
+#include "../Async/ResponseCode.hpp"
+#include "../Async/Tx/ResponseSender.hpp"
 #include "../Audio/AudioCoordinator.hpp"
 #include "../Bus/BusManager.hpp"
 #include "../Bus/BusResetCoordinator.hpp"
@@ -21,6 +25,8 @@
 #include "../Hardware/HardwareInterface.hpp"
 #include "../Hardware/InterruptManager.hpp"
 #include "../Logging/Logging.hpp"
+#include "../Protocols/AVC/FCPResponseRouter.hpp"
+#include "../Protocols/SBP2/AddressSpaceManager.hpp"
 #include "../Scheduling/Scheduler.hpp"
 
 void ServiceContext::Reset() {
@@ -39,6 +45,7 @@ void ServiceContext::Reset() {
     deps.interrupts.reset();
     deps.topology.reset();
     deps.fcpResponseRouter.reset(); // Clean up FCP router
+    deps.sbp2AddressSpaceManager.reset();
     deps.avcDiscovery.reset();      // Clean up AV/C discovery
     deps.irmClient.reset();         // Clean up IRM client
     deps.asyncController.reset();
@@ -125,6 +132,121 @@ void DriverWiring::EnsureDeps(ASFWDriver* driver, ::ServiceContext& ctx) {
 
     // AV/C discovery wiring is done after ControllerCore is created so it can
     // depend only on IFireWireBus ports (ControllerCore::Bus()).
+}
+
+void DriverWiring::EnsureSbp2Deps(::ServiceContext& ctx) {
+    auto& d = ctx.deps;
+
+    if (!d.sbp2AddressSpaceManager && d.hardware) {
+        d.sbp2AddressSpaceManager =
+            std::make_shared<ASFW::Protocols::SBP2::AddressSpaceManager>(d.hardware.get());
+        ASFW_LOG(Controller, "[Controller] SBP2 AddressSpaceManager initialized");
+    }
+
+    if (ctx.controller) {
+        ctx.controller->SetSbp2AddressSpaceManager(d.sbp2AddressSpaceManager);
+    }
+
+    if (!d.asyncSubsystem) {
+        return;
+    }
+
+    auto* router = d.asyncSubsystem->GetPacketRouter();
+    if (!router) {
+        return;
+    }
+
+    auto* sbp2Manager = d.sbp2AddressSpaceManager.get();
+    auto* fcpRouter = d.fcpResponseRouter.get();
+    auto* responder = router->GetResponseSender();
+
+    router->RegisterRequestHandler(
+        0x0,
+        [sbp2Manager](const ASFW::Async::ARPacketView& packet) {
+            if (!sbp2Manager || packet.header.size() < 16) {
+                return ASFW::Async::ResponseCode::AddressError;
+            }
+
+            const uint64_t destOffset = ASFW::Async::ExtractDestOffset(packet.header);
+            const auto quadletData = std::span<const uint8_t>(packet.header.data() + 12, 4);
+            return sbp2Manager->ApplyRemoteWrite(destOffset, quadletData);
+        });
+
+    router->RegisterRequestHandler(
+        0x1,
+        [sbp2Manager, fcpRouter](const ASFW::Async::ARPacketView& packet) {
+            if (sbp2Manager && packet.header.size() >= 16 && !packet.payload.empty()) {
+                const uint64_t destOffset = ASFW::Async::ExtractDestOffset(packet.header);
+                const auto sbp2Result =
+                    sbp2Manager->ApplyRemoteWrite(destOffset, packet.payload);
+                if (sbp2Result != ASFW::Async::ResponseCode::AddressError) {
+                    return sbp2Result;
+                }
+            }
+
+            if (fcpRouter) {
+                const ASFW::Protocols::Ports::BlockWriteRequestView request{
+                    .sourceID = packet.sourceID,
+                    .destOffset = ASFW::Async::ExtractDestOffset(packet.header),
+                    .payload = packet.payload,
+                };
+                const auto disposition = fcpRouter->RouteBlockWrite(request);
+                if (disposition == ASFW::Protocols::Ports::BlockWriteDisposition::kAddressError) {
+                    return ASFW::Async::ResponseCode::AddressError;
+                }
+                return ASFW::Async::ResponseCode::Complete;
+            }
+
+            return ASFW::Async::ResponseCode::AddressError;
+        });
+
+    router->RegisterRequestHandler(
+        0x4,
+        [sbp2Manager, responder](const ASFW::Async::ARPacketView& packet) {
+            uint32_t quadlet = 0;
+            auto result = ASFW::Async::ResponseCode::AddressError;
+
+            if (sbp2Manager && packet.header.size() >= 12) {
+                const uint64_t destOffset = ASFW::Async::ExtractDestOffset(packet.header);
+                result = sbp2Manager->ReadQuadlet(destOffset, &quadlet);
+            }
+
+            if (responder) {
+                responder->SendReadQuadletResponse(packet, result, quadlet);
+            }
+            return ASFW::Async::ResponseCode::NoResponse;
+        });
+
+    router->RegisterRequestHandler(
+        0x5,
+        [sbp2Manager, responder](const ASFW::Async::ARPacketView& packet) {
+            auto result = ASFW::Async::ResponseCode::AddressError;
+            ASFW::Protocols::SBP2::AddressSpaceManager::ReadSlice slice{};
+
+            if (sbp2Manager && packet.header.size() >= 16) {
+                const uint64_t destOffset = ASFW::Async::ExtractDestOffset(packet.header);
+                const auto readLength =
+                    static_cast<uint32_t>(ASFW::Async::ExtractDataLength(packet.header));
+                if (readLength > 0) {
+                    result = sbp2Manager->ResolveReadSlice(destOffset, readLength, &slice);
+                } else {
+                    result = ASFW::Async::ResponseCode::DataError;
+                }
+            }
+
+            if (responder) {
+                if (result == ASFW::Async::ResponseCode::Complete) {
+                    responder->SendReadBlockResponse(
+                        packet, result, slice.payloadDeviceAddress, slice.payloadLength);
+                } else {
+                    responder->SendReadBlockResponse(packet, result, 0, 0);
+                }
+            }
+            return ASFW::Async::ResponseCode::NoResponse;
+        });
+
+    ASFW_LOG(Controller,
+             "[Controller] PacketRouter wired for SBP2 address spaces (tCode 0x0/0x1/0x4/0x5)");
 }
 
 kern_return_t DriverWiring::PrepareQueue(ASFWDriver& service, ::ServiceContext& ctx) {

--- a/ASFWDriver/Service/DriverContext.hpp
+++ b/ASFWDriver/Service/DriverContext.hpp
@@ -49,6 +49,7 @@ namespace ASFW::Driver {
 class DriverWiring {
 public:
     static void EnsureDeps(ASFWDriver* driver, ::ServiceContext& ctx);
+    static void EnsureSbp2Deps(::ServiceContext& ctx);
     static kern_return_t PrepareQueue(ASFWDriver& service, ::ServiceContext& ctx);
     static kern_return_t PrepareInterrupts(ASFWDriver& service, IOService* provider, ::ServiceContext& ctx);
     static kern_return_t PrepareWatchdog(ASFWDriver& service, ::ServiceContext& ctx);

--- a/ASFWDriver/UserClient/Core/ASFWDriverUserClient.cpp
+++ b/ASFWDriver/UserClient/Core/ASFWDriverUserClient.cpp
@@ -53,6 +53,11 @@ enum {
     kMethodGetAudioAutoStart = 43,
     kMethodAsyncBlockRead = 44,
     kMethodAsyncBlockWrite = 45,
+    // SBP2 address space management
+    kMethodAllocateAddressRange = 46,
+    kMethodDeallocateAddressRange = 47,
+    kMethodReadIncomingData = 48,
+    kMethodWriteLocalData = 49,
     // TODO(ASFW-IRM): Remove temporary IRM test method after dedicated validation tooling exists.
     kMethodTestIRMAllocation = 26,
     kMethodTestIRMRelease = 27,
@@ -133,7 +138,10 @@ void ASFWDriverUserClient::free() {
         }
 
         if (ivars->runtimeState) {
-            delete static_cast<ASFW::UserClient::UserClientRuntimeState*>(ivars->runtimeState);
+            auto* runtimeState =
+                static_cast<ASFW::UserClient::UserClientRuntimeState*>(ivars->runtimeState);
+            runtimeState->ReleaseOwner(this);
+            delete runtimeState;
             ivars->runtimeState = nullptr;
         }
         IOSafeDeleteNULL(ivars, ASFWDriverUserClient_IVars, 1);
@@ -197,6 +205,7 @@ kern_return_t IMPL(ASFWDriverUserClient, Stop) {
         ivars->driver = nullptr;
     }
     if (auto* runtimeState = ASFW::UserClient::GetRuntimeState(this); runtimeState != nullptr) {
+        runtimeState->ReleaseOwner(this);
         runtimeState->ResetHandlers();
     }
 
@@ -308,6 +317,19 @@ kern_return_t ASFWDriverUserClient::ExternalMethod(uint64_t selector,
 
     case kMethodGetRawFCPCommandResult:
         return runtimeState->AVC().GetRawFCPCommandResult(arguments);
+
+    // SBP2 address space management (46-49)
+    case kMethodAllocateAddressRange:
+        return runtimeState->SBP2().AllocateAddressRange(arguments, this);
+
+    case kMethodDeallocateAddressRange:
+        return runtimeState->SBP2().DeallocateAddressRange(arguments, this);
+
+    case kMethodReadIncomingData:
+        return runtimeState->SBP2().ReadIncomingData(arguments, this);
+
+    case kMethodWriteLocalData:
+        return runtimeState->SBP2().WriteLocalData(arguments, this);
 
     // TransactionHandler methods - CompareSwap (17)
     case kMethodAsyncCompareSwap:

--- a/ASFWDriver/UserClient/Core/ASFWDriverUserClient.iig
+++ b/ASFWDriver/UserClient/Core/ASFWDriverUserClient.iig
@@ -54,6 +54,11 @@ public:
         kMethodGetAudioAutoStart       = 43,
         kMethodAsyncBlockRead          = 44,
         kMethodAsyncBlockWrite         = 45,
+        // SBP2 address space management
+        kMethodAllocateAddressRange    = 46,
+        kMethodDeallocateAddressRange  = 47,
+        kMethodReadIncomingData        = 48,
+        kMethodWriteLocalData          = 49,
         // TODO(ASFW-IRM): Remove temporary IRM test method after dedicated validation tooling exists.
         kMethodTestIRMAllocation       = 26,
         kMethodTestIRMRelease          = 27,

--- a/ASFWDriver/UserClient/Core/UserClientRuntimeState.hpp
+++ b/ASFWDriver/UserClient/Core/UserClientRuntimeState.hpp
@@ -9,6 +9,7 @@
 #include "../Handlers/ControllerCoreAccess.hpp"
 #include "../Handlers/DeviceDiscoveryHandler.hpp"
 #include "../Handlers/IsochHandler.hpp"
+#include "../Handlers/SBP2Handler.hpp"
 #include "../Handlers/StatusHandler.hpp"
 #include "../Handlers/TopologyHandler.hpp"
 #include "../Handlers/TransactionHandler.hpp"
@@ -50,13 +51,16 @@ class UserClientRuntimeState final {
 
         auto* controllerCore = GetControllerCorePtr(driver);
         auto* avcDiscovery = controllerCore ? controllerCore->GetAVCDiscovery() : nullptr;
+        auto* sbp2Manager = controllerCore ? controllerCore->GetSbp2AddressSpaceManager() : nullptr;
         avcHandler_ = std::make_unique<AVCHandler>(avcDiscovery);
         isochHandler_ = std::make_unique<IsochHandler>(driver);
+        sbp2Handler_ = std::make_unique<SBP2Handler>(sbp2Manager);
 
         return HandlersReady();
     }
 
     void ResetHandlers() noexcept {
+        sbp2Handler_.reset();
         isochHandler_.reset();
         avcHandler_.reset();
         deviceDiscoveryHandler_.reset();
@@ -67,11 +71,18 @@ class UserClientRuntimeState final {
         busResetHandler_.reset();
     }
 
+    void ReleaseOwner(void* owner) noexcept {
+        if (owner != nullptr && sbp2Handler_ != nullptr) {
+            sbp2Handler_->ReleaseOwner(owner);
+        }
+    }
+
     [[nodiscard]] bool HandlersReady() const noexcept {
         return busResetHandler_ != nullptr && topologyHandler_ != nullptr &&
                statusHandler_ != nullptr && transactionHandler_ != nullptr &&
                configRomHandler_ != nullptr && deviceDiscoveryHandler_ != nullptr &&
-               avcHandler_ != nullptr && isochHandler_ != nullptr;
+               avcHandler_ != nullptr && isochHandler_ != nullptr &&
+               sbp2Handler_ != nullptr;
     }
 
     [[nodiscard]] TransactionStorage& TransactionResults() noexcept { return transactionStorage_; }
@@ -86,6 +97,7 @@ class UserClientRuntimeState final {
     }
     [[nodiscard]] AVCHandler& AVC() noexcept { return *avcHandler_; }
     [[nodiscard]] IsochHandler& Isoch() noexcept { return *isochHandler_; }
+    [[nodiscard]] SBP2Handler& SBP2() noexcept { return *sbp2Handler_; }
 
   private:
     TransactionStorage transactionStorage_{};
@@ -97,6 +109,7 @@ class UserClientRuntimeState final {
     std::unique_ptr<DeviceDiscoveryHandler> deviceDiscoveryHandler_{};
     std::unique_ptr<AVCHandler> avcHandler_{};
     std::unique_ptr<IsochHandler> isochHandler_{};
+    std::unique_ptr<SBP2Handler> sbp2Handler_{};
 };
 
 template <typename ClientLike>

--- a/ASFWDriver/UserClient/Handlers/SBP2Handler.cpp
+++ b/ASFWDriver/UserClient/Handlers/SBP2Handler.cpp
@@ -1,0 +1,1 @@
+#include "SBP2Handler.hpp"

--- a/ASFWDriver/UserClient/Handlers/SBP2Handler.hpp
+++ b/ASFWDriver/UserClient/Handlers/SBP2Handler.hpp
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <DriverKit/IOUserClient.h>
+#include <DriverKit/OSData.h>
+
+#include "../../Logging/Logging.hpp"
+#include "../../Protocols/SBP2/AddressSpaceManager.hpp"
+
+namespace ASFW::UserClient {
+
+class SBP2Handler {
+public:
+    explicit SBP2Handler(ASFW::Protocols::SBP2::AddressSpaceManager* manager)
+        : manager_(manager) {}
+
+    ~SBP2Handler() = default;
+
+    SBP2Handler(const SBP2Handler&) = delete;
+    SBP2Handler& operator=(const SBP2Handler&) = delete;
+
+    kern_return_t AllocateAddressRange(IOUserClientMethodArguments* args, void* owner) {
+        if (!manager_) {
+            return kIOReturnNotReady;
+        }
+        if (!args || !args->scalarInput || args->scalarInputCount < 3 ||
+            !args->scalarOutput || args->scalarOutputCount < 1) {
+            return kIOReturnBadArgument;
+        }
+
+        const uint16_t addressHi = static_cast<uint16_t>(args->scalarInput[0] & 0xFFFFu);
+        const uint32_t addressLo = static_cast<uint32_t>(args->scalarInput[1] & 0xFFFF'FFFFu);
+        const uint32_t length = static_cast<uint32_t>(args->scalarInput[2] & 0xFFFF'FFFFu);
+
+        uint64_t handle = 0;
+        const kern_return_t kr = manager_->AllocateAddressRange(
+            owner,
+            addressHi,
+            addressLo,
+            length,
+            &handle,
+            nullptr);
+        if (kr != kIOReturnSuccess) {
+            return kr;
+        }
+
+        args->scalarOutput[0] = handle;
+        args->scalarOutputCount = 1;
+        return kIOReturnSuccess;
+    }
+
+    kern_return_t DeallocateAddressRange(IOUserClientMethodArguments* args, void* owner) {
+        if (!manager_) {
+            return kIOReturnNotReady;
+        }
+        if (!args || !args->scalarInput || args->scalarInputCount < 1) {
+            return kIOReturnBadArgument;
+        }
+
+        const uint64_t handle = args->scalarInput[0];
+        return manager_->DeallocateAddressRange(owner, handle);
+    }
+
+    kern_return_t ReadIncomingData(IOUserClientMethodArguments* args, void* owner) {
+        if (!manager_) {
+            return kIOReturnNotReady;
+        }
+        if (!args || !args->scalarInput || args->scalarInputCount < 3) {
+            return kIOReturnBadArgument;
+        }
+
+        const uint64_t handle = args->scalarInput[0];
+        const uint32_t offset = static_cast<uint32_t>(args->scalarInput[1] & 0xFFFF'FFFFu);
+        const uint32_t length = static_cast<uint32_t>(args->scalarInput[2] & 0xFFFF'FFFFu);
+
+        std::vector<uint8_t> data;
+        const kern_return_t kr = manager_->ReadIncomingData(owner, handle, offset, length, &data);
+        if (kr != kIOReturnSuccess) {
+            return kr;
+        }
+
+        OSData* output = OSData::withBytes(data.data(), static_cast<uint32_t>(data.size()));
+        if (!output) {
+            return kIOReturnNoMemory;
+        }
+
+        args->structureOutput = output;
+        args->structureOutputDescriptor = nullptr;
+        return kIOReturnSuccess;
+    }
+
+    kern_return_t WriteLocalData(IOUserClientMethodArguments* args, void* owner) {
+        if (!manager_) {
+            return kIOReturnNotReady;
+        }
+        if (!args || !args->scalarInput || args->scalarInputCount < 3 || !args->structureInput) {
+            return kIOReturnBadArgument;
+        }
+
+        OSData* payloadData = OSDynamicCast(OSData, args->structureInput);
+        if (!payloadData) {
+            return kIOReturnBadArgument;
+        }
+
+        const uint64_t handle = args->scalarInput[0];
+        const uint32_t offset = static_cast<uint32_t>(args->scalarInput[1] & 0xFFFF'FFFFu);
+        const uint32_t length = static_cast<uint32_t>(args->scalarInput[2] & 0xFFFF'FFFFu);
+
+        if (payloadData->getLength() != length) {
+            return kIOReturnBadArgument;
+        }
+
+        const auto* bytes = static_cast<const uint8_t*>(payloadData->getBytesNoCopy());
+        if (!bytes && length > 0) {
+            return kIOReturnBadArgument;
+        }
+
+        return manager_->WriteLocalData(
+            owner,
+            handle,
+            offset,
+            std::span<const uint8_t>(bytes, length));
+    }
+
+    void ReleaseOwner(void* owner) {
+        if (manager_) {
+            manager_->ReleaseOwner(owner);
+        }
+    }
+
+private:
+    ASFW::Protocols::SBP2::AddressSpaceManager* manager_{nullptr};
+};
+
+} // namespace ASFW::UserClient

--- a/tests/AddressSpaceManagerTests.cpp
+++ b/tests/AddressSpaceManagerTests.cpp
@@ -1,0 +1,174 @@
+#include <gtest/gtest.h>
+#include <array>
+
+#include "ASFWDriver/Protocols/SBP2/AddressSpaceManager.hpp"
+
+namespace {
+
+uint64_t ComposeAddress(uint16_t hi, uint32_t lo) {
+    return (static_cast<uint64_t>(hi) << 32) | static_cast<uint64_t>(lo);
+}
+
+} // namespace
+
+TEST(AddressSpaceManagerTests, AllocateWriteReadRoundTrip) {
+    ASFW::Protocols::SBP2::AddressSpaceManager manager(nullptr);
+    ASSERT_TRUE(manager.IsReady());
+
+    uint64_t handle = 0;
+    ASSERT_EQ(kIOReturnSuccess,
+              manager.AllocateAddressRange(reinterpret_cast<void*>(0x1),
+                                           0xFFFF,
+                                           0x0010'0000,
+                                           16,
+                                           &handle,
+                                           nullptr));
+
+    const std::array<uint8_t, 4> payload{0x11, 0x22, 0x33, 0x44};
+    EXPECT_EQ(kIOReturnSuccess,
+              manager.WriteLocalData(reinterpret_cast<void*>(0x1),
+                                     handle,
+                                     4,
+                                     std::span<const uint8_t>(payload.data(), payload.size())));
+
+    std::vector<uint8_t> readback;
+    ASSERT_EQ(kIOReturnSuccess,
+              manager.ReadIncomingData(reinterpret_cast<void*>(0x1),
+                                       handle,
+                                       0,
+                                       16,
+                                       &readback));
+
+    ASSERT_EQ(16u, readback.size());
+    EXPECT_EQ(0x11, readback[4]);
+    EXPECT_EQ(0x22, readback[5]);
+    EXPECT_EQ(0x33, readback[6]);
+    EXPECT_EQ(0x44, readback[7]);
+}
+
+TEST(AddressSpaceManagerTests, ApplyRemoteWriteThenReadIncoming) {
+    ASFW::Protocols::SBP2::AddressSpaceManager manager(nullptr);
+
+    uint64_t handle = 0;
+    ASSERT_EQ(kIOReturnSuccess,
+              manager.AllocateAddressRange(reinterpret_cast<void*>(0x2),
+                                           0xFFFF,
+                                           0x0020'0000,
+                                           12,
+                                           &handle,
+                                           nullptr));
+
+    const uint64_t writeAddress = ComposeAddress(0xFFFF, 0x0020'0000) + 2;
+    const std::array<uint8_t, 3> payload{0xAA, 0xBB, 0xCC};
+    EXPECT_EQ(ASFW::Async::ResponseCode::Complete,
+              manager.ApplyRemoteWrite(
+                  writeAddress,
+                  std::span<const uint8_t>(payload.data(), payload.size())));
+
+    std::vector<uint8_t> readback;
+    ASSERT_EQ(kIOReturnSuccess,
+              manager.ReadIncomingData(reinterpret_cast<void*>(0x2),
+                                       handle,
+                                       0,
+                                       12,
+                                       &readback));
+
+    ASSERT_EQ(12u, readback.size());
+    EXPECT_EQ(0xAA, readback[2]);
+    EXPECT_EQ(0xBB, readback[3]);
+    EXPECT_EQ(0xCC, readback[4]);
+}
+
+TEST(AddressSpaceManagerTests, ApplyRemoteWriteAcceptsQuadletAlignedMisalignedSource) {
+    ASFW::Protocols::SBP2::AddressSpaceManager manager(nullptr);
+
+    uint64_t handle = 0;
+    ASSERT_EQ(kIOReturnSuccess,
+              manager.AllocateAddressRange(reinterpret_cast<void*>(0xD),
+                                           0xFFFF,
+                                           0x0021'0000,
+                                           16,
+                                           &handle,
+                                           nullptr));
+
+    alignas(8) std::array<uint8_t, 20> raw{};
+    raw[4] = 0x10;
+    raw[5] = 0x20;
+    raw[6] = 0x30;
+    raw[7] = 0x40;
+    raw[8] = 0x50;
+    raw[9] = 0x60;
+    raw[10] = 0x70;
+    raw[11] = 0x80;
+
+    const uint64_t writeAddress = ComposeAddress(0xFFFF, 0x0021'0000) + 4;
+    const auto payload = std::span<const uint8_t>(raw.data() + 4, 8);
+    ASSERT_EQ(0u, reinterpret_cast<uintptr_t>(payload.data()) & 0x3u);
+    ASSERT_EQ(4u, reinterpret_cast<uintptr_t>(payload.data()) & 0x7u);
+
+    EXPECT_EQ(ASFW::Async::ResponseCode::Complete,
+              manager.ApplyRemoteWrite(writeAddress, payload));
+
+    std::vector<uint8_t> readback;
+    ASSERT_EQ(kIOReturnSuccess,
+              manager.ReadIncomingData(reinterpret_cast<void*>(0xD),
+                                       handle,
+                                       0,
+                                       16,
+                                       &readback));
+
+    ASSERT_EQ(16u, readback.size());
+    EXPECT_EQ(0x10, readback[4]);
+    EXPECT_EQ(0x20, readback[5]);
+    EXPECT_EQ(0x30, readback[6]);
+    EXPECT_EQ(0x40, readback[7]);
+    EXPECT_EQ(0x50, readback[8]);
+    EXPECT_EQ(0x60, readback[9]);
+    EXPECT_EQ(0x70, readback[10]);
+    EXPECT_EQ(0x80, readback[11]);
+}
+
+TEST(AddressSpaceManagerTests, ReadAfterDeallocateReturnsNotFound) {
+    ASFW::Protocols::SBP2::AddressSpaceManager manager(nullptr);
+
+    uint64_t handle = 0;
+    ASSERT_EQ(kIOReturnSuccess,
+              manager.AllocateAddressRange(reinterpret_cast<void*>(0x3),
+                                           0xFFFF,
+                                           0x0030'0000,
+                                           8,
+                                           &handle,
+                                           nullptr));
+
+    ASSERT_EQ(kIOReturnSuccess,
+              manager.DeallocateAddressRange(reinterpret_cast<void*>(0x3), handle));
+
+    std::vector<uint8_t> readback;
+    EXPECT_EQ(kIOReturnNotFound,
+              manager.ReadIncomingData(reinterpret_cast<void*>(0x3),
+                                       handle,
+                                       0,
+                                       4,
+                                       &readback));
+}
+
+TEST(AddressSpaceManagerTests, OutOfBoundsReadReturnsNoSpace) {
+    ASFW::Protocols::SBP2::AddressSpaceManager manager(nullptr);
+
+    uint64_t handle = 0;
+    ASSERT_EQ(kIOReturnSuccess,
+              manager.AllocateAddressRange(reinterpret_cast<void*>(0x4),
+                                           0xFFFF,
+                                           0x0040'0000,
+                                           8,
+                                           &handle,
+                                           nullptr));
+
+    std::vector<uint8_t> readback;
+    EXPECT_EQ(kIOReturnNoSpace,
+              manager.ReadIncomingData(reinterpret_cast<void*>(0x4),
+                                       handle,
+                                       6,
+                                       4,
+                                       &readback));
+}

--- a/tests/AddressSpaceManagerTests.cpp
+++ b/tests/AddressSpaceManagerTests.cpp
@@ -172,3 +172,103 @@ TEST(AddressSpaceManagerTests, OutOfBoundsReadReturnsNoSpace) {
                                        4,
                                        &readback));
 }
+
+TEST(AddressSpaceManagerTests, AutoAllocationReturnsDistinctAlignedRanges) {
+    ASFW::Protocols::SBP2::AddressSpaceManager manager(nullptr);
+
+    uint64_t firstHandle = 0;
+    ASFW::Protocols::SBP2::AddressSpaceManager::AddressRangeMeta firstMeta{};
+    ASSERT_EQ(kIOReturnSuccess,
+              manager.AllocateAddressRangeAuto(reinterpret_cast<void*>(0x5),
+                                               0xFFFF,
+                                               16,
+                                               &firstHandle,
+                                               &firstMeta));
+
+    uint64_t secondHandle = 0;
+    ASFW::Protocols::SBP2::AddressSpaceManager::AddressRangeMeta secondMeta{};
+    ASSERT_EQ(kIOReturnSuccess,
+              manager.AllocateAddressRangeAuto(reinterpret_cast<void*>(0x6),
+                                               0xFFFF,
+                                               24,
+                                               &secondHandle,
+                                               &secondMeta));
+
+    EXPECT_EQ(0xFFFFu, firstMeta.addressHi);
+    EXPECT_EQ(0xFFFFu, secondMeta.addressHi);
+    EXPECT_EQ(0u, firstMeta.addressLo % 8u);
+    EXPECT_EQ(0u, secondMeta.addressLo % 8u);
+    EXPECT_LT(firstMeta.addressLo, secondMeta.addressLo);
+    EXPECT_LE(firstMeta.addressLo + firstMeta.length, secondMeta.addressLo);
+}
+
+TEST(AddressSpaceManagerTests, AutoAllocationSkipsOccupiedFixedRange) {
+    ASFW::Protocols::SBP2::AddressSpaceManager manager(nullptr);
+
+    uint64_t fixedHandle = 0;
+    ASSERT_EQ(kIOReturnSuccess,
+              manager.AllocateAddressRange(reinterpret_cast<void*>(0x7),
+                                           0xFFFF,
+                                           0x0010'0000,
+                                           16,
+                                           &fixedHandle,
+                                           nullptr));
+
+    uint64_t autoHandle = 0;
+    ASFW::Protocols::SBP2::AddressSpaceManager::AddressRangeMeta autoMeta{};
+    ASSERT_EQ(kIOReturnSuccess,
+              manager.AllocateAddressRangeAuto(reinterpret_cast<void*>(0x8),
+                                               0xFFFF,
+                                               16,
+                                               &autoHandle,
+                                               &autoMeta));
+
+    EXPECT_EQ(0x0010'0010u, autoMeta.addressLo);
+}
+
+TEST(AddressSpaceManagerTests, AutoAllocationReusesFreedGap) {
+    ASFW::Protocols::SBP2::AddressSpaceManager manager(nullptr);
+
+    uint64_t firstHandle = 0;
+    ASFW::Protocols::SBP2::AddressSpaceManager::AddressRangeMeta firstMeta{};
+    ASSERT_EQ(kIOReturnSuccess,
+              manager.AllocateAddressRangeAuto(reinterpret_cast<void*>(0x9),
+                                               0xFFFF,
+                                               16,
+                                               &firstHandle,
+                                               &firstMeta));
+
+    uint64_t secondHandle = 0;
+    ASSERT_EQ(kIOReturnSuccess,
+              manager.AllocateAddressRangeAuto(reinterpret_cast<void*>(0xA),
+                                               0xFFFF,
+                                               16,
+                                               &secondHandle,
+                                               nullptr));
+
+    ASSERT_EQ(kIOReturnSuccess,
+              manager.DeallocateAddressRange(reinterpret_cast<void*>(0x9), firstHandle));
+
+    uint64_t thirdHandle = 0;
+    ASFW::Protocols::SBP2::AddressSpaceManager::AddressRangeMeta thirdMeta{};
+    ASSERT_EQ(kIOReturnSuccess,
+              manager.AllocateAddressRangeAuto(reinterpret_cast<void*>(0xB),
+                                               0xFFFF,
+                                               8,
+                                               &thirdHandle,
+                                               &thirdMeta));
+
+    EXPECT_EQ(firstMeta.addressLo, thirdMeta.addressLo);
+}
+
+TEST(AddressSpaceManagerTests, AutoAllocationRejectsRequestLargerThanWindow) {
+    ASFW::Protocols::SBP2::AddressSpaceManager manager(nullptr);
+
+    uint64_t handle = 0;
+    EXPECT_EQ(kIOReturnNoSpace,
+              manager.AllocateAddressRangeAuto(reinterpret_cast<void*>(0xC),
+                                               0xFFFF,
+                                               0x0FF0'0001u,
+                                               &handle,
+                                               nullptr));
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1458,3 +1458,25 @@ target_compile_definitions(AddressSpaceManagerTests
 target_include_directories(AddressSpaceManagerTests PRIVATE ${ASFW_COMMON_INCLUDES})
 
 gtest_discover_tests(AddressSpaceManagerTests)
+
+add_executable(SBP2ORBTests
+    "${ASFW_TESTS_DIR}/SBP2ORBTests.cpp"
+    "${ASFW_DRIVER_DIR}/Protocols/SBP2/SBP2CommandORB.cpp"
+    "${ASFW_DRIVER_DIR}/Protocols/SBP2/SBP2ManagementORB.cpp"
+    "${ASFW_TESTS_DIR}/HardwareInterfaceStub.cpp"
+    "${ASFW_TESTS_DIR}/LoggingStubs.cpp"
+)
+
+target_link_libraries(SBP2ORBTests
+    PRIVATE
+        GTest::gtest_main
+)
+
+target_compile_definitions(SBP2ORBTests
+    PRIVATE
+        ASFW_HOST_TEST
+)
+
+target_include_directories(SBP2ORBTests PRIVATE ${ASFW_COMMON_INCLUDES})
+
+gtest_discover_tests(SBP2ORBTests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1439,3 +1439,22 @@ target_compile_definitions(ROMScanNodeStateMachineTests
 target_include_directories(ROMScanNodeStateMachineTests PRIVATE ${ASFW_COMMON_INCLUDES})
 
 gtest_discover_tests(ROMScanNodeStateMachineTests)
+
+add_executable(AddressSpaceManagerTests
+    "${ASFW_TESTS_DIR}/AddressSpaceManagerTests.cpp"
+    "${ASFW_TESTS_DIR}/HardwareInterfaceStub.cpp"
+)
+
+target_link_libraries(AddressSpaceManagerTests
+    PRIVATE
+        GTest::gtest_main
+)
+
+target_compile_definitions(AddressSpaceManagerTests
+    PRIVATE
+        ASFW_HOST_TEST
+)
+
+target_include_directories(AddressSpaceManagerTests PRIVATE ${ASFW_COMMON_INCLUDES})
+
+gtest_discover_tests(AddressSpaceManagerTests)

--- a/tests/ConfigROMBIBParseTests.cpp
+++ b/tests/ConfigROMBIBParseTests.cpp
@@ -72,3 +72,36 @@ TEST(ConfigROMBIBParseTests, CRC_Mismatch_IsWarning_NotFailure) {
     EXPECT_EQ(bibRes->computed.value(), 0xEABFu);
     EXPECT_EQ(bibRes->bib.crc, 0xEABEu);
 }
+
+TEST(ConfigROMParserTests, SBP2ManagementAgentOffsetUsesCombinedCSRKey54) {
+    const std::array<uint32_t, 5> unitDirectoryWire = {
+        WireU32FromBENumeric(0x00040000u),
+        WireU32FromBENumeric(0x1200609Eu),
+        WireU32FromBENumeric(0x13010483u),
+        WireU32FromBENumeric(0x5400C000u),
+        WireU32FromBENumeric(0x14060000u),
+    };
+
+    auto entries = ASFW::Discovery::ConfigROMParser::ParseRootDirectory(
+        std::span{unitDirectoryWire},
+        static_cast<uint32_t>(unitDirectoryWire.size()));
+    ASSERT_TRUE(entries.has_value());
+
+    bool foundManagementAgent = false;
+    bool foundLun = false;
+    for (const auto& entry : *entries) {
+        if (entry.key == ASFW::Discovery::CfgKey::Management_Agent_Offset) {
+            foundManagementAgent = true;
+            EXPECT_EQ(entry.value, 0x00C000u);
+            EXPECT_EQ(entry.entryType, 1u);
+        }
+        if (entry.key == ASFW::Discovery::CfgKey::Logical_Unit_Number) {
+            foundLun = true;
+            EXPECT_EQ(entry.value, 0x060000u);
+            EXPECT_EQ(entry.entryType, 0u);
+        }
+    }
+
+    EXPECT_TRUE(foundManagementAgent);
+    EXPECT_TRUE(foundLun);
+}

--- a/tests/ConfigROMBuilderTests.cpp
+++ b/tests/ConfigROMBuilderTests.cpp
@@ -274,9 +274,16 @@ TEST_P(ConfigROMReferenceCrcTests, ReferenceDataHasValidCrcs) {
     const auto& testCase = GetParam();
     SCOPED_TRACE(testCase.description);
 
+    constexpr std::string_view kDeviceAttributeReferencePath =
+        "FirWireDriver/firewire/device-attribute-test.c";
+    if (!ASFW::Tests::RepoReferenceFileExists(kDeviceAttributeReferencePath)) {
+        GTEST_SKIP() << "Missing external Linux reference data: "
+                     << kDeviceAttributeReferencePath;
+    }
+
     std::vector<uint32_t> words;
     std::string errorMessage;
-    ASSERT_TRUE(ASFW::Tests::LoadHexArrayFromRepoFile("FirWireDriver/firewire/device-attribute-test.c",
+    ASSERT_TRUE(ASFW::Tests::LoadHexArrayFromRepoFile(kDeviceAttributeReferencePath,
                                                       testCase.arrayName,
                                                       words,
                                                       &errorMessage))

--- a/tests/ResponseSenderStub.cpp
+++ b/tests/ResponseSenderStub.cpp
@@ -17,4 +17,38 @@ void ResponseSender::SendWriteResponse(const ARPacketView& request, ResponseCode
     (void)rcode;
 }
 
+void ResponseSender::SendReadQuadletResponse(const ARPacketView& request,
+                                             ResponseCode rcode,
+                                             uint32_t quadletData) noexcept {
+    (void)request;
+    (void)rcode;
+    (void)quadletData;
+}
+
+void ResponseSender::SendReadBlockResponse(const ARPacketView& request,
+                                           ResponseCode rcode,
+                                           uint64_t payloadDeviceAddress,
+                                           uint32_t payloadLength) noexcept {
+    (void)request;
+    (void)rcode;
+    (void)payloadDeviceAddress;
+    (void)payloadLength;
+}
+
+void ResponseSender::SendResponse(const ARPacketView& request,
+                                  ResponseCode rcode,
+                                  uint8_t responseTCode,
+                                  const uint32_t* header,
+                                  std::size_t headerBytes,
+                                  uint64_t payloadDeviceAddress,
+                                  std::size_t payloadLength) noexcept {
+    (void)request;
+    (void)rcode;
+    (void)responseTCode;
+    (void)header;
+    (void)headerBytes;
+    (void)payloadDeviceAddress;
+    (void)payloadLength;
+}
+
 } // namespace ASFW::Async

--- a/tests/SBP2ORBTests.cpp
+++ b/tests/SBP2ORBTests.cpp
@@ -1,0 +1,296 @@
+#include <gtest/gtest.h>
+
+#include "ASFWDriver/Protocols/SBP2/SBP2CommandORB.hpp"
+#include "ASFWDriver/Protocols/SBP2/SBP2ManagementORB.hpp"
+#include "ASFWDriver/Protocols/SBP2/SBP2PageTable.hpp"
+#include "ASFWDriver/Protocols/SBP2/SBP2WireFormats.hpp"
+#include "ASFWDriver/Testing/HostDriverKitStubs.hpp"
+#include "tests/mocks/DeferredFireWireBus.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+namespace {
+
+using ASFW::Protocols::SBP2::AddressSpaceManager;
+using ASFW::Protocols::SBP2::SBP2CommandORB;
+using ASFW::Protocols::SBP2::SBP2ManagementORB;
+using ASFW::Protocols::SBP2::SBP2PageTable;
+using ASFW::Protocols::SBP2::Wire::FromBE16;
+using ASFW::Protocols::SBP2::Wire::FromBE32;
+using ASFW::Protocols::SBP2::Wire::ManagementAgentAddressLo;
+using ASFW::Protocols::SBP2::Wire::NormalizeBusNodeID;
+using ASFW::Protocols::SBP2::Wire::StatusBlock;
+using ASFW::Protocols::SBP2::Wire::ToBE16;
+using ASFW::Protocols::SBP2::Wire::ToBE32;
+namespace SBPStatus = ASFW::Protocols::SBP2::Wire::SBPStatus;
+
+uint64_t ComposeAddress(uint16_t hi, uint32_t lo) {
+    return (static_cast<uint64_t>(hi) << 32) | lo;
+}
+
+uint64_t DecodeOrbAddressFromPayload(std::span<const uint8_t> payload) {
+    const uint16_t addressHi =
+        static_cast<uint16_t>((static_cast<uint16_t>(payload[2]) << 8) | payload[3]);
+    const uint32_t addressLo =
+        (static_cast<uint32_t>(payload[4]) << 24) |
+        (static_cast<uint32_t>(payload[5]) << 16) |
+        (static_cast<uint32_t>(payload[6]) << 8) |
+        static_cast<uint32_t>(payload[7]);
+    return ComposeAddress(addressHi, addressLo);
+}
+
+uint32_t ReadQuadlet(AddressSpaceManager& manager, uint64_t address) {
+    uint32_t value = 0;
+    EXPECT_EQ(ASFW::Async::ResponseCode::Complete, manager.ReadQuadlet(address, &value));
+    return value;
+}
+
+uint64_t ReadStatusAddressFromManagementORB(AddressSpaceManager& manager, uint64_t orbAddress) {
+    const uint32_t hi = FromBE32(ReadQuadlet(
+        manager,
+        orbAddress + offsetof(ASFW::Protocols::SBP2::Wire::TaskManagementORB, statusFIFOAddressHi)));
+    const uint32_t lo = FromBE32(ReadQuadlet(
+        manager,
+        orbAddress + offsetof(ASFW::Protocols::SBP2::Wire::TaskManagementORB, statusFIFOAddressLo)));
+    return ComposeAddress(static_cast<uint16_t>(hi & 0xFFFFu), lo);
+}
+
+class ORBTimerRig {
+public:
+    ORBTimerRig() {
+        queue.SetManualDispatchForTesting(true);
+        ASFW::Testing::SetHostMonotonicClockForTesting([this]() { return nowNs; });
+
+        bus.SetGeneration(ASFW::FW::Generation{1});
+        bus.SetLocalNodeID(ASFW::FW::NodeId{0x21});
+        bus.SetDefaultSpeed(ASFW::FW::FwSpeed::S400);
+    }
+
+    ~ORBTimerRig() {
+        ASFW::Testing::ResetHostMonotonicClockForTesting();
+    }
+
+    void DrainReady() {
+        while (queue.DrainReadyForTesting() > 0U) {
+        }
+    }
+
+    void AdvanceMs(uint64_t milliseconds) {
+        nowNs += milliseconds * 1'000'000ULL;
+        DrainReady();
+    }
+
+    ASFW::Async::Testing::DeferredFireWireBus bus;
+    AddressSpaceManager addressManager{nullptr};
+    IODispatchQueue queue;
+    uint64_t nowNs{0};
+};
+
+TEST(SBP2ORBTests, CommandORBTimerFiresOnHostQueue) {
+    ORBTimerRig rig;
+
+    SBP2CommandORB orb(rig.addressManager, reinterpret_cast<void*>(0x1), 16);
+    int completionStatus = 99;
+    orb.SetTimeout(5);
+    orb.SetCompletionCallback([&completionStatus](int status, uint8_t) { completionStatus = status; });
+
+    orb.StartTimer(&rig.queue);
+    rig.AdvanceMs(5);
+
+    EXPECT_EQ(-1, completionStatus);
+}
+
+TEST(SBP2ORBTests, CommandORBCancelSuppressesPendingTimeout) {
+    ORBTimerRig rig;
+
+    SBP2CommandORB orb(rig.addressManager, reinterpret_cast<void*>(0x2), 16);
+    int completionCount = 0;
+    orb.SetTimeout(5);
+    orb.SetCompletionCallback([&completionCount](int, uint8_t) { ++completionCount; });
+
+    orb.StartTimer(&rig.queue);
+    orb.CancelTimer();
+    rig.AdvanceMs(5);
+
+    EXPECT_EQ(0, completionCount);
+}
+
+TEST(SBP2ORBTests, CommandORBDestructionInvalidatesPendingTimeout) {
+    ORBTimerRig rig;
+
+    int completionCount = 0;
+    {
+        auto orb = std::make_unique<SBP2CommandORB>(
+            rig.addressManager, reinterpret_cast<void*>(0x3), 16);
+        orb->SetTimeout(5);
+        orb->SetCompletionCallback([&completionCount](int, uint8_t) { ++completionCount; });
+        orb->StartTimer(&rig.queue);
+    }
+
+    rig.AdvanceMs(5);
+    EXPECT_EQ(0, completionCount);
+}
+
+TEST(SBP2ORBTests, PageTableUsesDirectDescriptorForSingleAlignedSegment) {
+    ORBTimerRig rig;
+
+    SBP2PageTable pageTable(rig.addressManager, reinterpret_cast<void*>(0x40));
+    const std::array<SBP2PageTable::Segment, 1> segments{{
+        {.address = 0x0001'2345'6000ULL, .length = 512},
+    }};
+
+    ASSERT_TRUE(pageTable.Build(segments, 0x21));
+
+    const auto& result = pageTable.GetResult();
+    EXPECT_TRUE(result.isDirect);
+    EXPECT_EQ(1u, pageTable.EntryCount());
+    EXPECT_EQ(0x0001u, FromBE32(result.dataDescriptorHi) & 0xFFFFu);
+    EXPECT_EQ(0x2345'6000u, FromBE32(result.dataDescriptorLo));
+    EXPECT_EQ(512u, FromBE16(result.dataSize));
+    EXPECT_EQ(0u, result.options);
+}
+
+TEST(SBP2ORBTests, PageTableSplitsSegmentsIntoPublishedEntries) {
+    ORBTimerRig rig;
+
+    SBP2PageTable pageTable(rig.addressManager, reinterpret_cast<void*>(0x41));
+    const std::array<SBP2PageTable::Segment, 1> segments{{
+        {.address = 0x0001'0000'1000ULL, .length = 0x30},
+    }};
+
+    ASSERT_TRUE(pageTable.Build(segments, 0x21, 0x10));
+
+    const auto& result = pageTable.GetResult();
+    ASSERT_FALSE(result.isDirect);
+    ASSERT_EQ(3u, pageTable.EntryCount());
+    EXPECT_EQ(3u, FromBE16(result.dataSize));
+    EXPECT_EQ(ASFW::Protocols::SBP2::Wire::Options::kPageTableUnrestricted,
+              result.options);
+
+    const uint32_t descriptorHi = FromBE32(result.dataDescriptorHi);
+    const uint16_t expectedNode = NormalizeBusNodeID(0x21);
+    EXPECT_EQ(expectedNode, static_cast<uint16_t>(descriptorHi >> 16));
+    EXPECT_EQ(0xFFFFu, descriptorHi & 0xFFFFu);
+
+    const uint64_t tableAddress =
+        ComposeAddress(static_cast<uint16_t>(descriptorHi & 0xFFFFu),
+                       FromBE32(result.dataDescriptorLo));
+    const uint32_t firstEntryHeader = FromBE32(ReadQuadlet(rig.addressManager, tableAddress));
+    const uint32_t firstEntryLo = FromBE32(ReadQuadlet(rig.addressManager, tableAddress + 4));
+
+    EXPECT_EQ(0x0010u, firstEntryHeader >> 16);
+    EXPECT_EQ(0x0001u, firstEntryHeader & 0xFFFFu);
+    EXPECT_EQ(0x0000'1000u, firstEntryLo);
+}
+
+TEST(SBP2ORBTests, ManagementORBStatusWriteCancelsTimeout) {
+    ORBTimerRig rig;
+
+    SBP2ManagementORB orb(rig.bus, rig.bus, rig.addressManager, reinterpret_cast<void*>(0x4));
+    orb.SetFunction(SBP2ManagementORB::Function::AbortTaskSet);
+    orb.SetLoginID(0x12);
+    orb.SetManagementAgentOffset(0x80);
+    orb.SetTargetNode(1, 0x3F);
+    orb.SetTimeout(5);
+    orb.SetWorkQueue(&rig.queue);
+
+    int completionStatus = 99;
+    orb.SetCompletionCallback([&completionStatus](int status) { completionStatus = status; });
+
+    ASSERT_TRUE(orb.Execute());
+    ASSERT_EQ(1u, rig.bus.PendingWriteCount());
+
+    const auto& write = rig.bus.WriteAt(0);
+    ASSERT_EQ(ManagementAgentAddressLo(0x80), write.address.addressLo);
+    const uint64_t orbAddress = DecodeOrbAddressFromPayload(write.data);
+
+    ASSERT_TRUE(rig.bus.CompleteNextWrite(ASFW::Async::AsyncStatus::kSuccess));
+    rig.DrainReady();
+
+    StatusBlock status{};
+    status.details = 0;
+    status.sbpStatus = SBPStatus::kNoAdditionalInfo;
+    rig.addressManager.ApplyRemoteWrite(
+        ReadStatusAddressFromManagementORB(rig.addressManager, orbAddress),
+        std::span<const uint8_t>{reinterpret_cast<const uint8_t*>(&status), sizeof(status)});
+
+    rig.AdvanceMs(5);
+    EXPECT_EQ(0, completionStatus);
+}
+
+TEST(SBP2ORBTests, ManagementORBUsesFullBusNodeIdInEmbeddedAddresses) {
+    ORBTimerRig rig;
+
+    SBP2ManagementORB orb(rig.bus, rig.bus, rig.addressManager, reinterpret_cast<void*>(0x6));
+    orb.SetFunction(SBP2ManagementORB::Function::AbortTaskSet);
+    orb.SetLoginID(0x12);
+    orb.SetManagementAgentOffset(0x80);
+    orb.SetTargetNode(1, 0x3F);
+
+    ASSERT_TRUE(orb.Execute());
+    ASSERT_EQ(1u, rig.bus.PendingWriteCount());
+
+    const auto& write = rig.bus.WriteAt(0);
+    const uint16_t payloadNode =
+        static_cast<uint16_t>((static_cast<uint16_t>(write.data[0]) << 8) | write.data[1]);
+    const uint64_t orbAddress = DecodeOrbAddressFromPayload(write.data);
+    const uint32_t statusHi = FromBE32(ReadQuadlet(
+        rig.addressManager,
+        orbAddress + offsetof(ASFW::Protocols::SBP2::Wire::TaskManagementORB, statusFIFOAddressHi)));
+
+    const uint16_t expectedNode = NormalizeBusNodeID(0x21);
+    EXPECT_EQ(expectedNode, payloadNode);
+    EXPECT_EQ((static_cast<uint32_t>(expectedNode) << 16) | 0xFFFFu, statusHi);
+}
+
+TEST(SBP2ORBTests, CommandORBDirectDescriptorUsesFullBusNodeId) {
+    ORBTimerRig rig;
+
+    SBP2CommandORB orb(rig.addressManager, reinterpret_cast<void*>(0x7), 16);
+    ASFW::Protocols::SBP2::SBP2PageTable::Result descriptor{};
+    descriptor.dataDescriptorHi = ToBE32(0x0000FFFFu);
+    descriptor.dataDescriptorLo = ToBE32(0x00112200u);
+    descriptor.dataSize = ToBE16(512);
+    descriptor.isDirect = true;
+
+    orb.SetDataDescriptor(descriptor);
+    orb.PrepareForExecution(0x21, ASFW::FW::FwSpeed::S400, 6);
+
+    const auto orbAddress = orb.GetORBAddress();
+    const uint64_t packedAddress = ComposeAddress(orbAddress.addressHi, orbAddress.addressLo);
+    const uint32_t dataDescriptorHi = FromBE32(ReadQuadlet(
+        rig.addressManager,
+        packedAddress + offsetof(ASFW::Protocols::SBP2::Wire::NormalORB, dataDescriptorHi)));
+
+    const uint16_t expectedNode = NormalizeBusNodeID(0x21);
+    EXPECT_EQ((static_cast<uint32_t>(expectedNode) << 16) | 0xFFFFu, dataDescriptorHi);
+}
+
+TEST(SBP2ORBTests, ManagementORBDestructionInvalidatesPendingTimeout) {
+    ORBTimerRig rig;
+
+    int completionCount = 0;
+    {
+        auto orb = std::make_unique<SBP2ManagementORB>(
+            rig.bus, rig.bus, rig.addressManager, reinterpret_cast<void*>(0x5));
+        orb->SetFunction(SBP2ManagementORB::Function::AbortTaskSet);
+        orb->SetLoginID(0x34);
+        orb->SetManagementAgentOffset(0x81);
+        orb->SetTargetNode(1, 0x3F);
+        orb->SetTimeout(5);
+        orb->SetWorkQueue(&rig.queue);
+        orb->SetCompletionCallback([&completionCount](int) { ++completionCount; });
+
+        ASSERT_TRUE(orb->Execute());
+        ASSERT_TRUE(rig.bus.CompleteNextWrite(ASFW::Async::AsyncStatus::kSuccess));
+        rig.DrainReady();
+    }
+
+    rig.AdvanceMs(5);
+    EXPECT_EQ(0, completionCount);
+}
+
+} // namespace

--- a/tests/SelfIDSequenceTests.cpp
+++ b/tests/SelfIDSequenceTests.cpp
@@ -14,21 +14,28 @@ using ASFW::Driver::SelfIDSequenceEnumerator;
 
 namespace {
 
-std::vector<uint32_t> LoadSequenceArray(std::string_view arrayName) {
-    std::vector<uint32_t> words;
+constexpr std::string_view kSelfIDReferencePath =
+    "FirWireDriver/firewire/self-id-sequence-helper-test.c";
+
+bool LoadSequenceArray(std::string_view arrayName, std::vector<uint32_t>& words) {
+    if (!ASFW::Tests::RepoReferenceFileExists(kSelfIDReferencePath)) {
+        return false;
+    }
+
     std::string error;
     bool ok = ASFW::Tests::LoadHexArrayFromRepoFile(
-        "FirWireDriver/firewire/self-id-sequence-helper-test.c", arrayName, words, &error);
-    if (!ok) {
-        ADD_FAILURE() << "Failed to load array '" << arrayName << "': " << error;
-    }
-    return words;
+        kSelfIDReferencePath, arrayName, words, &error);
+    EXPECT_TRUE(ok) << "Failed to load array '" << arrayName << "': " << error;
+    return ok;
 }
 
 } // namespace
 
 TEST(SelfIDSequenceEnumeratorTests, EnumeratesValidSequencesFromLinuxFixtures) {
-    auto valid = LoadSequenceArray("valid_sequences");
+    std::vector<uint32_t> valid;
+    if (!LoadSequenceArray("valid_sequences", valid)) {
+        GTEST_SKIP() << "Missing external Linux reference data: " << kSelfIDReferencePath;
+    }
     ASSERT_FALSE(valid.empty());
 
     SelfIDSequenceEnumerator enumerator;
@@ -54,7 +61,10 @@ TEST(SelfIDSequenceEnumeratorTests, EnumeratesValidSequencesFromLinuxFixtures) {
 }
 
 TEST(SelfIDSequenceEnumeratorTests, FlagsInvalidSequenceFromLinuxFixtures) {
-    auto invalid = LoadSequenceArray("invalid_sequences");
+    std::vector<uint32_t> invalid;
+    if (!LoadSequenceArray("invalid_sequences", invalid)) {
+        GTEST_SKIP() << "Missing external Linux reference data: " << kSelfIDReferencePath;
+    }
     ASSERT_FALSE(invalid.empty());
 
     SelfIDSequenceEnumerator enumerator;
@@ -66,7 +76,10 @@ TEST(SelfIDSequenceEnumeratorTests, FlagsInvalidSequenceFromLinuxFixtures) {
 }
 
 TEST(SelfIDSequenceEnumeratorTests, RecognisesChainedPacketsAndExtendedQuads) {
-    auto valid = LoadSequenceArray("valid_sequences");
+    std::vector<uint32_t> valid;
+    if (!LoadSequenceArray("valid_sequences", valid)) {
+        GTEST_SKIP() << "Missing external Linux reference data: " << kSelfIDReferencePath;
+    }
     ASSERT_GE(valid.size(), static_cast<size_t>(5));
 
     // Sequence starting at index 1 should contain two quadlets with more-bit chaining

--- a/tests/TestDataUtils.hpp
+++ b/tests/TestDataUtils.hpp
@@ -99,4 +99,8 @@ inline bool LoadHexArrayFromRepoFile(std::string_view relativePath,
     return LoadHexArrayFromCFile(absolutePath, arrayName, outWords, errorMessage);
 }
 
+inline bool RepoReferenceFileExists(std::string_view relativePath) {
+    return std::filesystem::exists(ResolveRepoRoot() / std::filesystem::path(relativePath));
+}
+
 } // namespace ASFW::Tests

--- a/tests/mocks/DeferredFireWireBus.hpp
+++ b/tests/mocks/DeferredFireWireBus.hpp
@@ -1,0 +1,172 @@
+#pragma once
+
+#include "../../ASFWDriver/Async/Interfaces/IFireWireBus.hpp"
+
+#include <algorithm>
+#include <array>
+#include <deque>
+#include <utility>
+#include <vector>
+
+namespace ASFW::Async::Testing {
+
+class DeferredFireWireBus : public IFireWireBus {
+public:
+    struct WriteSummary {
+        AsyncHandle handle{};
+        FW::Generation generation{0};
+        FW::NodeId nodeId{0};
+        FWAddress address{};
+        FW::FwSpeed speed{FW::FwSpeed::S100};
+        std::vector<uint8_t> data;
+    };
+
+    DeferredFireWireBus() = default;
+
+    void SetGeneration(FW::Generation generation) noexcept { generation_ = generation; }
+    void SetLocalNodeID(FW::NodeId nodeId) noexcept { localNodeId_ = nodeId; }
+    void SetDefaultSpeed(FW::FwSpeed speed) noexcept { defaultSpeed_ = speed; }
+
+    [[nodiscard]] size_t WriteCount() const noexcept { return writeHistory_.size(); }
+    [[nodiscard]] const WriteSummary& WriteAt(size_t index) const noexcept { return writeHistory_.at(index); }
+    [[nodiscard]] size_t PendingWriteCount() const noexcept { return pendingWrites_.size(); }
+
+    bool CompleteNextWrite(AsyncStatus status, std::span<const uint8_t> payload = {}) {
+        if (pendingWrites_.empty()) {
+            return false;
+        }
+
+        PendingWrite pending = std::move(pendingWrites_.front());
+        pendingWrites_.pop_front();
+        if (pending.callback) {
+            pending.callback(status, payload);
+        }
+        return true;
+    }
+
+    bool CompleteWrite(AsyncHandle handle,
+                       AsyncStatus status,
+                       std::span<const uint8_t> payload = {}) {
+        const auto it = std::find_if(
+            pendingWrites_.begin(), pendingWrites_.end(),
+            [handle](const PendingWrite& pending) {
+                return pending.summary.handle.value == handle.value;
+            });
+        if (it == pendingWrites_.end()) {
+            return false;
+        }
+
+        auto callback = std::move(it->callback);
+        pendingWrites_.erase(it);
+        if (callback) {
+            callback(status, payload);
+        }
+        return true;
+    }
+
+    AsyncHandle ReadBlock(FW::Generation generation,
+                          FW::NodeId nodeId,
+                          FWAddress address,
+                          uint32_t length,
+                          FW::FwSpeed speed,
+                          InterfaceCompletionCallback callback) override {
+        const AsyncHandle handle = NextHandle();
+        callback(AsyncStatus::kTimeout, std::span<const uint8_t>{});
+        return handle;
+    }
+
+    AsyncHandle WriteBlock(FW::Generation generation,
+                           FW::NodeId nodeId,
+                           FWAddress address,
+                           std::span<const uint8_t> data,
+                           FW::FwSpeed speed,
+                           InterfaceCompletionCallback callback) override {
+        const AsyncHandle handle = NextHandle();
+
+        WriteSummary summary{};
+        summary.handle = handle;
+        summary.generation = generation;
+        summary.nodeId = nodeId;
+        summary.address = address;
+        summary.speed = speed;
+        summary.data.assign(data.begin(), data.end());
+        writeHistory_.push_back(summary);
+
+        pendingWrites_.push_back(PendingWrite{
+            .summary = summary,
+            .callback = std::move(callback),
+        });
+        return handle;
+    }
+
+    AsyncHandle Lock(FW::Generation generation,
+                     FW::NodeId nodeId,
+                     FWAddress address,
+                     FW::LockOp lockOp,
+                     std::span<const uint8_t> operand,
+                     uint32_t responseLength,
+                     FW::FwSpeed speed,
+                     InterfaceCompletionCallback callback) override {
+        const AsyncHandle handle = NextHandle();
+        std::array<uint8_t, 4> zeroes{};
+        callback(AsyncStatus::kSuccess,
+                 std::span<const uint8_t>{zeroes.data(),
+                                          std::min<size_t>(zeroes.size(), responseLength)});
+        return handle;
+    }
+
+    bool Cancel(AsyncHandle handle) override {
+        const auto it = std::find_if(
+            pendingWrites_.begin(), pendingWrites_.end(),
+            [handle](const PendingWrite& pending) {
+                return pending.summary.handle.value == handle.value;
+            });
+        if (it == pendingWrites_.end()) {
+            return false;
+        }
+
+        auto callback = std::move(it->callback);
+        pendingWrites_.erase(it);
+        if (callback) {
+            callback(AsyncStatus::kAborted, std::span<const uint8_t>{});
+        }
+        return true;
+    }
+
+    FW::FwSpeed GetSpeed(FW::NodeId nodeId) const override {
+        return defaultSpeed_;
+    }
+
+    uint32_t HopCount(FW::NodeId nodeA, FW::NodeId nodeB) const override {
+        return 1;
+    }
+
+    FW::Generation GetGeneration() const override {
+        return generation_;
+    }
+
+    FW::NodeId GetLocalNodeID() const override {
+        return localNodeId_;
+    }
+
+private:
+    struct PendingWrite {
+        WriteSummary summary;
+        InterfaceCompletionCallback callback;
+    };
+
+    AsyncHandle NextHandle() noexcept {
+        const AsyncHandle handle = nextHandle_;
+        nextHandle_ = AsyncHandle{nextHandle_.value + 1};
+        return handle;
+    }
+
+    FW::Generation generation_{1};
+    FW::NodeId localNodeId_{0};
+    FW::FwSpeed defaultSpeed_{FW::FwSpeed::S400};
+    AsyncHandle nextHandle_{1};
+    std::vector<WriteSummary> writeHistory_;
+    std::deque<PendingWrite> pendingWrites_;
+};
+
+} // namespace ASFW::Async::Testing


### PR DESCRIPTION
## Scope
This PR combines the two stacked gly11 PRs into one upstream PR against `mrmidi/main`:

- gly11/ASFireWire#2: `feat(sbp2): add discovery and address-space plumbing`
- gly11/ASFireWire#3: `feat(sbp2): add ORB wire primitives`

PR #3 was built on top of PR #2, so opening the ORB branch directly against upstream `main` includes both layers.

## Summary
- add SBP-2 discovery plumbing needed to detect units and management agent offsets
- add SBP-2 ORB wire-format building blocks for later session and transport work
- add address-space auto-allocation and remote-write callbacks for ORB/status/page-table publishing
- add host-side tests for ORB timers, published page tables, full bus node ID encoding, and related plumbing

## Includes
- prerequisite discovery plumbing from `feat/sbp2-discovery-plumbing`
- `SBP2WireFormats` for management, normal ORB, page table, and status structures
- `SBP2PageTable`, `SBP2CommandORB`, and `SBP2ManagementORB` primitives
- `SCSICommandSet` request helpers and a deferred FireWire bus test double
- `AddressSpaceManager` auto-allocation and callback support used by the ORB primitives

## CI Compatibility Fixes
- allow fork PR builds to run when signing secrets are unavailable
- avoid C++ exception syntax in DriverKit code, where exceptions are disabled
- skip optional Linux reference fixture tests when the external reference files are not present in CI
- skip Sonar steps when `SONAR_TOKEN` is unavailable

## Deferred To Later PRs
- login session state machine and reconnect handling
- command transport / ORB queue management
- user client surface and Swift API

## Verification
- `./build.sh --no-bump`
- `./build.sh --no-bump --test-only --test-filter 'SBP2ORB|AddressSpaceManager'`
- `./build.sh --no-bump --test-only`
- GitHub PR checks are passing
