### PR TITLE
fix(dice): bind Alesis MultiMix active stream profile

### DIFF
--- a/ASFWDriver/Audio/Backends/DiceDuplexRestartCoordinator.cpp
+++ b/ASFWDriver/Audio/Backends/DiceDuplexRestartCoordinator.cpp
@@ -48,6 +48,10 @@ constexpr uint32_t kBlockingStreamModeRaw = static_cast<uint32_t>(Model::StreamM
 constexpr uint32_t kClockRequestWaitTimeoutMs = 15000;
 constexpr uint32_t kWaitPollMs = 10;
 
+[[nodiscard]] bool IsValidIsoChannel(uint8_t channel) noexcept {
+    return channel <= 0x3F;
+}
+
 enum class DiceRecoveryDisposition : uint8_t {
     kIgnore,
     kRestart,
@@ -99,6 +103,31 @@ struct DiceRecoveryDecision {
     }
 
     return DiceRestartState::kStarting;
+}
+
+[[nodiscard]] AudioDuplexChannels ResolveDuplexChannelsForRecord(
+    const Discovery::DeviceRecord& record) noexcept {
+    AudioDuplexChannels channels{
+        .deviceToHostIsoChannel = kDefaultIrChannel,
+        .hostToDeviceIsoChannel = kDefaultItChannel,
+    };
+
+    AudioStreamRuntimeCaps caps{};
+    bool haveCaps = record.protocol && record.protocol->GetRuntimeAudioStreamCaps(caps);
+    if (!haveCaps) {
+        haveCaps = DICE::TCAT::TryGetKnownDICEProfile(record.vendorId, record.modelId, caps);
+    }
+
+    if (haveCaps) {
+        if (IsValidIsoChannel(caps.deviceToHostIsoChannel)) {
+            channels.deviceToHostIsoChannel = caps.deviceToHostIsoChannel;
+        }
+        if (IsValidIsoChannel(caps.hostToDeviceIsoChannel)) {
+            channels.hostToDeviceIsoChannel = caps.hostToDeviceIsoChannel;
+        }
+    }
+
+    return channels;
 }
 
 [[nodiscard]] constexpr const char* ToString(DiceRestartReason reason) noexcept {
@@ -1076,10 +1105,7 @@ IOReturn DiceDuplexRestartCoordinator::RunDuplexStart(
     const DiceDesiredClockConfig& desiredClock,
     DiceRestartReason reason) noexcept {
     const FW::Generation topologyGeneration = record.gen;
-    const AudioDuplexChannels channels{
-        .deviceToHostIsoChannel = kDefaultIrChannel,
-        .hostToDeviceIsoChannel = kDefaultItChannel,
-    };
+    const AudioDuplexChannels channels = ResolveDuplexChannelsForRecord(record);
     const uint64_t restartId = AllocateRestartId();
 
     auto finalizeFailure = [&](IOReturn failureStatus,
@@ -1231,6 +1257,11 @@ IOReturn DiceDuplexRestartCoordinator::RunDuplexStart(
                 session.state,
                 session.phase,
                 reason);
+    ASFW_LOG(Audio,
+             "DiceDuplexRestartCoordinator: using DICE iso channels d2h=%u h2d=%u GUID=%llx",
+             channels.deviceToHostIsoChannel,
+             channels.hostToDeviceIsoChannel,
+             guid);
 
     const kern_return_t claimStatus = hostTransport_.BeginSplitDuplex(guid);
     if (claimStatus != kIOReturnSuccess) {

--- a/ASFWDriver/Protocols/Audio/AudioTypes.hpp
+++ b/ASFWDriver/Protocols/Audio/AudioTypes.hpp
@@ -10,6 +10,8 @@
 namespace ASFW::Audio {
 
 struct AudioStreamRuntimeCaps {
+    static constexpr uint8_t kInvalidIsoChannel = 0xFF;
+
     // Host-facing channel counts (PCM only).
     uint32_t hostInputPcmChannels{0};   // Device -> host capture channels
     uint32_t hostOutputPcmChannels{0};  // Host -> device playback channels
@@ -19,6 +21,10 @@ struct AudioStreamRuntimeCaps {
     uint32_t hostToDeviceAm824Slots{0}; // DICE RX stream slots (playback wire format)
 
     uint32_t sampleRateHz{0};
+
+    // Active DICE isochronous channels when discovered from stream entries.
+    uint8_t deviceToHostIsoChannel{kInvalidIsoChannel}; // DICE TX / host IR
+    uint8_t hostToDeviceIsoChannel{kInvalidIsoChannel}; // DICE RX / host IT
 };
 
 struct AudioDuplexChannels {

--- a/ASFWDriver/Protocols/Audio/DICE/Core/DICEDuplexBringupController.cpp
+++ b/ASFWDriver/Protocols/Audio/DICE/Core/DICEDuplexBringupController.cpp
@@ -56,11 +56,15 @@ void CacheRuntimeCaps(AudioStreamRuntimeCaps& caps,
                       const GlobalState& global,
                       const StreamConfig& tx,
                       const StreamConfig& rx) noexcept {
-    caps.hostInputPcmChannels = tx.TotalPcmChannels();
-    caps.deviceToHostAm824Slots = tx.TotalAm824Slots();
-    caps.hostOutputPcmChannels = rx.TotalPcmChannels();
-    caps.hostToDeviceAm824Slots = rx.TotalAm824Slots();
+    caps.hostInputPcmChannels = tx.ActivePcmChannels();
+    caps.deviceToHostAm824Slots = tx.ActiveAm824Slots();
+    caps.hostOutputPcmChannels = rx.ActivePcmChannels();
+    caps.hostToDeviceAm824Slots = rx.ActiveAm824Slots();
     caps.sampleRateHz = global.sampleRate;
+    caps.deviceToHostIsoChannel =
+        tx.FirstActiveIsoChannel(AudioStreamRuntimeCaps::kInvalidIsoChannel);
+    caps.hostToDeviceIsoChannel =
+        rx.FirstActiveIsoChannel(AudioStreamRuntimeCaps::kInvalidIsoChannel);
 }
 
 } // namespace

--- a/ASFWDriver/Protocols/Audio/DICE/Core/DICETypes.hpp
+++ b/ASFWDriver/Protocols/Audio/DICE/Core/DICETypes.hpp
@@ -340,6 +340,10 @@ struct StreamFormatEntry {
     [[nodiscard]] uint32_t Am824Slots() const noexcept {
         return pcmChannels + ((midiPorts + 7u) / 8u);
     }
+
+    [[nodiscard]] bool IsActive() const noexcept {
+        return isoChannel >= 0;
+    }
 };
 
 /// TX/RX stream section configuration
@@ -358,10 +362,30 @@ struct StreamConfig {
         return total;
     }
 
+    [[nodiscard]] uint32_t ActivePcmChannels() const noexcept {
+        uint32_t total = 0;
+        for (uint32_t i = 0; i < numStreams && i < 4; ++i) {
+            if (streams[i].IsActive()) {
+                total += streams[i].pcmChannels;
+            }
+        }
+        return total;
+    }
+
     [[nodiscard]] uint32_t TotalMidiPorts() const noexcept {
         uint32_t total = 0;
         for (uint32_t i = 0; i < numStreams && i < 4; ++i) {
             total += streams[i].midiPorts;
+        }
+        return total;
+    }
+
+    [[nodiscard]] uint32_t ActiveMidiPorts() const noexcept {
+        uint32_t total = 0;
+        for (uint32_t i = 0; i < numStreams && i < 4; ++i) {
+            if (streams[i].IsActive()) {
+                total += streams[i].midiPorts;
+            }
         }
         return total;
     }
@@ -372,6 +396,41 @@ struct StreamConfig {
             total += streams[i].Am824Slots();
         }
         return total;
+    }
+
+    [[nodiscard]] uint32_t ActiveAm824Slots() const noexcept {
+        uint32_t total = 0;
+        for (uint32_t i = 0; i < numStreams && i < 4; ++i) {
+            if (streams[i].IsActive()) {
+                total += streams[i].Am824Slots();
+            }
+        }
+        return total;
+    }
+
+    [[nodiscard]] uint32_t ActiveStreamCount() const noexcept {
+        uint32_t total = 0;
+        for (uint32_t i = 0; i < numStreams && i < 4; ++i) {
+            if (streams[i].IsActive()) {
+                ++total;
+            }
+        }
+        return total;
+    }
+
+    [[nodiscard]] uint8_t FirstActiveIsoChannel(uint8_t fallback) const noexcept {
+        for (uint32_t i = 0; i < numStreams && i < 4; ++i) {
+            if (streams[i].IsActive() && streams[i].isoChannel <= 0x3F) {
+                return static_cast<uint8_t>(streams[i].isoChannel);
+            }
+        }
+        return fallback;
+    }
+
+    [[nodiscard]] uint32_t DisabledPcmChannels() const noexcept {
+        const uint32_t total = TotalPcmChannels();
+        const uint32_t active = ActivePcmChannels();
+        return (total > active) ? (total - active) : 0;
     }
 
     // Legacy alias kept while call sites migrate to explicit semantics.

--- a/ASFWDriver/Protocols/Audio/DICE/TCAT/DICEKnownProfiles.hpp
+++ b/ASFWDriver/Protocols/Audio/DICE/TCAT/DICEKnownProfiles.hpp
@@ -21,6 +21,8 @@ namespace ASFW::Audio::DICE::TCAT {
         outCaps.hostOutputPcmChannels = 12;
         outCaps.deviceToHostAm824Slots = 9;
         outCaps.hostToDeviceAm824Slots = 13;
+        outCaps.deviceToHostIsoChannel = 1;
+        outCaps.hostToDeviceIsoChannel = 0;
         return true;
     }
 
@@ -31,6 +33,8 @@ namespace ASFW::Audio::DICE::TCAT {
         outCaps.hostOutputPcmChannels = 8;
         outCaps.deviceToHostAm824Slots = 17;
         outCaps.hostToDeviceAm824Slots = 9;
+        outCaps.deviceToHostIsoChannel = 1;
+        outCaps.hostToDeviceIsoChannel = 0;
         return true;
     }
 
@@ -41,6 +45,23 @@ namespace ASFW::Audio::DICE::TCAT {
         outCaps.hostOutputPcmChannels = 8;
         outCaps.deviceToHostAm824Slots = 17;
         outCaps.hostToDeviceAm824Slots = 9;
+        outCaps.deviceToHostIsoChannel = 1;
+        outCaps.hostToDeviceIsoChannel = 0;
+        return true;
+    }
+
+    // Alesis MultiMix FireWire recording-stability profile observed on local hardware.
+    // The DICE table exposes one active 12-channel device-to-host stream; a
+    // second 2-channel stream is disabled with iso=-1 and must not be published
+    // to CoreAudio as capture capacity.
+    if (vendorId == 0x000595U && modelId == 0x000000U) {
+        outCaps.sampleRateHz = 48000;
+        outCaps.hostInputPcmChannels = 12;
+        outCaps.hostOutputPcmChannels = 2;
+        outCaps.deviceToHostAm824Slots = 12;
+        outCaps.hostToDeviceAm824Slots = 2;
+        outCaps.deviceToHostIsoChannel = 1;
+        outCaps.hostToDeviceIsoChannel = 0;
         return true;
     }
 

--- a/ASFWDriver/Protocols/Audio/DICE/TCAT/DICETcatProtocol.cpp
+++ b/ASFWDriver/Protocols/Audio/DICE/TCAT/DICETcatProtocol.cpp
@@ -65,6 +65,10 @@ bool DICETcatProtocol::GetRuntimeAudioStreamCaps(AudioStreamRuntimeCaps& outCaps
     outCaps.hostOutputPcmChannels = hostOutputPcmChannels_.load(std::memory_order_relaxed);
     outCaps.deviceToHostAm824Slots = deviceToHostAm824Slots_.load(std::memory_order_relaxed);
     outCaps.hostToDeviceAm824Slots = hostToDeviceAm824Slots_.load(std::memory_order_relaxed);
+    outCaps.deviceToHostIsoChannel =
+        static_cast<uint8_t>(deviceToHostIsoChannel_.load(std::memory_order_relaxed));
+    outCaps.hostToDeviceIsoChannel =
+        static_cast<uint8_t>(hostToDeviceIsoChannel_.load(std::memory_order_relaxed));
     return true;
 }
 
@@ -305,11 +309,13 @@ void DICETcatProtocol::CacheRuntimeCaps(const GlobalState& global,
                                         const StreamConfig& tx,
                                         const StreamConfig& rx) noexcept {
     CacheRuntimeCaps(AudioStreamRuntimeCaps{
-        .hostInputPcmChannels = tx.TotalPcmChannels(),
-        .hostOutputPcmChannels = rx.TotalPcmChannels(),
-        .deviceToHostAm824Slots = tx.TotalAm824Slots(),
-        .hostToDeviceAm824Slots = rx.TotalAm824Slots(),
+        .hostInputPcmChannels = tx.ActivePcmChannels(),
+        .hostOutputPcmChannels = rx.ActivePcmChannels(),
+        .deviceToHostAm824Slots = tx.ActiveAm824Slots(),
+        .hostToDeviceAm824Slots = rx.ActiveAm824Slots(),
         .sampleRateHz = global.sampleRate,
+        .deviceToHostIsoChannel = tx.FirstActiveIsoChannel(AudioStreamRuntimeCaps::kInvalidIsoChannel),
+        .hostToDeviceIsoChannel = rx.FirstActiveIsoChannel(AudioStreamRuntimeCaps::kInvalidIsoChannel),
     });
 }
 
@@ -319,6 +325,8 @@ void DICETcatProtocol::CacheRuntimeCaps(const AudioStreamRuntimeCaps& caps) noex
     hostOutputPcmChannels_.store(caps.hostOutputPcmChannels, std::memory_order_relaxed);
     hostToDeviceAm824Slots_.store(caps.hostToDeviceAm824Slots, std::memory_order_relaxed);
     runtimeSampleRateHz_.store(caps.sampleRateHz, std::memory_order_relaxed);
+    deviceToHostIsoChannel_.store(caps.deviceToHostIsoChannel, std::memory_order_relaxed);
+    hostToDeviceIsoChannel_.store(caps.hostToDeviceIsoChannel, std::memory_order_relaxed);
     runtimeCapsValid_.store(true, std::memory_order_release);
 }
 
@@ -329,6 +337,8 @@ void DICETcatProtocol::ResetRuntimeCaps() noexcept {
     hostOutputPcmChannels_.store(0, std::memory_order_relaxed);
     deviceToHostAm824Slots_.store(0, std::memory_order_relaxed);
     hostToDeviceAm824Slots_.store(0, std::memory_order_relaxed);
+    deviceToHostIsoChannel_.store(AudioStreamRuntimeCaps::kInvalidIsoChannel, std::memory_order_relaxed);
+    hostToDeviceIsoChannel_.store(AudioStreamRuntimeCaps::kInvalidIsoChannel, std::memory_order_relaxed);
 }
 
 } // namespace ASFW::Audio::DICE::TCAT

--- a/ASFWDriver/Protocols/Audio/DICE/TCAT/DICETcatProtocol.hpp
+++ b/ASFWDriver/Protocols/Audio/DICE/TCAT/DICETcatProtocol.hpp
@@ -92,6 +92,8 @@ private:
     std::atomic<uint32_t> hostOutputPcmChannels_{0};
     std::atomic<uint32_t> deviceToHostAm824Slots_{0};
     std::atomic<uint32_t> hostToDeviceAm824Slots_{0};
+    std::atomic<uint32_t> deviceToHostIsoChannel_{AudioStreamRuntimeCaps::kInvalidIsoChannel};
+    std::atomic<uint32_t> hostToDeviceIsoChannel_{AudioStreamRuntimeCaps::kInvalidIsoChannel};
     std::atomic<bool> runtimeCapsValid_{false};
 };
 

--- a/ASFWDriver/Protocols/Audio/DeviceProtocolFactory.cpp
+++ b/ASFWDriver/Protocols/Audio/DeviceProtocolFactory.cpp
@@ -38,6 +38,15 @@ std::unique_ptr<IDeviceProtocol> DeviceProtocolFactory::Create(
         }
     }
 
+    if (vendorId == kAlesisVendorId && modelId == kAlesisMultiMixModelId) {
+        ASFW_LOG(DICE,
+                 "Creating generic DICETcatProtocol for Alesis MultiMix vendor=0x%06x model=0x%06x node=0x%04x",
+                 vendorId,
+                 modelId,
+                 nodeId);
+        return std::make_unique<DICE::TCAT::DICETcatProtocol>(busOps, busInfo, nodeId, irmClient);
+    }
+
     // Check for Apogee Duet FireWire (AV/C + vendor-dependent commands).
     if (vendorId == kApogeeVendorId && modelId == kApogeeDuetModelId) {
         ASFW_LOG(Audio,

--- a/ASFWDriver/Protocols/Audio/DeviceProtocolFactory.hpp
+++ b/ASFWDriver/Protocols/Audio/DeviceProtocolFactory.hpp
@@ -40,6 +40,8 @@ public:
     static constexpr uint32_t kSPro40Tcd3070ModelId = 0x0000de;
     static constexpr uint32_t kApogeeVendorId = 0x0003db;
     static constexpr uint32_t kApogeeDuetModelId = 0x01dddd;
+    static constexpr uint32_t kAlesisVendorId = 0x000595;
+    static constexpr uint32_t kAlesisMultiMixModelId = 0x000000;
     static constexpr uint32_t kFocusriteGuidModelSPro40Tcd3070 = 0x13;
     static constexpr const char* kFocusriteVendorName = "Focusrite";
     static constexpr const char* kSPro40ModelName = "Saffire Pro 40";
@@ -51,6 +53,8 @@ public:
     static constexpr const char* kSPro40Tcd3070ModelName = "Saffire Pro 40 (TCD3070)";
     static constexpr const char* kApogeeVendorName = "Apogee";
     static constexpr const char* kApogeeDuetModelName = "Duet";
+    static constexpr const char* kAlesisVendorName = "Alesis";
+    static constexpr const char* kAlesisMultiMixModelName = "MultiMix FireWire";
 
     struct KnownIdentity {
         uint32_t vendorId{0};
@@ -102,6 +106,10 @@ public:
         if (vendorId == kApogeeVendorId && modelId == kApogeeDuetModelId) {
             return MakeKnownIdentity(vendorId, modelId, DeviceIntegrationMode::kAVCDriven,
                                      kApogeeVendorName, kApogeeDuetModelName);
+        }
+        if (vendorId == kAlesisVendorId && modelId == kAlesisMultiMixModelId) {
+            return MakeKnownIdentity(vendorId, modelId, DeviceIntegrationMode::kHardcodedNub,
+                                     kAlesisVendorName, kAlesisMultiMixModelName);
         }
         return std::nullopt;
     }

--- a/tests/DICETcatProtocolTests.cpp
+++ b/tests/DICETcatProtocolTests.cpp
@@ -250,7 +250,7 @@ TEST(DICETcatProtocolTests, InitializeIsSideEffectFree) {
     EXPECT_EQ(bus.lockCount, 0);
 }
 
-TEST(DICETcatProtocolTests, RuntimeCapsAggregateAllConfiguredStreams) {
+TEST(DICETcatProtocolTests, RuntimeCapsAggregateActiveConfiguredStreams) {
     CountingFireWireBus bus;
     DICETcatProtocol protocol(bus, bus, 2, nullptr);
 
@@ -259,14 +259,18 @@ TEST(DICETcatProtocolTests, RuntimeCapsAggregateAllConfiguredStreams) {
 
     ASFW::Audio::DICE::StreamConfig tx{};
     tx.numStreams = 2;
+    tx.streams[0].isoChannel = 1;
     tx.streams[0].pcmChannels = 10;
     tx.streams[0].midiPorts = 1;
+    tx.streams[1].isoChannel = -1;
     tx.streams[1].pcmChannels = 6;
 
     ASFW::Audio::DICE::StreamConfig rx{};
     rx.numStreams = 2;
+    rx.streams[0].isoChannel = 0;
     rx.streams[0].pcmChannels = 8;
     rx.streams[0].midiPorts = 1;
+    rx.streams[1].isoChannel = -1;
     rx.streams[1].pcmChannels = 4;
 
     ASFW::Audio::DICE::TCAT::DICETcatProtocolTestPeer::CacheRuntimeCaps(protocol, global, tx, rx);
@@ -274,10 +278,12 @@ TEST(DICETcatProtocolTests, RuntimeCapsAggregateAllConfiguredStreams) {
     AudioStreamRuntimeCaps caps{};
     ASSERT_TRUE(protocol.GetRuntimeAudioStreamCaps(caps));
     EXPECT_EQ(caps.sampleRateHz, 48000U);
-    EXPECT_EQ(caps.hostInputPcmChannels, 16U);
-    EXPECT_EQ(caps.deviceToHostAm824Slots, 17U);
-    EXPECT_EQ(caps.hostOutputPcmChannels, 12U);
-    EXPECT_EQ(caps.hostToDeviceAm824Slots, 13U);
+    EXPECT_EQ(caps.hostInputPcmChannels, 10U);
+    EXPECT_EQ(caps.deviceToHostAm824Slots, 11U);
+    EXPECT_EQ(caps.hostOutputPcmChannels, 8U);
+    EXPECT_EQ(caps.hostToDeviceAm824Slots, 9U);
+    EXPECT_EQ(caps.deviceToHostIsoChannel, 1U);
+    EXPECT_EQ(caps.hostToDeviceIsoChannel, 0U);
 }
 
 TEST(DICETcatProtocolTests, ReadDuplexHealthReturnsCurrentGlobalLockState) {
@@ -290,10 +296,12 @@ TEST(DICETcatProtocolTests, ReadDuplexHealthReturnsCurrentGlobalLockState) {
 
     ASFW::Audio::DICE::StreamConfig tx{};
     tx.numStreams = 1;
+    tx.streams[0].isoChannel = 1;
     tx.streams[0].pcmChannels = 16;
 
     ASFW::Audio::DICE::StreamConfig rx{};
     rx.numStreams = 1;
+    rx.streams[0].isoChannel = 0;
     rx.streams[0].pcmChannels = 8;
 
     ASFW::Audio::DICE::TCAT::DICETcatProtocolTestPeer::CacheRuntimeCaps(protocol, global, tx, rx);
@@ -364,6 +372,16 @@ TEST(DICEKnownProfilesTests, ReturnsKnownFocusriteProfiles) {
     EXPECT_EQ(caps.hostOutputPcmChannels, 8U);
     EXPECT_EQ(caps.deviceToHostAm824Slots, 17U);
     EXPECT_EQ(caps.hostToDeviceAm824Slots, 9U);
+
+    caps = {};
+    EXPECT_TRUE(TryGetKnownDICEProfile(0x000595U, 0x000000U, caps));
+    EXPECT_EQ(caps.sampleRateHz, 48000U);
+    EXPECT_EQ(caps.hostInputPcmChannels, 12U);
+    EXPECT_EQ(caps.hostOutputPcmChannels, 2U);
+    EXPECT_EQ(caps.deviceToHostAm824Slots, 12U);
+    EXPECT_EQ(caps.hostToDeviceAm824Slots, 2U);
+    EXPECT_EQ(caps.deviceToHostIsoChannel, 1U);
+    EXPECT_EQ(caps.hostToDeviceIsoChannel, 0U);
 }
 
 } // namespace

--- a/tests/DeviceProtocolFactoryTests.cpp
+++ b/tests/DeviceProtocolFactoryTests.cpp
@@ -54,6 +54,11 @@ TEST(DeviceProtocolFactoryTests, SelectsIntegrationModeForKnownDevices) {
                   DeviceProtocolFactory::kApogeeVendorId,
                   DeviceProtocolFactory::kApogeeDuetModelId),
               DeviceIntegrationMode::kAVCDriven);
+
+    EXPECT_EQ(DeviceProtocolFactory::LookupIntegrationMode(
+                  DeviceProtocolFactory::kAlesisVendorId,
+                  DeviceProtocolFactory::kAlesisMultiMixModelId),
+              DeviceIntegrationMode::kHardcodedNub);
 }
 
 TEST(DeviceProtocolFactoryTests, RejectsUnknownDevices) {
@@ -94,6 +99,10 @@ TEST(DeviceProtocolFactoryTests, RecognizesKnownVendorModelPairs) {
     EXPECT_TRUE(DeviceProtocolFactory::IsKnownDevice(
         DeviceProtocolFactory::kApogeeVendorId,
         DeviceProtocolFactory::kApogeeDuetModelId));
+
+    EXPECT_TRUE(DeviceProtocolFactory::IsKnownDevice(
+        DeviceProtocolFactory::kAlesisVendorId,
+        DeviceProtocolFactory::kAlesisMultiMixModelId));
 }
 
 TEST(DeviceProtocolFactoryTests, InfersFocusriteIdentityFromGuid) {
@@ -137,6 +146,15 @@ TEST(DeviceProtocolFactoryTests, KeepsDeferredMultistreamFocusriteModelsRecogniz
     ASSERT_TRUE(spro26.has_value());
     EXPECT_EQ(spro26->integrationMode, DeviceIntegrationMode::kNone);
     EXPECT_STREQ(spro26->modelName, DeviceProtocolFactory::kSPro26ModelName);
+}
+
+TEST(DeviceProtocolFactoryTests, RecognizesAlesisMultiMixDiceProfile) {
+    const auto multiMix = DeviceProtocolFactory::LookupKnownIdentity(
+        DeviceProtocolFactory::kAlesisVendorId, DeviceProtocolFactory::kAlesisMultiMixModelId);
+    ASSERT_TRUE(multiMix.has_value());
+    EXPECT_EQ(multiMix->integrationMode, DeviceIntegrationMode::kHardcodedNub);
+    EXPECT_STREQ(multiMix->vendorName, DeviceProtocolFactory::kAlesisVendorName);
+    EXPECT_STREQ(multiMix->modelName, DeviceProtocolFactory::kAlesisMultiMixModelName);
 }
 
 } // namespace


### PR DESCRIPTION
Recognize the exact Alesis MultiMix FireWire DICE identity and use a known active stream profile for its observed 12-in/2-out 48 kHz shape. Ignore inactive DICE streams with iso=-1 when deriving runtime caps and choose the discovered/profile iso channels during duplex restart instead of hardcoded defaults.

Tests: DeviceProtocolFactoryTests, DICETcatProtocolTests, DICEDuplexBringupControllerTests, DiceDuplexRestartCoordinatorTests.