### PR TITLE
fix(foundation): stabilize async discovery and bus reset recovery

### DIFF
--- a/ASFW/DriverConnector+Discovery.swift
+++ b/ASFW/DriverConnector+Discovery.swift
@@ -23,11 +23,42 @@ extension ASFWDriverConnector {
         print("[Connector] 📦 Received \(wireData.count) bytes of wire format data")
 
         // Parse wire format
-        return parseDeviceDiscoveryWire(wireData)
+        return Self.parseDeviceDiscoveryWire(wireData)
     }
 
     /// Parse wire format data from driver
-    private func parseDeviceDiscoveryWire(_ data: Data) -> [FWDeviceInfo]? {
+    static func parseDeviceDiscoveryWire(_ data: Data) -> [FWDeviceInfo]? {
+        @inline(__always)
+        func readUInt8(at offset: Int) -> UInt8 {
+            data[data.startIndex + offset]
+        }
+
+        @inline(__always)
+        func readUInt32(at offset: Int) -> UInt32 {
+            var value: UInt32 = 0
+            for i in 0..<4 {
+                value |= UInt32(data[data.startIndex + offset + i]) << (i * 8)
+            }
+            return value
+        }
+
+        @inline(__always)
+        func readUInt64(at offset: Int) -> UInt64 {
+            var value: UInt64 = 0
+            for i in 0..<8 {
+                value |= UInt64(data[data.startIndex + offset + i]) << (i * 8)
+            }
+            return value
+        }
+
+        func readCString(at offset: Int, length: Int) -> String {
+            let start = data.startIndex + offset
+            let end = start + length
+            let bytes = data[start..<end]
+            let trimmed = bytes.prefix { $0 != 0 }
+            return String(decoding: trimmed, as: UTF8.self)
+        }
+
         var offset = 0
 
         // Read header
@@ -36,7 +67,7 @@ extension ASFWDriverConnector {
             return nil
         }
 
-        let deviceCount = data.withUnsafeBytes { $0.load(fromByteOffset: offset, as: UInt32.self) }
+        let deviceCount = readUInt32(at: offset)
         offset += 8  // deviceCount + padding
 
         print("[Connector] 📋 Device count: \(deviceCount)")
@@ -50,21 +81,16 @@ extension ASFWDriverConnector {
                 return nil
             }
 
-            let guid = data.withUnsafeBytes { $0.load(fromByteOffset: offset, as: UInt64.self) }
-            let vendorId = data.withUnsafeBytes { $0.load(fromByteOffset: offset + 8, as: UInt32.self) }
-            let modelId = data.withUnsafeBytes { $0.load(fromByteOffset: offset + 12, as: UInt32.self) }
-            let generation = data.withUnsafeBytes { $0.load(fromByteOffset: offset + 16, as: UInt32.self) }
-            let nodeId = data.withUnsafeBytes { $0.load(fromByteOffset: offset + 20, as: UInt8.self) }
-            let stateRaw = data.withUnsafeBytes { $0.load(fromByteOffset: offset + 21, as: UInt8.self) }
-            let unitCount = data.withUnsafeBytes { $0.load(fromByteOffset: offset + 22, as: UInt8.self) }
-
-            // Read vendor name (64 bytes at offset 24)
-            let vendorNameData = data.subdata(in: (offset + 24)..<(offset + 88))
-            let vendorName = String(cString: vendorNameData.withUnsafeBytes { $0.bindMemory(to: CChar.self).baseAddress! })
-
-            // Read model name (64 bytes at offset 88)
-            let modelNameData = data.subdata(in: (offset + 88)..<(offset + 152))
-            let modelName = String(cString: modelNameData.withUnsafeBytes { $0.bindMemory(to: CChar.self).baseAddress! })
+            let guid = readUInt64(at: offset)
+            let vendorId = readUInt32(at: offset + 8)
+            let modelId = readUInt32(at: offset + 12)
+            let generation = readUInt32(at: offset + 16)
+            let nodeId = readUInt8(at: offset + 20)
+            let stateRaw = readUInt8(at: offset + 21)
+            let unitCount = readUInt8(at: offset + 22)
+            let deviceKind = readUInt8(at: offset + 23)
+            let vendorName = readCString(at: offset + 24, length: 64)
+            let modelName = readCString(at: offset + 88, length: 64)
 
             let state = FWDeviceState(rawValue: stateRaw) ?? .created
 
@@ -73,23 +99,21 @@ extension ASFWDriverConnector {
             // Read units
             var units: [FWUnitInfo] = []
             for _ in 0..<unitCount {
-                guard offset + 144 <= data.count else {  // sizeof(FWUnitWire) = 144
+                guard offset + 160 <= data.count else {  // sizeof(FWUnitWire) = 160
                     print("[Connector] ❌ Data truncated while reading unit")
                     return nil
                 }
 
-                let specId = data.withUnsafeBytes { $0.load(fromByteOffset: offset, as: UInt32.self) }
-                let swVersion = data.withUnsafeBytes { $0.load(fromByteOffset: offset + 4, as: UInt32.self) }
-                let romOffset = data.withUnsafeBytes { $0.load(fromByteOffset: offset + 8, as: UInt32.self) }
-                let unitStateRaw = data.withUnsafeBytes { $0.load(fromByteOffset: offset + 12, as: UInt8.self) }
-
-                // Read unit vendor name (64 bytes at offset 16)
-                let unitVendorData = data.subdata(in: (offset + 16)..<(offset + 80))
-                let unitVendorName = String(cString: unitVendorData.withUnsafeBytes { $0.bindMemory(to: CChar.self).baseAddress! })
-
-                // Read unit product name (64 bytes at offset 80)
-                let unitProductData = data.subdata(in: (offset + 80)..<(offset + 144))
-                let unitProductName = String(cString: unitProductData.withUnsafeBytes { $0.bindMemory(to: CChar.self).baseAddress! })
+                let specId = readUInt32(at: offset)
+                let swVersion = readUInt32(at: offset + 4)
+                let romOffset = readUInt32(at: offset + 8)
+                let unitStateRaw = readUInt8(at: offset + 12)
+                let managementAgentOffset = readUInt32(at: offset + 16)
+                let lun = readUInt32(at: offset + 20)
+                let unitCharacteristics = readUInt32(at: offset + 24)
+                let fastStart = readUInt32(at: offset + 28)
+                let unitVendorName = readCString(at: offset + 32, length: 64)
+                let unitProductName = readCString(at: offset + 96, length: 64)
 
                 let unitState = FWUnitState(rawValue: unitStateRaw) ?? .created
 
@@ -98,11 +122,15 @@ extension ASFWDriverConnector {
                     swVersion: swVersion,
                     state: unitState,
                     romOffset: romOffset,
+                    managementAgentOffset: managementAgentOffset == 0 ? nil : managementAgentOffset,
+                    lun: lun == 0 ? nil : lun,
+                    unitCharacteristics: unitCharacteristics == 0 ? nil : unitCharacteristics,
+                    fastStart: fastStart == 0 ? nil : fastStart,
                     vendorName: unitVendorName.isEmpty ? nil : unitVendorName,
                     productName: unitProductName.isEmpty ? nil : unitProductName
                 ))
 
-                offset += 144  // sizeof(FWUnitWire)
+                offset += 160  // sizeof(FWUnitWire)
             }
 
             devices.append(FWDeviceInfo(
@@ -115,7 +143,8 @@ extension ASFWDriverConnector {
                 nodeId: nodeId,
                 generation: generation,
                 state: state,
-                units: units
+                units: units,
+                deviceKind: deviceKind
             ))
         }
 

--- a/ASFW/Models/DriverConnectorModels.swift
+++ b/ASFW/Models/DriverConnectorModels.swift
@@ -514,8 +514,13 @@ struct DriverConnectorFWDeviceInfo: Identifiable {
     let generation: UInt32
     let state: DriverConnectorFWDeviceState
     let units: [DriverConnectorFWUnitInfo]
+    let deviceKind: UInt8  // DeviceKind enum value from driver
 
     var stateString: String { state.description }
+    var isStorage: Bool { deviceKind == 4 }  // DeviceKind::Storage = 4
+    var hasSBP2Unit: Bool { units.contains(where: \.isSBP2Unit) }
+    var sbp2Units: [DriverConnectorFWUnitInfo] { units.filter(\.isSBP2Unit) }
+    var storageUnits: [DriverConnectorFWUnitInfo] { sbp2Units }
 }
 
 struct DriverConnectorFWUnitInfo: Identifiable {
@@ -524,12 +529,23 @@ struct DriverConnectorFWUnitInfo: Identifiable {
     let swVersion: UInt32
     let state: DriverConnectorFWUnitState
     let romOffset: UInt32
+    let managementAgentOffset: UInt32?
+    let lun: UInt32?
+    let unitCharacteristics: UInt32?
+    let fastStart: UInt32?
     let vendorName: String?
     let productName: String?
+
+    private static let sbp2SpecId: UInt32 = 0x00609E
+    private static let sbp2SwVersion: UInt32 = 0x010483
 
     var specIdHex: String { String(format: "0x%06X", specId) }
     var swVersionHex: String { String(format: "0x%06X", swVersion) }
     var stateString: String { state.description }
+    var isSBP2Unit: Bool {
+        specId == Self.sbp2SpecId && swVersion == Self.sbp2SwVersion
+    }
+    var isSBP2Storage: Bool { isSBP2Unit }
 }
 
 // API compatibility aliases (keep existing public names and nested access stable)

--- a/ASFWDriver/Async/PacketHelpers.hpp
+++ b/ASFWDriver/Async/PacketHelpers.hpp
@@ -20,10 +20,10 @@ namespace ASFW::Async {
 ///
 /// Per IEEE 1394-1995 §6.2.1, destination_offset is at bytes 8-13 (48-bit).
 ///
-/// @param header Packet header bytes (big-endian, minimum 16 bytes)
+/// @param header Packet header bytes (big-endian, minimum 12 bytes)
 /// @return Destination offset (48-bit address), or 0 if header too short
 inline uint64_t ExtractDestOffset(std::span<const uint8_t> header) {
-    if (header.size() < 16) {
+    if (header.size() < 12) {
         return 0;
     }
 
@@ -65,20 +65,28 @@ inline uint64_t ExtractDestOffset(std::span<const uint8_t> header) {
     return (offset_high << 32) | offset_low;
 }
 
-/// Extract data length from block write/read packet header
+/// Extract data length from an OHCI AR DMA block packet header.
 ///
-/// Per IEEE 1394-1995 §6.2.4, data_length is at bytes 14-15 (16-bit).
+/// IEEE 1394 wire format stores Q3 as:
+///   [data_length:16][extended_tcode:16]
 ///
-/// @param header Packet header bytes (big-endian, minimum 16 bytes)
+/// OHCI AR DMA writes each quadlet to memory in little-endian host order, so
+/// Q3 appears in memory as:
+///   [extended_tcode_lo][extended_tcode_hi][data_length_lo][data_length_hi]
+///
+/// That means data_length lives in header[14:15] as a little-endian 16-bit
+/// value, not a big-endian wire-order value.
+///
+/// @param header Packet header bytes in OHCI AR DMA memory order
 /// @return Data length in bytes, or 0 if header too short
 inline uint16_t ExtractDataLength(std::span<const uint8_t> header) {
     if (header.size() < 16) {
         return 0;
     }
 
-    // Data length: bytes 14-15 (16-bit big-endian)
-    return (static_cast<uint16_t>(header[14]) << 8) |
-           static_cast<uint16_t>(header[15]);
+    // Q3 is stored little-endian in the AR DMA buffer.
+    return static_cast<uint16_t>(header[14]) |
+           (static_cast<uint16_t>(header[15]) << 8);
 }
 
 /// Extract extended transaction code from packet header

--- a/ASFWDriver/Async/PacketHelpers.hpp
+++ b/ASFWDriver/Async/PacketHelpers.hpp
@@ -20,7 +20,7 @@ namespace ASFW::Async {
 ///
 /// Per IEEE 1394-1995 §6.2.1, destination_offset is at bytes 8-13 (48-bit).
 ///
-/// @param header Packet header bytes (big-endian, minimum 12 bytes)
+/// @param header Packet header bytes in OHCI AR DMA memory order, minimum 12 bytes
 /// @return Destination offset (48-bit address), or 0 if header too short
 inline uint64_t ExtractDestOffset(std::span<const uint8_t> header) {
     if (header.size() < 12) {
@@ -93,7 +93,7 @@ inline uint16_t ExtractDataLength(std::span<const uint8_t> header) {
 ///
 /// For block write/read packets, extended_tcode is at byte 7.
 ///
-/// @param header Packet header bytes (big-endian, minimum 16 bytes)
+/// @param header Packet header bytes in OHCI AR DMA memory order, minimum 16 bytes
 /// @return Extended tcode, or 0 if header too short
 inline uint8_t ExtractExtendedTCode(std::span<const uint8_t> header) {
     if (header.size() < 16) {

--- a/ASFWDriver/Async/Rx/PacketRouter.cpp
+++ b/ASFWDriver/Async/Rx/PacketRouter.cpp
@@ -1,12 +1,42 @@
 #include "PacketRouter.hpp"
 
+#include <array>
 #include <cstring>
 
+#include "../../Common/FWCommon.hpp"
 #include "ARPacketParser.hpp"
 #include "../../Logging/Logging.hpp"
 #include "../Tx/ResponseSender.hpp"
 
 namespace ASFW::Async {
+
+namespace {
+
+std::span<const uint8_t> CopyAlignedPayload(std::span<const uint8_t> source,
+                                            std::array<uint8_t, ASFW::FW::MaxPayload::kS800>& scratch) {
+    if (source.empty()) {
+        return {};
+    }
+
+    if (source.size() > scratch.size()) {
+        return {};
+    }
+
+    std::size_t index = 0;
+    for (; index + sizeof(uint32_t) <= source.size(); index += sizeof(uint32_t)) {
+        uint32_t quadlet = 0;
+        __builtin_memcpy(&quadlet, source.data() + index, sizeof(uint32_t));
+        __builtin_memcpy(scratch.data() + index, &quadlet, sizeof(uint32_t));
+    }
+
+    for (; index < source.size(); ++index) {
+        scratch[index] = source[index];
+    }
+
+    return std::span<const uint8_t>(scratch.data(), source.size());
+}
+
+} // namespace
 
 void PacketRouter::RegisterRequestHandler(uint8_t tCode, PacketHandler handler) {
     if (tCode >= 16) {
@@ -56,12 +86,26 @@ void PacketRouter::RoutePacket(ARContextType contextType, std::span<const uint8_
         const size_t headerLen = packetInfo.headerLength;
         const size_t dataLen = packetInfo.dataLength;
         const uint8_t tCode = packetInfo.tCode;
+        alignas(8) std::array<uint8_t, ASFW::FW::MaxPayload::kS800> payloadScratch{};
 
         // Build zero-copy view over header and payload
         ARPacketView view;
         view.tCode = tCode;
         view.header = std::span<const uint8_t>(packetStart, headerLen);
-        view.payload = std::span<const uint8_t>(packetStart + headerLen, dataLen);
+        if (dataLen > 0) {
+            const auto payloadBytes = std::span<const uint8_t>(packetStart + headerLen, dataLen);
+            view.payload = CopyAlignedPayload(payloadBytes, payloadScratch);
+            if (view.payload.empty()) {
+                ASFW_LOG(Async,
+                         "PacketRouter: payload %zu exceeds aligned scratch buffer for tCode=0x%x",
+                         dataLen,
+                         tCode);
+                offset += packetInfo.totalLength;
+                continue;
+            }
+        } else {
+            view.payload = {};
+        }
 
         // Trailer fields – use low 16 bits for xferStatus/timeStamp
         view.xferStatus = static_cast<uint16_t>(packetInfo.xferStatus & 0xFFFF);

--- a/ASFWDriver/Async/Rx/PacketRouter.cpp
+++ b/ASFWDriver/Async/Rx/PacketRouter.cpp
@@ -88,7 +88,7 @@ void PacketRouter::RoutePacket(ARContextType contextType, std::span<const uint8_
         const uint8_t tCode = packetInfo.tCode;
         alignas(8) std::array<uint8_t, ASFW::FW::MaxPayload::kS800> payloadScratch{};
 
-        // Build zero-copy view over header and payload
+        // Build a dispatch view over the header and aligned payload bytes.
         ARPacketView view;
         view.tCode = tCode;
         view.header = std::span<const uint8_t>(packetStart, headerLen);

--- a/ASFWDriver/Async/Rx/PacketRouter.hpp
+++ b/ASFWDriver/Async/Rx/PacketRouter.hpp
@@ -13,17 +13,19 @@ namespace ASFW::Async {
 class ResponseSender;
 
 /**
- * \brief Zero-copy view of an AR packet for handler dispatch.
+ * \brief Dispatch view of an AR packet for handler callbacks.
  *
- * Provides read-only access to packet header and payload without copying data.
- * All multi-byte fields are in BIG-ENDIAN (IEEE 1394 wire format).
+ * Provides read-only access to packet header and payload during RoutePacket().
+ * Header bytes are in OHCI AR DMA memory order; decoded scalar fields are in
+ * host order. Payload may point at an aligned scratch copy for handlers that
+ * need stable byte access.
  */
 struct ARPacketView {
     std::span<const uint8_t> header;   ///< Packet header (12-16 bytes depending on tCode)
     std::span<const uint8_t> payload;  ///< Packet payload (0-N bytes depending on packet type)
     uint8_t tCode;                     ///< Transaction code (extracted from header first byte)
-    uint16_t sourceID;                 ///< Source node ID (big-endian)
-    uint16_t destID;                   ///< Destination node ID (big-endian)
+    uint16_t sourceID;                 ///< Decoded source node ID (host order)
+    uint16_t destID;                   ///< Decoded destination node ID (host order)
     uint8_t tLabel;                    ///< Transaction label (6 bits)
 
     // New: OHCI trailer fields (raw)
@@ -43,7 +45,7 @@ enum class ARContextType : uint8_t {
  * \brief Packet handler callback type.
  *
  * Invoked by PacketRouter when packet with matching tCode is received.
- * Handler receives zero-copy view of packet data.
+ * Handler receives an ARPacketView valid for the duration of the callback.
  *
  * **Thread Safety**
  * Handlers are invoked from interrupt context. Must complete quickly and
@@ -77,7 +79,7 @@ using PacketHandler = std::function<ResponseCode(const ARPacketView&)>;
  * - 0xE: PHY packet
  *
  * **Design Rationale**
- * - **Zero-copy**: Uses std::span to avoid copying packet data
+ * - **Span-based dispatch**: Uses std::span views and an aligned payload scratch buffer
  * - **Functional handlers**: std::function allows lambdas and captures
  * - **Separate request/response tables**: Different tCode space for each context
  * - **Single-threaded**: No locking (caller must serialize)
@@ -92,7 +94,7 @@ using PacketHandler = std::function<ResponseCode(const ARPacketView&)>;
  * See drivers/firewire/ohci.c handle_ar_packet():
  * - Switch on tCode (lines 1680-1710)
  * - Dispatches to fw_core_handle_request() or fw_core_handle_response()
- * - Zero-copy packet forwarding to core layer
+ * - Packet forwarding to core layer without reparsing full packet streams
  *
  * **Usage Example**
  * \code
@@ -170,7 +172,7 @@ public:
      * 1. Use ARPacketParser::ParseNext() to extract packets from buffer
      * 2. For each packet:
      *    a. Extract tCode from header first byte (bits[7:4])
-     *    b. Build ARPacketView with zero-copy spans
+     *    b. Build ARPacketView from header span and aligned payload bytes
      *    c. Lookup handler in requestHandlers_ or responseHandlers_
      *    d. Invoke handler(view) if registered, else log warning
      * 3. Continue until buffer exhausted
@@ -218,7 +220,7 @@ private:
     /**
      * \brief Extract tCode from packet header first byte (Phase 2.2: std::span).
      *
-     * \param header Packet header bytes (big-endian)
+     * \param header Packet header bytes in OHCI AR DMA memory order
      * \return tCode value (4 bits, range 0-15)
      *
      * **IEEE 1394 Wire Format**
@@ -236,8 +238,8 @@ private:
     /**
      * \brief Extract source ID from packet header (Phase 2.2: std::span).
      *
-     * \param header Packet header bytes (big-endian)
-     * \return Source node ID (16 bits, big-endian)
+     * \param header Packet header bytes in OHCI AR DMA memory order
+     * \return Source node ID (16 bits, host order)
      *
      * **IEEE 1394 Wire Format**
      * sourceID is at bytes [4-5] of async packet header (OHCI Figure 8-7).
@@ -247,8 +249,8 @@ private:
     /**
      * \brief Extract destination ID from packet header (Phase 2.2: std::span).
      *
-     * \param header Packet header bytes (big-endian)
-     * \return Destination node ID (16 bits, big-endian)
+     * \param header Packet header bytes in OHCI AR DMA memory order
+     * \return Destination node ID (16 bits, host order)
      *
      * **IEEE 1394 Wire Format**
      * destinationID is at bytes [0-1] of async packet header.
@@ -258,7 +260,7 @@ private:
     /**
      * \brief Extract transaction label from packet header (Phase 2.2: std::span).
      *
-     * \param header Packet header bytes (big-endian)
+     * \param header Packet header bytes in OHCI AR DMA memory order
      * \return tLabel value (6 bits, range 0-63)
      *
      * **IEEE 1394 Wire Format**

--- a/ASFWDriver/Async/Track/TransactionCompletionHandler.hpp
+++ b/ASFWDriver/Async/Track/TransactionCompletionHandler.hpp
@@ -376,7 +376,9 @@ public:
 
         Transaction* txn = txnMgr_->FindByMatchKey(key);
         if (!txn) {
-            ASFW_LOG(Async, "⚠️  OnARResponse: No transaction for key");
+            ASFW_LOG(Async,
+                     "OnARResponse: no transaction for key node=0x%04X gen=%u tLabel=%u",
+                     key.node.value, key.generation.value, key.label.value);
             return;
         }
 

--- a/ASFWDriver/Bus/BusManager.cpp
+++ b/ASFWDriver/Bus/BusManager.cpp
@@ -43,6 +43,23 @@ namespace {
     });
 }
 
+[[nodiscard]] bool IsTwoNodeLocalRootTopology(const TopologySnapshot& topology) {
+    if (!topology.localNodeId.has_value() || !topology.rootNodeId.has_value()) {
+        return false;
+    }
+    if (*topology.localNodeId != *topology.rootNodeId) {
+        return false;
+    }
+
+    uint8_t remoteActiveNodes = 0;
+    for (const auto& node : topology.nodes) {
+        if (node.linkActive && node.nodeId != *topology.localNodeId) {
+            ++remoteActiveNodes;
+        }
+    }
+    return remoteActiveNodes == 1U;
+}
+
 } // namespace
 
 // ============================================================================
@@ -264,6 +281,12 @@ std::optional<BusManager::GapDecision> BusManager::EvaluateGapPolicy(
     }
 
     if (AnyObservedGapNeedsRetool(observedGaps, gapState_.lastConfirmedGap, targetGap)) {
+        if (IsTwoNodeLocalRootTopology(topology)) {
+            ASFW_LOG(BusManager,
+                     "Skipping target gap optimization for two-node local-root topology");
+            return std::nullopt;
+        }
+
         ASFW_LOG(BusManager, "Retooling gap count to %u (confirmed=%u)", targetGap,
                  gapState_.lastConfirmedGap);
         return GapDecision{targetGap, GapDecisionReason::TargetGap};

--- a/ASFWDriver/Bus/BusManager.hpp
+++ b/ASFWDriver/Bus/BusManager.hpp
@@ -49,8 +49,11 @@ public:
      * @brief Gap-reset state tracked across generations.
      *
      * `lastConfirmedGap` is the most recent stable packet-0 gap observed on an
-     * accepted topology. `inFlight` is populated only after the coordinator has
-     * successfully dispatched a corrective reset carrying a gap update.
+     * accepted topology. It remains `0xFF` until the first stable topology is
+     * accepted so the optimizer can distinguish "unknown previous gap" from a
+     * real confirmed `gap_count = 63`. `inFlight` is populated only after the
+     * coordinator has successfully dispatched a corrective reset carrying a gap
+     * update.
      */
     struct GapState {
         struct InFlightReset {
@@ -58,7 +61,7 @@ public:
             GapDecisionReason reason{GapDecisionReason::MismatchForce63};
         };
 
-        uint8_t lastConfirmedGap{0x3F};
+        uint8_t lastConfirmedGap{0xFF};
         std::optional<InFlightReset> inFlight;
     };
 
@@ -73,7 +76,7 @@ public:
         RootPolicy rootPolicy = RootPolicy::Delegate;
         uint8_t forcedRootNodeID = 0xFF;
         bool delegateCycleMaster = true;
-        bool enableGapOptimization = false;
+        bool enableGapOptimization = true;
         uint8_t forcedGapCount = 0;
         bool forcedGapFlag = false;
     };

--- a/ASFWDriver/Bus/BusResetCoordinator.cpp
+++ b/ASFWDriver/Bus/BusResetCoordinator.cpp
@@ -61,7 +61,10 @@ void LogStateTransition(ASFW::Driver::BusResetCoordinator::State previousState,
 
 namespace ASFW::Driver {
 
-BusResetCoordinator::BusResetCoordinator() = default;
+std::atomic<uint32_t> BusResetCoordinator::nextDiagnosticsInstanceId_{1};
+
+BusResetCoordinator::BusResetCoordinator()
+    : diagnosticsInstanceId_(nextDiagnosticsInstanceId_.fetch_add(1, std::memory_order_relaxed)) {}
 BusResetCoordinator::~BusResetCoordinator() = default;
 
 void BusResetCoordinator::Initialize(HardwareInterface* hw, OSSharedPtr<IODispatchQueue> workQueue,
@@ -104,6 +107,7 @@ void BusResetCoordinator::OnIrq(uint32_t intEvent, uint64_t timestamp) {
         cycle_.timing.lastBusResetEdgeNs = timestamp;
         pendingBusResetEdge_ = true;
         relevant = true;
+        ++busResetIrqCount_;
         LogBusResetEdgeLatched(timestamp);
     }
 
@@ -132,6 +136,23 @@ void BusResetCoordinator::OnIrq(uint32_t intEvent, uint64_t timestamp) {
 
 void BusResetCoordinator::BindCallbacks(TopologyReadyCallback onTopology) {
     topologyCallback_ = std::move(onTopology);
+}
+
+BusResetCoordinator::ResetDiagnostics BusResetCoordinator::Diagnostics() const {
+    return ResetDiagnostics{
+        .driverStartId = diagnosticsInstanceId_,
+        .resetEpoch = resetEpoch_,
+        .manualResetEpoch = manualResetEpoch_,
+        .softwareResetIssuedCount = softwareResetIssuedCount_,
+        .busResetIrqCount = busResetIrqCount_,
+        .lastAcceptedGeneration = lastAcceptedGeneration_,
+        .lastTopologyNodeCount = lastTopologyNodeCount_,
+        .readyForDiscoveryFailureBits = readyForDiscoveryFailureBits_,
+        .lastRecoveryReasonCode = lastRecoveryReasonCode_,
+        .lastResetKind = static_cast<uint8_t>(lastResetKind_),
+        .recoveryResetAttempts = manualRecoveryResetAttempts_,
+        .discoveryCallbackCount = discoveryCallbackCount_,
+    };
 }
 
 uint64_t BusResetCoordinator::MonotonicNow() {

--- a/ASFWDriver/Bus/BusResetCoordinator.hpp
+++ b/ASFWDriver/Bus/BusResetCoordinator.hpp
@@ -110,6 +110,33 @@ class BusResetCoordinator {
     const char* StateString() const;
     static const char* StateString(State state);
 
+    enum class RecoveryReasonCode : uint8_t {
+        None = 0,
+        SelfIDDecodeFailed = 1,
+        SelfIDTimeout = 2,
+        TopologyBuildFailed = 3,
+        SoftwareResetDispatchFailed = 4,
+        ReadyForDiscoveryFailed = 5,
+        ManualResetWatchdog = 6,
+    };
+
+    struct ResetDiagnostics {
+        uint32_t driverStartId{0};
+        uint32_t resetEpoch{0};
+        uint32_t manualResetEpoch{0};
+        uint32_t softwareResetIssuedCount{0};
+        uint32_t busResetIrqCount{0};
+        uint32_t lastAcceptedGeneration{0};
+        uint8_t lastTopologyNodeCount{0};
+        uint8_t readyForDiscoveryFailureBits{0};
+        RecoveryReasonCode lastRecoveryReasonCode{RecoveryReasonCode::None};
+        uint8_t lastResetKind{0};
+        uint8_t recoveryResetAttempts{0};
+        uint8_t discoveryCallbackCount{0};
+    };
+
+    ResetDiagnostics Diagnostics() const;
+
     /**
      * Reset delegation retry counter (Linux pattern for emergency bypass).
      *
@@ -236,13 +263,16 @@ class BusResetCoordinator {
     bool DispatchSoftwareReset(const ResetRequest& request);
     void ClearDelegationAttempt();
     void RecordRecoveryReason(std::string reason);
+    void RecordRecoveryReasonCode(RecoveryReasonCode code);
+    void ScheduleManualResetWatchdog(uint32_t manualEpoch, uint32_t resetEpoch);
+    void MaybeRecoverMissingManualResetIrq(uint32_t manualEpoch, uint32_t resetEpoch);
 
     bool G_ATInactive();
     bool HasSelfIDCompletion() const;
     bool CanAttemptSelfIDDecode() const;
     bool G_NodeIDValid() const;
 
-    bool ReadyForDiscovery(Discovery::Generation gen) const;
+    bool ReadyForDiscovery(Discovery::Generation gen);
 
     static uint64_t MonotonicNow();
 
@@ -290,6 +320,20 @@ class BusResetCoordinator {
     static constexpr uint32_t kMaxDiscoveryDelayMs = 10000; // 10s cap
     uint32_t currentDiscoveryDelayMs_{0};
     bool previousScanHadBusyNodes_{false};
+
+    static std::atomic<uint32_t> nextDiagnosticsInstanceId_;
+    uint32_t diagnosticsInstanceId_{0};
+    uint32_t resetEpoch_{0};
+    uint32_t manualResetEpoch_{0};
+    uint32_t softwareResetIssuedCount_{0};
+    uint32_t busResetIrqCount_{0};
+    uint32_t lastAcceptedGeneration_{0};
+    uint8_t lastTopologyNodeCount_{0};
+    uint8_t readyForDiscoveryFailureBits_{0};
+    RecoveryReasonCode lastRecoveryReasonCode_{RecoveryReasonCode::None};
+    ResetRequestKind lastResetKind_{ResetRequestKind::Recovery};
+    uint8_t manualRecoveryResetAttempts_{0};
+    uint8_t discoveryCallbackCount_{0};
 };
 
 } // namespace ASFW::Driver

--- a/ASFWDriver/Bus/BusResetCoordinator.hpp
+++ b/ASFWDriver/Bus/BusResetCoordinator.hpp
@@ -110,6 +110,9 @@ class BusResetCoordinator {
     const char* StateString() const;
     static const char* StateString(State state);
 
+    // ASFW-defined diagnostics codes for BusResetCoordinator recovery paths.
+    // These are not OHCI/IEEE 1394 wire or register values. They label the
+    // coordinator FSM branch that most recently recorded a recovery trigger.
     enum class RecoveryReasonCode : uint8_t {
         None = 0,
         SelfIDDecodeFailed = 1,

--- a/ASFWDriver/Bus/BusResetCoordinatorActions.cpp
+++ b/ASFWDriver/Bus/BusResetCoordinatorActions.cpp
@@ -1,6 +1,11 @@
 #include "BusResetCoordinator.hpp"
 
+#include <algorithm>
 #include <cstring>
+
+#ifndef ASFW_HOST_TEST
+#include <DriverKit/IOLib.h>
+#endif
 
 #include "../Async/Interfaces/IAsyncControllerPort.hpp"
 #include "../ConfigROM/ConfigROMStager.hpp"
@@ -17,6 +22,8 @@ namespace {
 
 constexpr uint64_t kRepeatedResetHoldoffNs = 2'000'000'000ULL;
 constexpr uint8_t kConservativeMismatchGapCount = 0x3FU;
+constexpr uint32_t kManualResetWatchdogMs = 500;
+constexpr uint8_t kMaxManualRecoveryResetAttempts = 1;
 
 void MergePhyConfig(ASFW::Driver::BusManager::PhyConfigCommand& base,
                     const ASFW::Driver::BusManager::PhyConfigCommand& addition) {
@@ -162,6 +169,7 @@ bool BusResetCoordinator::BuildTopology() {
     if (!snapshot) {
         RecordRecoveryReason(std::string{"Topology build failed: "} +
                              TopologyManager::TopologyBuildErrorCodeString(snapshot.error().code));
+        RecordRecoveryReasonCode(RecoveryReasonCode::TopologyBuildFailed);
         cycle_.acceptedTopology.reset();
         RequestSoftwareReset({ResetRequestKind::Recovery, ResetFlavor::Short, std::nullopt,
                               "Invalid Self-ID topology"});
@@ -172,6 +180,9 @@ bool BusResetCoordinator::BuildTopology() {
     }
 
     cycle_.acceptedTopology = *snapshot;
+    lastAcceptedGeneration_ = snapshot->generation;
+    lastTopologyNodeCount_ =
+        static_cast<uint8_t>(std::min<std::size_t>(snapshot->nodes.size(), 0xFFU));
     cycle_.timing.lastSelfIdCompletionNs = timestamp;
     cycle_.timing.softwareResetBlockedUntilNs = timestamp + kRepeatedResetHoldoffNs;
 
@@ -465,6 +476,7 @@ bool BusResetCoordinator::DispatchSoftwareReset(const ResetRequest& request) {
     ASFW_LOG(BusReset, "Issuing %{public}s %{public}s software reset (%{public}s)",
              resetKindString(request.kind), resetFlavorString(request.flavor),
              request.reason.c_str());
+    lastResetKind_ = request.kind;
 
     if (request.phyConfig.has_value()) {
         const auto& command = *request.phyConfig;
@@ -487,6 +499,7 @@ bool BusResetCoordinator::DispatchSoftwareReset(const ResetRequest& request) {
 
     if (!hardware_->InitiateBusReset(request.flavor == ResetFlavor::Short)) {
         RecordRecoveryReason(std::string{"Software reset dispatch failed: "} + request.reason);
+        RecordRecoveryReasonCode(RecoveryReasonCode::SoftwareResetDispatchFailed);
         if (request.gapDecisionReason.has_value() && busManager_ != nullptr) {
             busManager_->ClearInFlightGapReset();
         }
@@ -499,6 +512,11 @@ bool BusResetCoordinator::DispatchSoftwareReset(const ResetRequest& request) {
     if (request.gapDecisionReason.has_value() && request.phyConfig.has_value() &&
         request.phyConfig->gapCount.has_value() && (busManager_ != nullptr)) {
         busManager_->NoteGapResetIssued(*request.phyConfig->gapCount, *request.gapDecisionReason);
+    }
+
+    ++softwareResetIssuedCount_;
+    if (request.kind == ResetRequestKind::ManualBusManager) {
+        ScheduleManualResetWatchdog(manualResetEpoch_, resetEpoch_);
     }
 
     return true;
@@ -516,7 +534,58 @@ void BusResetCoordinator::RecordRecoveryReason(std::string reason) {
     metrics_.lastFailureReason = *cycle_.recoveryReason;
 }
 
+void BusResetCoordinator::RecordRecoveryReasonCode(RecoveryReasonCode code) {
+    lastRecoveryReasonCode_ = code;
+}
+
+void BusResetCoordinator::ScheduleManualResetWatchdog(uint32_t manualEpoch, uint32_t resetEpoch) {
+    if (workQueue_.get() == nullptr) {
+        return;
+    }
+
+#ifdef ASFW_HOST_TEST
+    if (workQueue_->UsesManualDispatchForTesting()) {
+        workQueue_->DispatchAsyncAfter(static_cast<uint64_t>(kManualResetWatchdogMs) * 1'000'000ULL,
+                                       ^{
+                                         MaybeRecoverMissingManualResetIrq(manualEpoch, resetEpoch);
+                                       });
+        return;
+    }
+#endif
+
+    workQueue_->DispatchAsync(^{
+#ifdef ASFW_HOST_TEST
+      (void)manualEpoch;
+      (void)resetEpoch;
+#else
+      IOSleep(kManualResetWatchdogMs);
+      MaybeRecoverMissingManualResetIrq(manualEpoch, resetEpoch);
+#endif
+    });
+}
+
+void BusResetCoordinator::MaybeRecoverMissingManualResetIrq(uint32_t manualEpoch,
+                                                            uint32_t resetEpoch) {
+    if (manualEpoch != manualResetEpoch_ || resetEpoch != resetEpoch_) {
+        return;
+    }
+
+    if (manualRecoveryResetAttempts_ >= kMaxManualRecoveryResetAttempts) {
+        RecordRecoveryReason("Manual reset watchdog reached bounded recovery limit");
+        RecordRecoveryReasonCode(RecoveryReasonCode::ManualResetWatchdog);
+        return;
+    }
+
+    ++manualRecoveryResetAttempts_;
+    RecordRecoveryReason("Manual reset watchdog did not observe busReset IRQ/topology");
+    RecordRecoveryReasonCode(RecoveryReasonCode::ManualResetWatchdog);
+    RequestSoftwareReset({ResetRequestKind::Recovery, ResetFlavor::Short, std::nullopt,
+                          "Manual reset watchdog recovery", std::nullopt});
+}
+
 void BusResetCoordinator::RequestUserReset(bool shortReset) {
+    ++manualResetEpoch_;
+    manualRecoveryResetAttempts_ = 0;
     RequestSoftwareReset({ResetRequestKind::ManualBusManager,
                           shortReset ? ResetFlavor::Short : ResetFlavor::Long, std::nullopt,
                           "UserClient-initiated", std::nullopt});

--- a/ASFWDriver/Bus/BusResetCoordinatorDiscoveryDelay.cpp
+++ b/ASFWDriver/Bus/BusResetCoordinatorDiscoveryDelay.cpp
@@ -6,13 +6,32 @@
 
 namespace ASFW::Driver {
 
-bool BusResetCoordinator::ReadyForDiscovery(Discovery::Generation gen) const {
+bool BusResetCoordinator::ReadyForDiscovery(Discovery::Generation gen) {
     const bool nodeValid = G_NodeIDValid();
     const bool genMatch = (gen == lastGeneration_);
     const bool hasTopo = cycle_.acceptedTopology.has_value();
     const bool ready = nodeValid && filtersEnabled_ && atArmed_ && hasTopo && genMatch;
 
+    uint8_t failureBits = 0;
+    if (!nodeValid) {
+        failureBits |= 1U << 0U;
+    }
+    if (!filtersEnabled_) {
+        failureBits |= 1U << 1U;
+    }
+    if (!atArmed_) {
+        failureBits |= 1U << 2U;
+    }
+    if (!hasTopo) {
+        failureBits |= 1U << 3U;
+    }
+    if (!genMatch) {
+        failureBits |= 1U << 4U;
+    }
+    readyForDiscoveryFailureBits_ = failureBits;
+
     if (!ready) {
+        RecordRecoveryReasonCode(RecoveryReasonCode::ReadyForDiscoveryFailed);
         ASFW_LOG(BusReset,
                  "ReadyForDiscovery(gen=%u): NOT READY — nodeValid=%d filters=%d at=%d "
                  "topo=%d genMatch=%d(last=%u)",

--- a/ASFWDriver/Bus/BusResetCoordinatorFSM.cpp
+++ b/ASFWDriver/Bus/BusResetCoordinatorFSM.cpp
@@ -1,9 +1,8 @@
 #include "BusResetCoordinator.hpp"
 
-#ifdef ASFW_HOST_TEST
-#include <chrono>
-#include <thread>
-#else
+#include <algorithm>
+
+#ifndef ASFW_HOST_TEST
 #include <DriverKit/IOLib.h>
 #endif
 
@@ -18,6 +17,7 @@ namespace {
 
 constexpr uint32_t kDeferredPollMs = 1;
 constexpr uint32_t kSelfIDTimeoutMs = 1000;
+constexpr uint32_t kAppleScanBusDelayMs = 100;
 
 } // namespace
 
@@ -30,6 +30,8 @@ void BusResetCoordinator::BeginNewResetCycle() {
     filtersEnabled_ = false;
     atArmed_ = false;
     cycle_.ResetForNewEdge();
+    ++resetEpoch_;
+    readyForDiscoveryFailureBits_ = 0;
 
     if ((romScanner_ != nullptr) && (lastGeneration_.value > 0U)) {
         ++metrics_.abortCount;
@@ -75,6 +77,7 @@ BusResetCoordinator::StepResult BusResetCoordinator::StepWaitingSelfID() {
         const bool decoded = DecodeSelfID();
         ClearConsumedSelfIDInterrupts();
         if (!decoded) {
+            RecordRecoveryReasonCode(RecoveryReasonCode::SelfIDDecodeFailed);
             RequestSoftwareReset(
                 {ResetRequestKind::Recovery, ResetFlavor::Short, std::nullopt,
                  "Self-ID decode failed"});
@@ -86,6 +89,7 @@ BusResetCoordinator::StepResult BusResetCoordinator::StepWaitingSelfID() {
     const uint64_t waitedNs = MonotonicNow() - stateEntryTime_;
     if (waitedNs >= static_cast<uint64_t>(kSelfIDTimeoutMs) * 1'000'000ULL) {
         RecordRecoveryReason("Self-ID timeout");
+        RecordRecoveryReasonCode(RecoveryReasonCode::SelfIDTimeout);
         ClearConsumedSelfIDInterrupts();
         RequestSoftwareReset(
             {ResetRequestKind::Recovery, ResetFlavor::Short, std::nullopt, "Self-ID timeout"});
@@ -199,28 +203,31 @@ BusResetCoordinator::StepResult BusResetCoordinator::StepComplete() {
     if (topologyCallback_ && cycle_.acceptedTopology.has_value() && (workQueue_.get() != nullptr)) {
         auto topo = *cycle_.acceptedTopology;
         const Discovery::Generation generation{topo.generation};
+        uint32_t delayMs = kAppleScanBusDelayMs;
 
         if (previousScanHadBusyNodes_ && currentDiscoveryDelayMs_ > 0U) {
-            const uint32_t delayMs = currentDiscoveryDelayMs_;
-            ASFW_LOG(BusReset, "Discovery delayed %ums for generation %u", delayMs,
-                     generation.value);
-            workQueue_->DispatchAsync(^{
-#ifdef ASFW_HOST_TEST
-              std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
-#else
-              IOSleep(delayMs);
-#endif
-              if (ReadyForDiscovery(generation)) {
-                  topologyCallback_(topo);
-              }
-            });
-        } else {
-            workQueue_->DispatchAsync(^{
-              if (ReadyForDiscovery(generation)) {
-                  topologyCallback_(topo);
-              }
-            });
+            delayMs = std::max(delayMs, currentDiscoveryDelayMs_);
         }
+
+        ASFW_LOG(BusReset, "Discovery delayed %ums for generation %u", delayMs, generation.value);
+#ifdef ASFW_HOST_TEST
+        workQueue_->DispatchAsyncAfter(static_cast<uint64_t>(delayMs) * 1'000'000ULL, ^{
+          if (ReadyForDiscovery(generation)) {
+              discoveryCallbackCount_ = static_cast<uint8_t>(
+                  std::min<uint32_t>(static_cast<uint32_t>(discoveryCallbackCount_) + 1U, 0xFFU));
+              topologyCallback_(topo);
+          }
+        });
+#else
+        workQueue_->DispatchAsync(^{
+          IOSleep(delayMs);
+          if (ReadyForDiscovery(generation)) {
+              discoveryCallbackCount_ = static_cast<uint8_t>(
+                  std::min<uint32_t>(static_cast<uint32_t>(discoveryCallbackCount_) + 1U, 0xFFU));
+              topologyCallback_(topo);
+          }
+        });
+#endif
     }
 
     return StepResult::Finish;

--- a/ASFWDriver/Common/FWCommon.hpp
+++ b/ASFWDriver/Common/FWCommon.hpp
@@ -388,7 +388,10 @@ inline constexpr uint8_t kUnitDependentInfo = 0x14;
 inline constexpr uint8_t kUnitLocation = 0x15;
 inline constexpr uint8_t kUnitPollMask = 0x16;
 inline constexpr uint8_t kModelId = 0x17;
-inline constexpr uint8_t kGeneration = 0x38; // Apple-specific
+inline constexpr uint8_t kGeneration = 0x38; // Apple-specific (root dir, immediate)
+inline constexpr uint8_t kManagementAgentOffset = 0x38; // SBP-2 (unit dir, CSR offset type=1)
+inline constexpr uint8_t kUnitCharacteristics   = 0x39; // SBP-2 (unit dir, immediate)
+inline constexpr uint8_t kFastStart             = 0x3A; // SBP-2 (unit dir, leaf)
 } // namespace ConfigKey
 
 // ============================================================================

--- a/ASFWDriver/ConfigROM/Parse/ConfigROMParser.cpp
+++ b/ASFWDriver/ConfigROM/Parse/ConfigROMParser.cpp
@@ -140,12 +140,27 @@ void ConfigROMParser::AppendRecognizedEntry(std::vector<RomEntry>& entries, uint
 
     case 0x38: // Legacy non-standard fallback for Management_Agent_Offset
         if (keyType == EntryType::kCSROffset) {
-            entries.push_back(RomEntry{.key = CfgKey::Management_Agent_Offset,
-                                       .value = value,
-                                       .entryType = keyType});
+            entries.push_back(
+                RomEntry{.key = CfgKey::Management_Agent_Offset, .value = value, .entryType = keyType});
         }
         return;
 
+    case 0x39: // Unit_Characteristics (SBP-2) — immediate
+        if (keyType == EntryType::kImmediate) {
+            entries.push_back(
+                RomEntry{.key = CfgKey::Unit_Characteristics, .value = value, .entryType = keyType});
+        }
+        return;
+
+    case 0x3A: // Fast_Start (SBP-2) — leaf
+        if (keyType == EntryType::kLeaf && targetOffsetQuadlets != 0) {
+            entries.push_back(
+                RomEntry{.key = CfgKey::Fast_Start,
+                         .value = value,
+                         .entryType = keyType,
+                         .leafOffsetQuadlets = targetOffsetQuadlets});
+        }
+        return;
     default:
         return;
     }

--- a/ASFWDriver/ConfigROM/Remote/ROMScanNodeStateMachine.hpp
+++ b/ASFWDriver/ConfigROM/Remote/ROMScanNodeStateMachine.hpp
@@ -10,6 +10,7 @@ class ROMScanNodeStateMachine {
     enum class State : uint8_t {
         Idle,
         ReadingBIB,
+        WaitingRepublish,
         VerifyingIRM_Read,
         VerifyingIRM_Lock,
         ReadingRootDir,
@@ -34,12 +35,19 @@ class ROMScanNodeStateMachine {
     [[nodiscard]] State CurrentState() const { return state_; }
     [[nodiscard]] FwSpeed CurrentSpeed() const { return currentSpeed_; }
     [[nodiscard]] uint8_t RetriesLeft() const { return retriesLeft_; }
+    [[nodiscard]] uint8_t SlowPublishRetriesLeft() const { return slowPublishRetriesLeft_; }
 
     void SetCurrentSpeed(FwSpeed speed) { currentSpeed_ = speed; }
     void SetRetriesLeft(uint8_t retries) { retriesLeft_ = retries; }
+    void SetSlowPublishRetriesLeft(uint8_t retries) { slowPublishRetriesLeft_ = retries; }
     void DecrementRetries() {
         if (retriesLeft_ > 0) {
             --retriesLeft_;
+        }
+    }
+    void DecrementSlowPublishRetries() {
+        if (slowPublishRetriesLeft_ > 0) {
+            --slowPublishRetriesLeft_;
         }
     }
 
@@ -71,15 +79,18 @@ class ROMScanNodeStateMachine {
         case Idle:
             return next == ReadingBIB || next == Failed;
         case ReadingBIB:
-            return next == VerifyingIRM_Read || next == ReadingRootDir || next == Complete ||
-                   next == Idle || next == Failed;
+            return next == WaitingRepublish || next == VerifyingIRM_Read ||
+                   next == ReadingRootDir || next == Complete || next == Idle || next == Failed;
+        case WaitingRepublish:
+            return next == Idle || next == ReadingRootDir || next == Failed;
         case VerifyingIRM_Read:
             return next == VerifyingIRM_Lock || next == ReadingRootDir || next == Complete ||
                    next == Failed;
         case VerifyingIRM_Lock:
             return next == ReadingRootDir || next == Complete || next == Failed;
         case ReadingRootDir:
-            return next == ReadingDetails || next == Complete || next == Failed || next == Idle;
+            return next == WaitingRepublish || next == ReadingDetails || next == Complete ||
+                   next == Failed || next == Idle;
         case ReadingDetails:
             return next == Complete || next == Failed;
         case Complete:
@@ -115,6 +126,7 @@ class ROMScanNodeStateMachine {
         irmIsBad_ = false;
         irmBitBucket_ = 0xFFFFFFFF;
         bibInProgress_ = false;
+        slowPublishRetriesLeft_ = 0;
     }
 
   private:
@@ -131,6 +143,7 @@ class ROMScanNodeStateMachine {
     uint32_t irmBitBucket_{0xFFFFFFFF};
 
     bool bibInProgress_{false};
+    uint8_t slowPublishRetriesLeft_{0};
 };
 
 } // namespace ASFW::Discovery

--- a/ASFWDriver/ConfigROM/Remote/ROMScanSession.cpp
+++ b/ASFWDriver/ConfigROM/Remote/ROMScanSession.cpp
@@ -15,6 +15,30 @@ namespace ASFW::Discovery {
 
 namespace {
 
+constexpr uint32_t kNikonOui = 0x0090B5;
+constexpr uint8_t kNikonSlowPublishRetryBudget = 4;
+constexpr uint64_t kNikonSlowPublishDelayNs = 500ULL * 1'000'000ULL;
+
+uint32_t SpeedMbps(FwSpeed speed) {
+    return 100u << static_cast<uint8_t>(speed);
+}
+
+[[nodiscard]] constexpr uint32_t ExtractOui(uint64_t guid) noexcept {
+    return static_cast<uint32_t>((guid >> 40U) & 0xFFFFFFULL);
+}
+
+[[nodiscard]] constexpr bool IsNikonGuid(uint64_t guid) noexcept {
+    return ExtractOui(guid) == kNikonOui;
+}
+
+[[nodiscard]] constexpr bool IsMinimalROM(const BusInfoBlock& bib) noexcept {
+    return bib.crcLength <= bib.busInfoLength;
+}
+
+[[nodiscard]] constexpr bool IsNikonMinimalROM(const BusInfoBlock& bib) noexcept {
+    return IsMinimalROM(bib) && IsNikonGuid(bib.guid);
+}
+
 void LogBIBReadFailed(uint8_t nodeId) {
     ASFW_LOG(ConfigROM, "ROMScanSession: Node %u BIB read failed, retrying", nodeId);
 }
@@ -37,6 +61,32 @@ void LogBIBCRCMismatch(uint8_t nodeId, uint16_t computed, uint16_t expected) {
     ASFW_LOG_V1(ConfigROM,
                 "ROMScanSession: Node %u BIB CRC mismatch (computed=0x%04x expected=0x%04x)",
                 nodeId, computed, expected);
+}
+
+void LogNikonSlowPublishRetry(uint8_t nodeId, uint8_t retriesLeft) {
+    ASFW_LOG(
+        ConfigROM,
+        "ROMScanSession: Node %u Nikon minimal-ROM compatibility retry scheduled (remaining=%u)",
+        nodeId, retriesLeft);
+}
+
+void LogNikonRootDirProbe(uint8_t nodeId, uint32_t offsetBytes) {
+    ASFW_LOG(ConfigROM,
+             "ROMScanSession: Node %u Nikon minimal-ROM compatibility probing root dir "
+             "(offset=0x%x)",
+             nodeId, offsetBytes);
+}
+
+void LogNikonRootDirProbeFailed(uint8_t nodeId, Async::AsyncStatus status, uint8_t retriesLeft) {
+    ASFW_LOG(ConfigROM,
+             "ROMScanSession: Node %u Nikon root dir probe failed (status=%u, remaining=%u)",
+             nodeId, static_cast<uint32_t>(status), retriesLeft);
+}
+
+void LogNikonRootDirProbeExhausted(uint8_t nodeId) {
+    ASFW_LOG(ConfigROM,
+             "ROMScanSession: Node %u Nikon root dir probe exhausted, completing as minimal ROM",
+             nodeId);
 }
 
 } // namespace
@@ -96,6 +146,8 @@ void ROMScanSession::Start(ROMScanRequest request, ScanCompletionCallback comple
                 session->nodeScans_.emplace_back(node.nodeId, session->gen_,
                                                  session->params_.startSpeed,
                                                  session->params_.perStepRetries);
+                session->nodeScans_.back().SetSlowPublishRetriesLeft(
+                    kNikonSlowPublishRetryBudget);
             }
         } else {
             auto targets = std::move(request.targetNodes);
@@ -109,6 +161,8 @@ void ROMScanSession::Start(ROMScanRequest request, ScanCompletionCallback comple
                 }
                 session->nodeScans_.emplace_back(nodeId, session->gen_, session->params_.startSpeed,
                                                  session->params_.perStepRetries);
+                session->nodeScans_.back().SetSlowPublishRetriesLeft(
+                    kNikonSlowPublishRetryBudget);
             }
         }
 
@@ -153,6 +207,50 @@ void ROMScanSession::DispatchAsync(std::function<void()> work) {
     queue->DispatchAsync(^{
       (*captured)();
     });
+}
+
+void ROMScanSession::DispatchDelayed(std::function<void()> work, uint64_t delayNs) {
+    if (!work) {
+        return;
+    }
+
+    if (!dispatchQueue_) {
+#ifdef ASFW_HOST_TEST
+        Post(std::move(work));
+        return;
+#else
+        const uint64_t delayMs = delayNs / 1'000'000ULL;
+        const uint64_t trailingNs = delayNs % 1'000'000ULL;
+        Post([delayMs, trailingNs, work = std::move(work)]() mutable {
+            if (delayMs > 0) {
+                IOSleep(delayMs);
+            }
+            if (trailingNs > 0) {
+                IODelay((trailingNs + 999ULL) / 1000ULL);
+            }
+            work();
+        });
+        return;
+#endif
+    }
+
+#ifdef ASFW_HOST_TEST
+    dispatchQueue_->DispatchAsyncAfter(delayNs, std::move(work));
+#else
+    const uint64_t delayMs = delayNs / 1'000'000ULL;
+    const uint64_t trailingNs = delayNs % 1'000'000ULL;
+    auto queue = dispatchQueue_;
+    auto captured = std::make_shared<std::function<void()>>(std::move(work));
+    queue->DispatchAsync(^{
+      if (delayMs > 0) {
+          IOSleep(delayMs);
+      }
+      if (trailingNs > 0) {
+          IODelay((trailingNs + 999ULL) / 1000ULL);
+      }
+      (*captured)();
+    });
+#endif
 }
 
 void ROMScanSession::Post(std::function<void()> task) {
@@ -280,17 +378,16 @@ void ROMScanSession::RetryWithFallback(ROMScanNodeStateMachine& node) {
 
     switch (decision) {
     case RetryBackoffPolicy::Decision::RetrySameSpeed:
-        ASFW_LOG_V2(ConfigROM, "ROMScanSession: Node %u retry at S%u00 (retries left=%u)",
-                    node.NodeId(), static_cast<uint32_t>(node.CurrentSpeed()) + 1,
+        ASFW_LOG_V2(ConfigROM, "ROMScanSession: Node %u retry at S%u (retries left=%u)",
+                    node.NodeId(), SpeedMbps(node.CurrentSpeed()),
                     node.RetriesLeft());
         break;
     case RetryBackoffPolicy::Decision::RetryWithFallback: {
         const auto newSpeed = node.CurrentSpeed();
         (void)newSpeed;
         ASFW_LOG_V2(ConfigROM,
-                    "ROMScanSession: Node %u speed fallback S%u00 -> S%u00, retries reset",
-                    node.NodeId(), static_cast<uint32_t>(oldSpeed) + 1,
-                    static_cast<uint32_t>(newSpeed) + 1);
+                    "ROMScanSession: Node %u speed fallback S%u -> S%u, retries reset",
+                    node.NodeId(), SpeedMbps(oldSpeed), SpeedMbps(newSpeed));
         break;
     }
     case RetryBackoffPolicy::Decision::FailedExhausted:
@@ -372,22 +469,83 @@ void ROMScanSession::ContinueAfterBIBSuccess(ROMScanNodeStateMachine& node, uint
         return;
     }
 
-    if (node.ROM().bib.crcLength <= node.ROM().bib.busInfoLength) {
-        if (!TransitionNodeState(node, ROMScanNodeStateMachine::State::Complete,
-                                 "BIB minimal ROM complete")) {
-            Pump();
+    if (IsMinimalROM(node.ROM().bib)) {
+        if (ShouldDelayMinimalROMCompletion(node)) {
+            ScheduleMinimalROMRetry(node);
             return;
         }
-        completedROMs_.push_back(std::move(node.MutableROM()));
-        Pump();
+
+        CompleteMinimalROM(node, "BIB minimal ROM complete");
         return;
     }
 
     StartRootDirRead(node);
 }
 
+bool ROMScanSession::ShouldDelayMinimalROMCompletion(const ROMScanNodeStateMachine& node) const {
+    if (!IsMinimalROM(node.ROM().bib)) {
+        return false;
+    }
+
+    if (node.SlowPublishRetriesLeft() == 0) {
+        return false;
+    }
+
+    return IsNikonMinimalROM(node.ROM().bib);
+}
+
+void ROMScanSession::ScheduleMinimalROMRetry(ROMScanNodeStateMachine& node) {
+    if (!TransitionNodeState(node, ROMScanNodeStateMachine::State::WaitingRepublish,
+                             "Nikon minimal ROM compatibility wait")) {
+        Pump();
+        return;
+    }
+
+    hadBusyNodes_ = true;
+    node.DecrementSlowPublishRetries();
+    LogNikonSlowPublishRetry(node.NodeId(), node.SlowPublishRetriesLeft());
+
+    const uint8_t nodeId = node.NodeId();
+    auto weakSelf = weak_from_this();
+    DispatchDelayed(
+        [weakSelf, nodeId]() {
+            if (auto self = weakSelf.lock(); self) {
+                self->DispatchAsync([self = std::move(self), nodeId]() {
+                    if (self->aborted_.load(std::memory_order_relaxed)) {
+                        return;
+                    }
+
+                    auto* nodePtr = self->FindNode(nodeId);
+                    if (nodePtr == nullptr) {
+                        return;
+                    }
+
+                    auto& delayedNode = *nodePtr;
+                    if (delayedNode.CurrentState() !=
+                        ROMScanNodeStateMachine::State::WaitingRepublish) {
+                        return;
+                    }
+
+                    self->StartRootDirRead(delayedNode);
+                });
+            }
+        },
+        kNikonSlowPublishDelayNs);
+}
+
+void ROMScanSession::CompleteMinimalROM(ROMScanNodeStateMachine& node, const char* reason) {
+    if (!TransitionNodeState(node, ROMScanNodeStateMachine::State::Complete, reason)) {
+        Pump();
+        return;
+    }
+
+    completedROMs_.push_back(std::move(node.MutableROM()));
+    Pump();
+}
+
 void ROMScanSession::StartRootDirRead(ROMScanNodeStateMachine& node) {
     const uint8_t nodeId = node.NodeId();
+    const uint32_t offsetBytes = ASFW::ConfigROM::RootDirStartBytes(node.ROM().bib);
 
     if (!TransitionNodeState(node, ROMScanNodeStateMachine::State::ReadingRootDir,
                              "BIB complete enter root dir read")) {
@@ -395,10 +553,13 @@ void ROMScanSession::StartRootDirRead(ROMScanNodeStateMachine& node) {
         return;
     }
 
+    if (IsNikonMinimalROM(node.ROM().bib)) {
+        LogNikonRootDirProbe(nodeId, offsetBytes);
+    }
+
     node.SetRetriesLeft(params_.perStepRetries);
     ++inflight_;
 
-    const uint32_t offsetBytes = ASFW::ConfigROM::RootDirStartBytes(node.ROM().bib);
     auto weakSelf = weak_from_this();
     reader_->ReadRootDirQuadlets(
         nodeId, gen_, node.CurrentSpeed(), offsetBytes, 0,
@@ -433,6 +594,18 @@ void ROMScanSession::HandleRootDirComplete(uint8_t nodeId, ROMReader::ReadResult
     auto& node = *nodePtr;
 
     if (!result.success || result.quadletsBE.empty()) {
+        if (ShouldDelayMinimalROMCompletion(node)) {
+            LogNikonRootDirProbeFailed(nodeId, result.status, node.SlowPublishRetriesLeft());
+            ScheduleMinimalROMRetry(node);
+            return;
+        }
+
+        if (IsNikonMinimalROM(node.ROM().bib)) {
+            LogNikonRootDirProbeExhausted(nodeId);
+            CompleteMinimalROM(node, "Nikon root dir probe exhausted");
+            return;
+        }
+
         ASFW_LOG(ConfigROM, "ROMScanSession: Node %u RootDir read failed - marking failed", nodeId);
         (void)TransitionNodeState(node, ROMScanNodeStateMachine::State::Failed,
                                   "RootDir read failed");

--- a/ASFWDriver/ConfigROM/Remote/ROMScanSession.hpp
+++ b/ASFWDriver/ConfigROM/Remote/ROMScanSession.hpp
@@ -59,6 +59,9 @@ class ROMScanSession final : public std::enable_shared_from_this<ROMScanSession>
     void StartBIBRead(ROMScanNodeStateMachine& node);
     void HandleBIBComplete(uint8_t nodeId, ROMReader::ReadResult result);
     void ContinueAfterBIBSuccess(ROMScanNodeStateMachine& node, uint8_t nodeId);
+    [[nodiscard]] bool ShouldDelayMinimalROMCompletion(const ROMScanNodeStateMachine& node) const;
+    void ScheduleMinimalROMRetry(ROMScanNodeStateMachine& node);
+    void CompleteMinimalROM(ROMScanNodeStateMachine& node, const char* reason);
 
     void StartIRMRead(ROMScanNodeStateMachine& node);
     void HandleIRMReadComplete(uint8_t nodeId, bool success, uint32_t valueHostOrder);
@@ -78,6 +81,7 @@ class ROMScanSession final : public std::enable_shared_from_this<ROMScanSession>
     void RetryWithFallback(ROMScanNodeStateMachine& node);
 
     void DispatchAsync(std::function<void()> work);
+    void DispatchDelayed(std::function<void()> work, uint64_t delayNs);
 
     Async::IFireWireBus& bus_;
     SpeedPolicy& speedPolicy_;

--- a/ASFWDriver/ConfigROM/Store/ConfigROMStore.cpp
+++ b/ASFWDriver/ConfigROM/Store/ConfigROMStore.cpp
@@ -9,6 +9,9 @@ namespace ASFW::Discovery {
 
 namespace {
 
+constexpr uint32_t kUnitSpecIdSBP2 = 0x00609E;
+constexpr uint32_t kUnitSwVersionSBP2 = 0x010483;
+
 class LockGuard {
   public:
     explicit LockGuard(IOLock* lock) noexcept : lock_(lock) {
@@ -29,6 +32,19 @@ class LockGuard {
   private:
     IOLock* lock_{nullptr};
 };
+
+[[nodiscard]] bool HasSBP2Unit(const ASFW::Discovery::ConfigROM& rom) noexcept {
+    for (const auto& unit : rom.unitDirectories) {
+        if (unit.unitSpecId == kUnitSpecIdSBP2 && unit.unitSwVersion == kUnitSwVersionSBP2) {
+            return true;
+        }
+    }
+    return false;
+}
+
+[[nodiscard]] bool HasParsedUnitProfile(const ASFW::Discovery::ConfigROM& rom) noexcept {
+    return !rom.unitDirectories.empty();
+}
 
 } // namespace
 
@@ -75,12 +91,27 @@ void ConfigROMStore::Insert(const ConfigROM& rom) {
     romsByGenNode_[key] = romCopy;
 
     auto it = romsByGuid_.find(romCopy.bib.guid);
-    if (it == romsByGuid_.end() || it->second.gen.value < romCopy.gen.value) {
+    const bool shouldUpdateGuid =
+        it == romsByGuid_.end() ||
+        (it->second.gen.value < romCopy.gen.value &&
+         (HasParsedUnitProfile(romCopy) || !HasParsedUnitProfile(it->second)));
+
+    if (shouldUpdateGuid) {
         romsByGuid_[romCopy.bib.guid] = romCopy;
 
-        ASFW_LOG_V2(ConfigROM, "ConfigROMStore::Insert: GUID=0x%016llx gen=%u node=%u state=%u",
+        ASFW_LOG_V2(ConfigROM,
+                    "ConfigROMStore::Insert: GUID=0x%016llx gen=%u node=%u state=%u "
+                    "rawQuadlets=%zu rootEntries=%zu unitDirs=%zu hasSBP2=%d",
                     romCopy.bib.guid, romCopy.gen.value, romCopy.nodeId,
-                    static_cast<uint8_t>(romCopy.state));
+                    static_cast<uint8_t>(romCopy.state), romCopy.rawQuadlets.size(),
+                    romCopy.rootDirMinimal.size(), romCopy.unitDirectories.size(),
+                    HasSBP2Unit(romCopy) ? 1 : 0);
+    } else {
+        ASFW_LOG_V2(ConfigROM,
+                    "ConfigROMStore::Insert: retaining richer GUID cache for GUID=0x%016llx "
+                    "candidateGen=%u candidateUnitDirs=%zu cachedGen=%u cachedUnitDirs=%zu",
+                    romCopy.bib.guid, romCopy.gen.value, romCopy.unitDirectories.size(),
+                    it->second.gen.value, it->second.unitDirectories.size());
     }
 }
 
@@ -112,6 +143,7 @@ const ConfigROM* ConfigROMStore::FindLatestForNode(uint8_t nodeId) const {
     LockGuard guard(lock_);
 
     const ConfigROM* latest = nullptr;
+    const ConfigROM* latestWithUnitProfile = nullptr;
     for (const auto& [key, rom] : romsByGenNode_) {
         if (rom.nodeId != nodeId) {
             continue;
@@ -119,7 +151,21 @@ const ConfigROM* ConfigROMStore::FindLatestForNode(uint8_t nodeId) const {
         if (latest == nullptr || rom.gen.value > latest->gen.value) {
             latest = &rom;
         }
+        if (HasParsedUnitProfile(rom) &&
+            (latestWithUnitProfile == nullptr ||
+             rom.gen.value > latestWithUnitProfile->gen.value)) {
+            latestWithUnitProfile = &rom;
+        }
     }
+
+    if (latestWithUnitProfile != nullptr && latest != latestWithUnitProfile) {
+        ASFW_LOG_V2(ConfigROM,
+                    "ConfigROMStore::FindLatestForNode: node=%u using gen=%u with unit profile "
+                    "instead of partial gen=%u",
+                    nodeId, latestWithUnitProfile->gen.value, latest ? latest->gen.value : 0);
+        return latestWithUnitProfile;
+    }
+
     return latest;
 }
 

--- a/ASFWDriver/ConfigROM/Store/ConfigROMStore.cpp
+++ b/ASFWDriver/ConfigROM/Store/ConfigROMStore.cpp
@@ -158,7 +158,8 @@ const ConfigROM* ConfigROMStore::FindLatestForNode(uint8_t nodeId) const {
         }
     }
 
-    if (latestWithUnitProfile != nullptr && latest != latestWithUnitProfile) {
+    if (latestWithUnitProfile != nullptr && latest != latestWithUnitProfile &&
+        latest != nullptr && latestWithUnitProfile->bib.guid == latest->bib.guid) {
         ASFW_LOG_V2(ConfigROM,
                     "ConfigROMStore::FindLatestForNode: node=%u using gen=%u with unit profile "
                     "instead of partial gen=%u",

--- a/ASFWDriver/Controller/BringupOverrides.hpp
+++ b/ASFWDriver/Controller/BringupOverrides.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "ControllerConfig.hpp"
+#include "../Bus/BusManager.hpp"
+
+namespace ASFW::Driver {
+
+// Host cycle-master bring-up configuration. Linux firewire_ohci and Apple
+// IOFireWireController both make the local PHY contender-capable during init,
+// while root delegation remains policy-controlled by BusManager.
+inline void ApplyBringupOverrides(ControllerConfig& config, BusManager* busManager) {
+    config.allowCycleMasterEligibility = true;
+
+    if (busManager != nullptr) {
+        // When experimental flag is set, disable delegation so host keeps
+        // root/cycle-master. Otherwise use default delegation policy.
+        busManager->SetDelegateMode(!config.experimentalHostCycleMasterBringup);
+    }
+}
+
+} // namespace ASFW::Driver

--- a/ASFWDriver/Controller/ControllerConfig.cpp
+++ b/ASFWDriver/Controller/ControllerConfig.cpp
@@ -9,10 +9,10 @@ ControllerConfig ControllerConfig::MakeDefault() {
     config.vendor.vendorName = "Unknown";
     config.localGuid = 0;
     config.enableVerboseLogging = false;
+    config.experimentalHostCycleMasterBringup = false;
     config.allowCycleMasterEligibility = false;
     config.supportedSpeeds = {100, 200, 400};
     return config;
 }
 
 } // namespace ASFW::Driver
-

--- a/ASFWDriver/Controller/ControllerConfig.hpp
+++ b/ASFWDriver/Controller/ControllerConfig.hpp
@@ -19,6 +19,7 @@ struct ControllerConfig {
     VendorInfo vendor;
     uint64_t localGuid{0};
     bool enableVerboseLogging{false};
+    bool experimentalHostCycleMasterBringup{false};
     bool allowCycleMasterEligibility{false};
     std::vector<uint32_t> supportedSpeeds;
 
@@ -26,4 +27,3 @@ struct ControllerConfig {
 };
 
 } // namespace ASFW::Driver
-

--- a/ASFWDriver/Controller/ControllerCoreDiscovery.cpp
+++ b/ASFWDriver/Controller/ControllerCoreDiscovery.cpp
@@ -16,6 +16,7 @@
 #include "../ConfigROM/ROMScanner.hpp"
 #include "../Diagnostics/DiagnosticLogger.hpp"
 #include "../Diagnostics/MetricsSink.hpp"
+#include "../Discovery/DiscoveryConvergence.hpp"
 #include "../Discovery/DeviceManager.hpp"
 #include "../Discovery/DeviceRegistry.hpp"
 #include "../Discovery/SpeedPolicy.hpp"
@@ -154,6 +155,15 @@ void ControllerCore::OnDiscoveryScanComplete(Discovery::Generation gen,
             deps_.busReset->EscalateDiscoveryDelay();
         }
     }
+
+    bool zeroRomScanInconclusive = false;
+    if (deps_.topology) {
+        if (const auto latestTopology = deps_.topology->LatestSnapshot()) {
+            zeroRomScanInconclusive = Discovery::IsZeroRomScanInconclusive(
+                gen, roms.size(), *latestTopology);
+        }
+    }
+
     std::unordered_set<uint64_t> discoveredGuids;
     discoveredGuids.reserve(roms.size());
 
@@ -188,7 +198,7 @@ void ControllerCore::OnDiscoveryScanComplete(Discovery::Generation gen,
                  deviceRecord.isAudioCandidate ? "YES" : "NO");
     }
 
-    if (deps_.deviceManager) {
+    if (deps_.deviceManager && !zeroRomScanInconclusive) {
         auto devices = deps_.deviceManager->GetAllDevices();
         for (const auto& device : devices) {
             if (!device) {
@@ -205,6 +215,11 @@ void ControllerCore::OnDiscoveryScanComplete(Discovery::Generation gen,
                      gen.value, guid);
             deps_.deviceManager->MarkDeviceLost(guid);
         }
+    } else if (deps_.deviceManager && zeroRomScanInconclusive) {
+        ASFW_LOG(Discovery,
+                 "ROM scan for gen=%u produced 0 ROMs but topology still has remote "
+                 "link-active nodes; keeping existing devices until a conclusive scan",
+                 gen.value);
     }
 
     ASFW_LOG(Discovery, "═══════════════════════════════════════");

--- a/ASFWDriver/Controller/ControllerCoreLifecycle.cpp
+++ b/ASFWDriver/Controller/ControllerCoreLifecycle.cpp
@@ -32,6 +32,7 @@
 #include "../Protocols/Audio/DeviceProtocolFactory.hpp"
 #include "../Scheduling/Scheduler.hpp"
 #include "../Version/DriverVersion.hpp"
+#include "BringupOverrides.hpp"
 #include "ControllerStateMachine.hpp"
 #include "Logging.hpp"
 
@@ -80,6 +81,8 @@ kern_return_t ControllerCore::InitializeBusResetAndDiscovery() {
                  "❌ CRITICAL: Missing dependencies for BusResetCoordinator initialization");
         return kIOReturnNoResources;
     }
+
+    ApplyBringupOverrides(config_, deps_.busManager.get());
 
     auto workQueue = deps_.scheduler->Queue();
     ASFW_LOG(Controller, "Initializing BusResetCoordinator");

--- a/ASFWDriver/Discovery/DeviceManager.cpp
+++ b/ASFWDriver/Discovery/DeviceManager.cpp
@@ -3,6 +3,28 @@
 
 namespace ASFW::Discovery {
 
+namespace {
+
+constexpr uint32_t kSBP2UnitSpecId = 0x00609E;
+constexpr uint32_t kSBP2UnitSwVersion = 0x010483;
+constexpr uint8_t kSBP2MissingTerminateThreshold = 2;
+
+bool HasSBP2Unit(const std::shared_ptr<FWDevice>& device)
+{
+    if (!device) {
+        return false;
+    }
+
+    for (const auto& unit : device->GetUnits()) {
+        if (unit && unit->Matches(kSBP2UnitSpecId, kSBP2UnitSwVersion)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
 DeviceManager::DeviceManager() : mutex_(IOLockAlloc()) {
     if (!mutex_) {
         // Handle allocation failure - in DriverKit, this might panic or we need to handle it
@@ -267,6 +289,7 @@ std::shared_ptr<FWDevice> DeviceManager::UpsertDevice(
     IOLockLock(mutex_);
     Guid64 guid = record.guid;
     auto it = devicesByGuid_.find(guid);
+    missingScanCounts_.erase(guid);
 
     if (it != devicesByGuid_.end()) {
         // Device exists - resume it
@@ -329,9 +352,53 @@ std::shared_ptr<FWDevice> DeviceManager::UpsertDevice(
 
 void DeviceManager::MarkDeviceLost(Guid64 guid)
 {
-    // Immediate-unplug policy for audio stability/cleanup.
-    // TODO: check suspend+timeout policy if needed
-    TerminateDevice(guid);
+    IOLockLock(mutex_);
+    auto it = devicesByGuid_.find(guid);
+    if (it == devicesByGuid_.end()) {
+        IOLockUnlock(mutex_);
+        return;
+    }
+
+    auto device = it->second;
+    if (!device || device->IsTerminated()) {
+        IOLockUnlock(mutex_);
+        return;
+    }
+
+    if (!HasSBP2Unit(device)) {
+        missingScanCounts_.erase(guid);
+        IOLockUnlock(mutex_);
+        TerminateDevice(guid);
+        return;
+    }
+
+    const uint8_t missingCount = ++missingScanCounts_[guid];
+    if (missingCount >= kSBP2MissingTerminateThreshold) {
+        IOLockUnlock(mutex_);
+        TerminateDevice(guid);
+        return;
+    }
+
+    if (device->IsReady()) {
+        device->Suspend();
+        NotifyDeviceSuspended(device);
+        for (const auto& unit : device->GetUnits()) {
+            if (unit && unit->IsSuspended()) {
+                NotifyUnitSuspended(unit);
+            }
+        }
+    }
+
+    auto genNodeIt = genNodeToGuid_.begin();
+    while (genNodeIt != genNodeToGuid_.end()) {
+        if (genNodeIt->second == guid) {
+            genNodeIt = genNodeToGuid_.erase(genNodeIt);
+        } else {
+            ++genNodeIt;
+        }
+    }
+
+    IOLockUnlock(mutex_);
 }
 
 void DeviceManager::TerminateDevice(Guid64 guid)
@@ -345,6 +412,7 @@ void DeviceManager::TerminateDevice(Guid64 guid)
 
     auto device = it->second;
     if (!device) {
+        missingScanCounts_.erase(guid);
         IOLockUnlock(mutex_);
         return;
     }
@@ -374,6 +442,7 @@ void DeviceManager::TerminateDevice(Guid64 guid)
 
     // Remove from primary map
     devicesByGuid_.erase(it);
+    missingScanCounts_.erase(guid);
 
     IOLockUnlock(mutex_);
 }

--- a/ASFWDriver/Discovery/DeviceManager.hpp
+++ b/ASFWDriver/Discovery/DeviceManager.hpp
@@ -92,6 +92,7 @@ private:
     using GenNodeKey = uint32_t;
     static GenNodeKey MakeKey(Generation gen, uint8_t nodeId);
     std::map<GenNodeKey, Guid64> genNodeToGuid_;
+    std::map<Guid64, uint8_t> missingScanCounts_;
 
     std::set<IDeviceObserver*> deviceObservers_;
     std::set<IUnitObserver*> unitObservers_;

--- a/ASFWDriver/Discovery/DeviceRegistry.cpp
+++ b/ASFWDriver/Discovery/DeviceRegistry.cpp
@@ -249,7 +249,7 @@ DeviceKind DeviceRegistry::ClassifyDevice(const ConfigROM& rom) const {
             return DeviceKind::Storage;
         }
     }
-    
+
     return DeviceKind::Unknown;
 }
 

--- a/ASFWDriver/Discovery/DiscoveryConvergence.hpp
+++ b/ASFWDriver/Discovery/DiscoveryConvergence.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstddef>
+
+#include "../Controller/ControllerTypes.hpp"
+#include "DiscoveryTypes.hpp"
+
+namespace ASFW::Discovery {
+
+[[nodiscard]] inline bool HasRemoteLinkActiveNode(const ASFW::Driver::TopologySnapshot& topology) {
+    if (!topology.localNodeId.has_value()) {
+        return false;
+    }
+
+    const uint8_t localNodeId = *topology.localNodeId;
+    for (const auto& node : topology.nodes) {
+        if (node.nodeId != localNodeId && node.linkActive) {
+            return true;
+        }
+    }
+    return false;
+}
+
+[[nodiscard]] inline bool IsZeroRomScanInconclusive(
+    Generation scanGeneration,
+    std::size_t romCount,
+    const ASFW::Driver::TopologySnapshot& topology) {
+    return romCount == 0U && topology.generation == scanGeneration.value &&
+           HasRemoteLinkActiveNode(topology);
+}
+
+} // namespace ASFW::Discovery

--- a/ASFWDriver/Discovery/DiscoveryTypes.hpp
+++ b/ASFWDriver/Discovery/DiscoveryTypes.hpp
@@ -88,6 +88,8 @@ enum class CfgKey : uint8_t {
     Node_Capabilities = 0x0C,
     Unit_Directory = 0xD1,  // IEEE 1212 Unit_Directory (keyId=0x11 when keyType=3)
     Management_Agent_Offset = 0x54,  // SBP-2 (keyType=CSR offset, keyId=0x14)
+    Unit_Characteristics   = 0x39,  // SBP-2 (immediate in unit directory)
+    Fast_Start             = 0x3A,  // SBP-2 (leaf in unit directory)
 };
 
 struct RomEntry {
@@ -108,6 +110,11 @@ struct UnitDirectory {
     std::optional<uint32_t> logicalUnitNumber;
     std::optional<uint32_t> modelId;
     std::optional<std::string> modelName;
+
+    // SBP-2 specific (from Management_Agent_Offset, Unit_Characteristics, Fast_Start keys)
+    std::optional<uint32_t> managementAgentOffset;
+    std::optional<uint32_t> unitCharacteristics;
+    std::optional<uint32_t> fastStart;
 };
 
 // ROM lifecycle state (matching Apple IOFireWireROMCache patterns)
@@ -212,7 +219,7 @@ struct DiscoverySnapshot {
 // ============================================================================
 
 struct ROMScannerParams {
-    FwSpeed startSpeed{FwSpeed::S100};
+    FwSpeed startSpeed{FwSpeed::S400};
     uint8_t maxInflight{2};
     uint8_t perStepRetries{2};
     bool doIRMCheck{false};

--- a/ASFWDriver/Discovery/FWDevice.cpp
+++ b/ASFWDriver/Discovery/FWDevice.cpp
@@ -116,16 +116,34 @@ std::vector<RomEntry> FWDevice::ExtractUnitDirectory(
                     entries.push_back(RomEntry{CfgKey::Unit_Sw_Version, value, keyType, 0});
                 }
                 break;
-            case 0x14:  // Logical_Unit_Number or SBP-2 Management_Agent_Offset
+            case 0x14:  // Logical_Unit_Number
                 if (keyType == 0) {  // Immediate
                     entries.push_back(RomEntry{CfgKey::Logical_Unit_Number, value, keyType, 0});
-                } else if (keyType == 1) {  // CSR offset
+                } else if (keyType == 1) {  // CSR offset: SBP-2 Management_Agent_Offset
                     entries.push_back(RomEntry{CfgKey::Management_Agent_Offset, value, keyType, 0});
                 }
                 break;
             case 0x38:  // Legacy non-standard fallback for Management_Agent_Offset
                 if (keyType == 1) {
                     entries.push_back(RomEntry{CfgKey::Management_Agent_Offset, value, keyType, 0});
+                }
+                break;
+            case 0x39:  // Unit_Characteristics (SBP-2, immediate)
+                if (keyType == 0) {
+                    entries.push_back(RomEntry{CfgKey::Unit_Characteristics, value, keyType, 0});
+                }
+                break;
+            case 0x3A:  // Fast_Start (SBP-2, leaf)
+                if (keyType == 2) {
+                    // Compute leaf offset: value is a signed 24-bit offset from this entry
+                    const int32_t signedValue = ((value & 0x800000U) != 0U)
+                        ? static_cast<int32_t>(value | 0xFF000000U)
+                        : static_cast<int32_t>(value);
+                    const int32_t rel = static_cast<int32_t>(i) + signedValue;
+                    if (rel >= 0) {
+                        entries.push_back(RomEntry{CfgKey::Fast_Start, value, keyType,
+                                                   static_cast<uint32_t>(rel)});
+                    }
                 }
                 break;
             default:

--- a/ASFWDriver/Discovery/FWUnit.cpp
+++ b/ASFWDriver/Discovery/FWUnit.cpp
@@ -62,6 +62,18 @@ void FWUnit::ParseEntries(const std::vector<RomEntry>& entries)
                 modelId_ = entry.value;
                 break;
 
+            case CfgKey::Management_Agent_Offset:
+                managementAgentOffset_ = entry.value;
+                break;
+
+            case CfgKey::Unit_Characteristics:
+                unitCharacteristics_ = entry.value;
+                break;
+
+            case CfgKey::Fast_Start:
+                fastStart_ = entry.value;
+                break;
+
             // Other keys (CSR offsets, dependent directories) ignored for now
             default:
                 break;

--- a/ASFWDriver/Discovery/FWUnit.hpp
+++ b/ASFWDriver/Discovery/FWUnit.hpp
@@ -32,6 +32,10 @@ public:
     std::optional<uint32_t> GetLUN() const { return logicalUnitNumber_; }
     uint32_t GetDirectoryOffset() const { return directoryOffset_; }
 
+    std::optional<uint32_t> GetManagementAgentOffset() const { return managementAgentOffset_; }
+    std::optional<uint32_t> GetUnitCharacteristics() const { return unitCharacteristics_; }
+    std::optional<uint32_t> GetFastStart() const { return fastStart_; }
+
     std::string_view GetVendorName() const { return vendorName_; }
     std::string_view GetProductName() const { return productName_; }
 
@@ -64,6 +68,11 @@ private:
     uint32_t unitSwVersion_{0};
     uint32_t modelId_{0};
     std::optional<uint32_t> logicalUnitNumber_;
+
+    // SBP-2 specific metadata
+    std::optional<uint32_t> managementAgentOffset_;
+    std::optional<uint32_t> unitCharacteristics_;
+    std::optional<uint32_t> fastStart_;
 
     std::string vendorName_;
     std::string productName_;

--- a/ASFWDriver/Discovery/SpeedPolicy.cpp
+++ b/ASFWDriver/Discovery/SpeedPolicy.cpp
@@ -6,6 +6,12 @@ namespace ASFW::Discovery {
 
 SpeedPolicy::SpeedPolicy() = default;
 
+namespace {
+uint32_t SpeedMbps(FwSpeed speed) {
+    return 100u << static_cast<uint8_t>(speed);
+}
+} // namespace
+
 LinkPolicy SpeedPolicy::ForNode(uint8_t nodeId) const {
     LinkPolicy policy{};
     
@@ -13,7 +19,7 @@ LinkPolicy SpeedPolicy::ForNode(uint8_t nodeId) const {
     if (it != nodeStates_.end()) {
         policy.localToNode = it->second.currentSpeed;
     } else {
-        policy.localToNode = FwSpeed::S100;
+        policy.localToNode = FwSpeed::S400;
     }
     
     policy.maxPayloadBytes = ComputeMaxPayload(policy.localToNode);
@@ -30,32 +36,27 @@ void SpeedPolicy::RecordSuccess(uint8_t nodeId, FwSpeed speed) {
     state.timeoutCount = 0;
     
     // Rate-limited success logging
-    // Fix speed display: S100=0→100, S200=1→200, S400=2→400, S800=3→800
     ASFW_LOG_RL(Discovery, "speed_success", 5000, OS_LOG_TYPE_DEBUG,
-                "Node %u: Success at S%u00 (total=%u)",
-                nodeId, (static_cast<uint32_t>(speed) * 2) + 1, state.successCount);
+                "Node %u: Success at S%u (total=%u)",
+                nodeId, SpeedMbps(speed), state.successCount);
 }
 
 void SpeedPolicy::RecordTimeout(uint8_t nodeId, FwSpeed speed) {
     auto& state = nodeStates_[nodeId];
+    state.currentSpeed = speed;
     state.timeoutCount++;
     
-    // Fix speed display: S100=0→100, S200=1→200, S400=2→400, S800=3→800
-    ASFW_LOG(Discovery, "Node %u: Timeout at S%u00 (count=%u)",
-             nodeId, (static_cast<uint32_t>(speed) * 2) + 1, state.timeoutCount);
+    ASFW_LOG(Discovery, "Node %u: Timeout at S%u (count=%u)",
+             nodeId, SpeedMbps(speed), state.timeoutCount);
     
-    // After multiple timeouts at current speed, downgrade
-    if (state.timeoutCount >= 2) {
-        FwSpeed downgraded = DowngradeSpeed(speed);
-        if (downgraded != speed) {
-            state.currentSpeed = downgraded;
-            state.timeoutCount = 0;  // Reset counter after downgrade
-            // Fix speed display: S100=0→100, S200=1→200, S400=2→400, S800=3→800
-            ASFW_LOG(Discovery, "Node %u: Downgraded S%u00 → S%u00",
-                     nodeId,
-                     (static_cast<uint32_t>(speed) * 2) + 1,
-                     (static_cast<uint32_t>(downgraded) * 2) + 1);
-        }
+    // ROMScanSession calls this only after the per-step retry budget is exhausted.
+    // Downgrade one tier immediately so discovery really follows S400→S200→S100.
+    FwSpeed downgraded = DowngradeSpeed(speed);
+    if (downgraded != speed) {
+        state.currentSpeed = downgraded;
+        state.timeoutCount = 0;
+        ASFW_LOG(Discovery, "Node %u: Downgraded S%u → S%u",
+                 nodeId, SpeedMbps(speed), SpeedMbps(downgraded));
     }
 }
 
@@ -95,4 +96,3 @@ FwSpeed SpeedPolicy::DowngradeSpeed(FwSpeed current) const {
 }
 
 } // namespace ASFW::Discovery
-

--- a/ASFWDriver/Discovery/SpeedPolicy.hpp
+++ b/ASFWDriver/Discovery/SpeedPolicy.hpp
@@ -30,7 +30,7 @@ public:
 
 private:
     struct NodeSpeedState {
-        FwSpeed currentSpeed{FwSpeed::S100};
+        FwSpeed currentSpeed{FwSpeed::S400};
         uint8_t timeoutCount{0};
         uint8_t successCount{0};
     };
@@ -46,4 +46,3 @@ private:
 };
 
 } // namespace ASFW::Discovery
-

--- a/ASFWDriver/UserClient/Handlers/DeviceDiscoveryHandler.cpp
+++ b/ASFWDriver/UserClient/Handlers/DeviceDiscoveryHandler.cpp
@@ -139,7 +139,7 @@ kern_return_t DeviceDiscoveryHandler::GetDiscoveredDevices(IOUserClientMethodArg
         deviceWire.nodeId = device->GetNodeID();
         deviceWire.state = StateToWire(device->GetState());
         deviceWire.unitCount = static_cast<uint8_t>(device->GetUnits().size());
-        deviceWire._padding = 0;
+        deviceWire.deviceKind = static_cast<uint8_t>(device->GetKind());
 
         // Copy vendor and model names
         CopyStringToBuffer(deviceWire.vendorName, sizeof(deviceWire.vendorName),
@@ -160,6 +160,10 @@ kern_return_t DeviceDiscoveryHandler::GetDiscoveredDevices(IOUserClientMethodArg
             unitWire.romOffset = unit->GetDirectoryOffset();
             unitWire.state = UnitStateToWire(unit->GetState());
             memset(unitWire._padding, 0, sizeof(unitWire._padding));
+            unitWire.managementAgentOffset = unit->GetManagementAgentOffset().value_or(0);
+            unitWire.lun = unit->GetLUN().value_or(0);
+            unitWire.unitCharacteristics = unit->GetUnitCharacteristics().value_or(0);
+            unitWire.fastStart = unit->GetFastStart().value_or(0);
 
             // Copy vendor and product names
             CopyStringToBuffer(unitWire.vendorName, sizeof(unitWire.vendorName),

--- a/ASFWDriver/UserClient/Handlers/TransactionHandler.cpp
+++ b/ASFWDriver/UserClient/Handlers/TransactionHandler.cpp
@@ -358,15 +358,14 @@ kern_return_t TransactionHandler::GetTransactionResult(IOUserClientMethodArgumen
         args->scalarOutputCount = 3;
     }
 
-    if (args->structureOutput && foundResult->dataLength > 0) {
-        OSData* resultData = OSData::withBytes(foundResult->data, foundResult->dataLength);
-        if (resultData) {
-            args->structureOutput = resultData;
-            args->structureOutputDescriptor = nullptr;
-        } else {
-            storage_->Unlock();
-            return kIOReturnNoMemory;
-        }
+    const void* resultBytes = foundResult->Data();
+    OSData* resultData = OSData::withBytes(resultBytes, foundResult->dataLength);
+    if (resultData) {
+        args->structureOutput = resultData;
+        args->structureOutputDescriptor = nullptr;
+    } else {
+        storage_->Unlock();
+        return kIOReturnNoMemory;
     }
 
     ASFW_LOG(UserClient, "GetTransactionResult: handle=0x%04x status=%u rCode=0x%02x len=%u",

--- a/ASFWDriver/UserClient/Storage/TransactionStorage.cpp
+++ b/ASFWDriver/UserClient/Storage/TransactionStorage.cpp
@@ -10,7 +10,6 @@
 
 #include <DriverKit/IOLib.h>
 #include <algorithm>
-#include <cstring>
 
 namespace ASFW::UserClient {
 
@@ -51,11 +50,13 @@ bool TransactionStorage::StoreResult(uint16_t handle, uint32_t status, uint8_t r
     result.handle = handle;
     result.status = status;
     result.responseCode = responseCode;
-    result.dataLength = (responseLength > 512) ? 512 : responseLength;
+    result.data.clear();
 
-    if (responsePayload && responseLength > 0 && result.dataLength > 0) {
-        std::memcpy(result.data, responsePayload, result.dataLength);
+    if (responsePayload && responseLength > 0) {
+        const auto* bytes = static_cast<const uint8_t*>(responsePayload);
+        result.data.assign(bytes, bytes + responseLength);
     }
+    result.dataLength = static_cast<uint32_t>(result.data.size());
 
     completedHead_ = nextHead;
 

--- a/ASFWDriver/UserClient/Storage/TransactionStorage.hpp
+++ b/ASFWDriver/UserClient/Storage/TransactionStorage.hpp
@@ -10,6 +10,7 @@
 
 #include <cstdint>
 #include <cstddef>
+#include <vector>
 
 // Forward declarations
 struct IOLock;
@@ -22,7 +23,11 @@ struct TransactionResult {
     uint32_t status{0};  // AsyncStatus value
     uint8_t responseCode{0xFF};
     uint32_t dataLength{0};
-    uint8_t data[512]{};  // Max response data size
+    std::vector<uint8_t> data{};
+
+    [[nodiscard]] const uint8_t* Data() const {
+        return data.empty() ? nullptr : data.data();
+    }
 };
 
 // Ring buffer storage for completed transaction results

--- a/ASFWDriver/UserClient/WireFormats/DeviceDiscoveryWireFormats.hpp
+++ b/ASFWDriver/UserClient/WireFormats/DeviceDiscoveryWireFormats.hpp
@@ -19,6 +19,10 @@ struct __attribute__((packed)) FWUnitWire {
     uint32_t romOffset;
     uint8_t state;              // 0=Created, 1=Ready, 2=Suspended, 3=Terminated
     uint8_t _padding[3];
+    uint32_t managementAgentOffset;
+    uint32_t lun;
+    uint32_t unitCharacteristics;
+    uint32_t fastStart;
     char vendorName[64];        // null-terminated
     char productName[64];       // null-terminated
 };
@@ -32,7 +36,7 @@ struct __attribute__((packed)) FWDeviceWire {
     uint8_t nodeId;
     uint8_t state;              // 0=Created, 1=Ready, 2=Suspended, 3=Terminated
     uint8_t unitCount;          // Number of units following this device
-    uint8_t _padding;
+    uint8_t deviceKind;         // DeviceKind enum value
     char vendorName[64];        // null-terminated
     char modelName[64];         // null-terminated
     // Followed by: FWUnitWire array (unitCount elements)

--- a/tests/AsyncPacketSerDesLinuxCompatTests.cpp
+++ b/tests/AsyncPacketSerDesLinuxCompatTests.cpp
@@ -34,16 +34,17 @@ constexpr std::array<uint32_t, N> LoadHostQuadlets(const uint8_t* base) {
     return words;
 }
 
-std::vector<uint8_t> MakeARBufferFromWireWords(std::initializer_list<uint32_t> quadlets,
+std::vector<uint8_t> MakeARBufferFromOHCIWords(std::initializer_list<uint32_t> hostOrderQuadlets,
                                                uint32_t trailerLE = 0) {
     std::vector<uint8_t> bytes;
-    bytes.reserve(quadlets.size() * sizeof(uint32_t) + sizeof(uint32_t));
+    bytes.reserve(hostOrderQuadlets.size() * sizeof(uint32_t) + sizeof(uint32_t));
 
-    for (uint32_t word : quadlets) {
-        bytes.push_back(static_cast<uint8_t>((word >> 24) & 0xFF));
-        bytes.push_back(static_cast<uint8_t>((word >> 16) & 0xFF));
-        bytes.push_back(static_cast<uint8_t>((word >> 8) & 0xFF));
+    for (uint32_t word : hostOrderQuadlets) {
+        // OHCI AR DMA stores each received quadlet in little-endian memory order.
         bytes.push_back(static_cast<uint8_t>(word & 0xFF));
+        bytes.push_back(static_cast<uint8_t>((word >> 8) & 0xFF));
+        bytes.push_back(static_cast<uint8_t>((word >> 16) & 0xFF));
+        bytes.push_back(static_cast<uint8_t>((word >> 24) & 0xFF));
     }
 
     // OHCI appends a little-endian trailer. Zero is portable regardless of byte order.
@@ -208,7 +209,7 @@ TEST(AsyncPacketSerDesLinuxCompat, LockRequestMatchesLinuxVector) {
 // -----------------------
 
 TEST(AsyncPacketSerDesLinuxCompat, ParseReadQuadletResponseMatchesLinuxVector) {
-    const auto packet = MakeARBufferFromWireWords({
+    const auto packet = MakeARBufferFromOHCIWords({
         0xFFC1F160u,
         0xFFC00000u,
         0x00000000u,
@@ -241,7 +242,7 @@ TEST(AsyncPacketSerDesLinuxCompat, ParseReadQuadletResponseMatchesLinuxVector) {
 
 TEST(AsyncPacketSerDesLinuxCompat, ParseReadBlockResponseComputesPayloadLength) {
     // Q3 specifies data_length = 0x20 (32 bytes), so we need to include 32 bytes of payload
-    const auto packet = MakeARBufferFromWireWords({
+    const auto packet = MakeARBufferFromOHCIWords({
         0xFFC1E170u,  // Q0: header
         0xFFC00000u,  // Q1: source ID
         0x00000000u,  // Q2: reserved
@@ -275,7 +276,7 @@ TEST(AsyncPacketSerDesLinuxCompat, ParseReadBlockResponseComputesPayloadLength) 
 }
 
 TEST(AsyncPacketSerDesLinuxCompat, ParseLockResponsePreservesExtendedTCodeLength) {
-    const auto packet = MakeARBufferFromWireWords({
+    const auto packet = MakeARBufferFromOHCIWords({
         0xFFC12DB0u,
         0xFFC00000u,
         0x00000000u,
@@ -305,11 +306,50 @@ TEST(AsyncPacketSerDesLinuxCompat, ParseLockResponsePreservesExtendedTCodeLength
     EXPECT_TRUE(handled);
 }
 
+TEST(AsyncPacketSerDesLinuxCompat, RequestPayloadIsCopiedIntoAlignedScratchBeforeHandler) {
+    const auto packet = MakeARBufferFromOHCIWords({
+        0xFFC16510u,  // Q0: tCode=0x1 (write block), tLabel arbitrary
+        0xFFC0ECC0u,  // Q1: src=0xFFC0, addrHi=0xECC0
+        0x00000000u,  // Q2: addrLo
+        0x00080000u,  // Q3: data_length=8
+        0x11223344u,  // payload q0
+        0x55667788u,  // payload q1
+    });
+
+    std::vector<uint8_t> misaligned;
+    misaligned.reserve(packet.size() + 4);
+    misaligned.insert(misaligned.end(), {0xDE, 0xAD, 0xBE, 0xEF});
+    misaligned.insert(misaligned.end(), packet.begin(), packet.end());
+
+    const auto buffer = std::span<const uint8_t>(misaligned.data() + 4, packet.size());
+    const auto rawPayloadPtr = reinterpret_cast<uintptr_t>(buffer.data() + 16);
+
+    PacketRouter router;
+    bool handled = false;
+    router.RegisterRequestHandler(0x1, [&](const ARPacketView& view) {
+        handled = true;
+        EXPECT_EQ(view.payload.size(), 8u);
+        EXPECT_EQ(0u, reinterpret_cast<uintptr_t>(view.payload.data()) & 0x7u);
+        EXPECT_NE(rawPayloadPtr, reinterpret_cast<uintptr_t>(view.payload.data()));
+        if (view.payload.size() == 8u) {
+            EXPECT_EQ((std::array<uint8_t, 8>{0x44, 0x33, 0x22, 0x11, 0x88, 0x77, 0x66, 0x55}),
+                      (std::array<uint8_t, 8>{
+                          view.payload[0], view.payload[1], view.payload[2], view.payload[3],
+                          view.payload[4], view.payload[5], view.payload[6], view.payload[7],
+                      }));
+        }
+        return ResponseCode::Complete;
+    });
+
+    router.RoutePacket(ARContextType::Request, buffer);
+    EXPECT_TRUE(handled);
+}
+
 TEST(AsyncPacketSerDesLinuxCompat, ExtractTLabelUsesWireByteTwo) {
-    // Read quadlet response packet: tLabel=48, tCode=6, rCode=0
-    // IEEE 1394 wire: Byte2=[tLabel:6][rt:2], Byte3=[tCode:4][rCode:4]
+    // Read quadlet response packet as OHCI AR DMA memory: tLabel=48, tCode=6, rCode=0.
+    // After the little-endian quadlet write, memory byte1 holds [tLabel:6][rt:2].
     const std::array<uint8_t, 16> responseBytes{
-        0x60, 0x01, 0xC2, 0x60,  // Fixed byte3: was 0xFF (invalid tCode=0xF) → 0x60 (tCode=6)
+        0x60, 0xC2, 0x01, 0x60,
         0x00, 0x00, 0xC0, 0xFF,
         0x00, 0x00, 0x00, 0x00,
         0x04, 0x20, 0x8F, 0xE2,

--- a/tests/BusManagerGapOptimizationTests.cpp
+++ b/tests/BusManagerGapOptimizationTests.cpp
@@ -4,6 +4,8 @@
 #include <vector>
 
 #include "ASFWDriver/Bus/BusManager.hpp"
+#include "ASFWDriver/Controller/ControllerConfig.hpp"
+#include "ASFWDriver/Controller/BringupOverrides.hpp"
 
 using namespace ASFW::Driver;
 
@@ -31,7 +33,68 @@ TopologySnapshot MakeTopology(const std::optional<uint8_t> localNodeId,
     return topology;
 }
 
+TopologyNode MakeNode(const uint8_t nodeId, const bool contender, const bool linkActive = true) {
+    TopologyNode node{};
+    node.nodeId = nodeId;
+    node.isIRMCandidate = contender;
+    node.linkActive = linkActive;
+    return node;
+}
+
 } // namespace
+
+TEST(BusManagerGapOptimizationTests, ControllerConfigDefaultsPreserveDelegatedMode) {
+    ControllerConfig config{};
+    EXPECT_FALSE(config.allowCycleMasterEligibility);
+    EXPECT_FALSE(config.experimentalHostCycleMasterBringup);
+
+    const ControllerConfig defaultConfig = ControllerConfig::MakeDefault();
+    EXPECT_FALSE(defaultConfig.allowCycleMasterEligibility);
+    EXPECT_FALSE(defaultConfig.experimentalHostCycleMasterBringup);
+}
+
+TEST(BusManagerGapOptimizationTests, DefaultBringupDelegatesRootToPeerContender) {
+    BusManager busManager;
+
+    TopologySnapshot topology{};
+    topology.localNodeId = 1U;
+    topology.rootNodeId = 1U;
+    topology.irmNodeId = 1U;
+    topology.nodes = {
+        MakeNode(0U, true),
+        MakeNode(1U, true),
+    };
+
+    const auto command = busManager.AssignCycleMaster(topology, {});
+    ASSERT_TRUE(command.has_value());
+    ASSERT_TRUE(command->forceRootNodeID.has_value());
+    ASSERT_TRUE(command->setContender.has_value());
+    EXPECT_EQ(*command->forceRootNodeID, 0U);
+    EXPECT_FALSE(*command->setContender);
+}
+
+TEST(BusManagerGapOptimizationTests, ExperimentalHostCycleMasterBringupDisablesDelegation) {
+    ControllerConfig config{};
+    config.experimentalHostCycleMasterBringup = true;
+
+    BusManager busManager;
+    ApplyBringupOverrides(config, &busManager);
+
+    EXPECT_TRUE(config.allowCycleMasterEligibility);
+    EXPECT_FALSE(busManager.GetConfig().delegateCycleMaster);
+
+    TopologySnapshot topology{};
+    topology.localNodeId = 1U;
+    topology.rootNodeId = 1U;
+    topology.irmNodeId = 1U;
+    topology.nodes = {
+        MakeNode(0U, true),
+        MakeNode(1U, true),
+    };
+
+    const auto command = busManager.AssignCycleMaster(topology, {});
+    EXPECT_FALSE(command.has_value());
+}
 
 TEST(BusManagerGapOptimizationTests, InconsistentObservedBaseGapsForceConservative63) {
     BusManager busManager;
@@ -60,9 +123,42 @@ TEST(BusManagerGapOptimizationTests, ObservedZeroGapRetoolsToCurrentTargetGap) {
     EXPECT_EQ(decision->gapCount, 10U);
 }
 
-TEST(BusManagerGapOptimizationTests, ObservedGapsMatchingPreviousGapNeedNoAction) {
+TEST(BusManagerGapOptimizationTests, ObservedDefault63GapWithUnknownHistoryRetoolsToCurrentTargetGap) {
     BusManager busManager;
     busManager.SetGapOptimizationEnabled(true);
+
+    const auto topology = MakeTopology(0U, 0U, 4U);
+    const auto decision =
+        busManager.EvaluateGapPolicy(topology,
+                                     {MakeBaseSelfID(0U, 63U), MakeBaseSelfID(1U, 63U)});
+
+    ASSERT_TRUE(decision.has_value());
+    EXPECT_EQ(decision->reason, BusManager::GapDecisionReason::TargetGap);
+    EXPECT_EQ(decision->gapCount, 10U);
+}
+
+TEST(BusManagerGapOptimizationTests, TwoNodeLocalRootSkipsTargetGapOptimization) {
+    BusManager busManager;
+    busManager.SetGapOptimizationEnabled(true);
+
+    auto topology = MakeTopology(1U, 1U, 1U);
+    topology.rootNodeId = 1U;
+    topology.nodes = {
+        MakeNode(0U, true),
+        MakeNode(1U, true),
+    };
+
+    const auto decision =
+        busManager.EvaluateGapPolicy(topology,
+                                     {MakeBaseSelfID(0U, 63U), MakeBaseSelfID(1U, 63U)});
+
+    EXPECT_FALSE(decision.has_value());
+}
+
+TEST(BusManagerGapOptimizationTests, ObservedGapsMatchingConfirmedGapNeedNoAction) {
+    BusManager busManager;
+    busManager.SetGapOptimizationEnabled(true);
+    busManager.NoteStableGapObserved(63U);
 
     const auto topology = MakeTopology(0U, 0U, 4U);
     const auto decision =

--- a/tests/BusResetCoordinatorTests.cpp
+++ b/tests/BusResetCoordinatorTests.cpp
@@ -355,7 +355,7 @@ TEST(BusResetCoordinatorTests, StableResetPublishesTopologyExactlyOnce) {
         7U, {MakeBaseSelfID(0U, 63U, true, true), MakeBaseSelfID(1U, 63U)});
     rig.PrimeCapture(rawCapture, 7U);
     rig.TriggerStickyCompletion();
-    rig.AdvanceMs(1U);
+    rig.AdvanceMs(100U);
 
     ASSERT_EQ(rig.publishedTopologies.size(), 1U);
     EXPECT_EQ(rig.publishedTopologies.front().generation, 7U);
@@ -370,6 +370,25 @@ TEST(BusResetCoordinatorTests, StableResetPublishesTopologyExactlyOnce) {
     EXPECT_FALSE(rig.hardware.TestBusResetIssued());
 }
 
+TEST(BusResetCoordinatorTests, StableResetDelaysDiscoveryByAppleScanDelay) {
+    BusResetTestRig rig;
+    rig.Initialize();
+
+    rig.StartResetCycle();
+
+    const auto rawCapture = MakeRawSelfIDCapture(
+        7U, {MakeBaseSelfID(0U, 63U, true, true), MakeBaseSelfID(1U, 63U)});
+    rig.PrimeCapture(rawCapture, 7U);
+    rig.TriggerStickyCompletion();
+
+    rig.AdvanceMs(99U);
+    EXPECT_TRUE(rig.publishedTopologies.empty());
+
+    rig.AdvanceMs(1U);
+    ASSERT_EQ(rig.publishedTopologies.size(), 1U);
+    EXPECT_EQ(rig.publishedTopologies.front().generation, 7U);
+}
+
 TEST(BusResetCoordinatorTests, StickyCompletionOnlyStillCompletesDecodePath) {
     BusResetTestRig rig;
     rig.Initialize();
@@ -380,7 +399,7 @@ TEST(BusResetCoordinatorTests, StickyCompletionOnlyStillCompletesDecodePath) {
         3U, {MakeBaseSelfID(0U, 63U, true, false), MakeBaseSelfID(1U, 63U)});
     rig.PrimeCapture(rawCapture, 3U);
     rig.TriggerStickyCompletion();
-    rig.AdvanceMs(1U);
+    rig.AdvanceMs(100U);
 
     ASSERT_EQ(rig.publishedTopologies.size(), 1U);
     EXPECT_EQ(rig.publishedTopologies.front().generation, 3U);
@@ -435,7 +454,7 @@ TEST(BusResetCoordinatorTests, InvalidTopologyDoesNotReusePreviouslyPublishedSna
         MakeRawSelfIDCapture(12U, {MakeBaseSelfID(0U, 63U, true, true), MakeBaseSelfID(1U, 63U)});
     rig.PrimeCapture(stableCapture, 12U);
     rig.TriggerStickyCompletion();
-    rig.AdvanceMs(1U);
+    rig.AdvanceMs(100U);
 
     ASSERT_EQ(rig.publishedTopologies.size(), 1U);
     rig.ResetHardwareState();
@@ -471,6 +490,40 @@ TEST(BusResetCoordinatorTests, SelfIDTimeoutRequestsShortRecoveryResetAfterDeadl
     ASSERT_TRUE(rig.coordinator.Metrics().lastFailureReason.has_value());
     EXPECT_NE(rig.coordinator.Metrics().lastFailureReason->find("Self-ID timeout"),
               std::string::npos);
+}
+
+TEST(BusResetCoordinatorTests, ManualResetWithoutIrqTriggersOneBoundedRecoveryReset) {
+    BusResetTestRig rig;
+    rig.Initialize();
+
+    rig.coordinator.RequestUserReset(true);
+    rig.DrainReady();
+
+    auto countBusResets = [&rig]() {
+        const auto operations = rig.hardware.CopyTestOperations();
+        return static_cast<size_t>(std::count(operations.begin(), operations.end(),
+                                             HardwareInterface::TestOperation::InitiateBusReset));
+    };
+
+    EXPECT_EQ(countBusResets(), 1U);
+    auto diag = rig.coordinator.Diagnostics();
+    EXPECT_EQ(diag.manualResetEpoch, 1U);
+    EXPECT_EQ(diag.resetEpoch, 0U);
+    EXPECT_EQ(diag.softwareResetIssuedCount, 1U);
+
+    rig.AdvanceMs(499U);
+    EXPECT_EQ(countBusResets(), 1U);
+
+    rig.AdvanceMs(1U);
+    EXPECT_EQ(countBusResets(), 2U);
+    diag = rig.coordinator.Diagnostics();
+    EXPECT_EQ(diag.recoveryResetAttempts, 1U);
+    EXPECT_EQ(diag.softwareResetIssuedCount, 2U);
+    EXPECT_EQ(diag.lastRecoveryReasonCode,
+              BusResetCoordinator::RecoveryReasonCode::ManualResetWatchdog);
+
+    rig.AdvanceMs(1000U);
+    EXPECT_EQ(countBusResets(), 2U);
 }
 
 TEST(BusResetCoordinatorTests, GapMismatchResetIsDeferredThenSentWithPhyConfig) {
@@ -676,7 +729,7 @@ TEST(BusResetCoordinatorTests, StableAcceptedGenerationCommitsGapAfterSuccessful
                                                 MakeBaseSelfID(1U, 21U, true, false)}),
                      21U);
     rig.TriggerStickyCompletion();
-    rig.AdvanceMs(1U);
+    rig.AdvanceMs(100U);
 
     EXPECT_FALSE(rig.hardware.TestPhyConfigIssued());
     EXPECT_FALSE(rig.hardware.TestBusResetIssued());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -253,6 +253,7 @@ gtest_discover_tests(SelfIDCaptureTests)
 add_executable(BusManagerGapOptimizationTests
     "${ASFW_TESTS_DIR}/BusManagerGapOptimizationTests.cpp"
     "${ASFW_DRIVER_DIR}/Bus/BusManager.cpp"
+    "${ASFW_DRIVER_DIR}/Controller/ControllerConfig.cpp"
     "${ASFW_TESTS_DIR}/LoggingStubs.cpp"
 )
 
@@ -338,6 +339,29 @@ target_compile_definitions(FireWireIOReturnTests
 target_include_directories(FireWireIOReturnTests PRIVATE ${ASFW_COMMON_INCLUDES})
 
 gtest_discover_tests(FireWireIOReturnTests)
+
+# =============================================================================
+# Transaction Storage Tests - async user-client result retention
+# =============================================================================
+add_executable(TransactionStorageTests
+    "${ASFW_TESTS_DIR}/TransactionStorageTests.cpp"
+    "${ASFW_DRIVER_DIR}/UserClient/Storage/TransactionStorage.cpp"
+    "${ASFW_TESTS_DIR}/LoggingStubs.cpp"
+)
+
+target_link_libraries(TransactionStorageTests
+    PRIVATE
+        GTest::gtest_main
+)
+
+target_compile_definitions(TransactionStorageTests
+    PRIVATE
+        ASFW_HOST_TEST
+)
+
+target_include_directories(TransactionStorageTests PRIVATE ${ASFW_COMMON_INCLUDES})
+
+gtest_discover_tests(TransactionStorageTests)
 
 # =============================================================================
 # DMA Memory Tests - FakeDMAMemory unit tests
@@ -1421,6 +1445,24 @@ target_compile_definitions(ROMScannerDetailsDiscoveryTests
 target_include_directories(ROMScannerDetailsDiscoveryTests PRIVATE ${ASFW_COMMON_INCLUDES})
 
 gtest_discover_tests(ROMScannerDetailsDiscoveryTests)
+
+add_executable(DiscoveryConvergenceTests
+    "${ASFW_TESTS_DIR}/DiscoveryConvergenceTests.cpp"
+)
+
+target_link_libraries(DiscoveryConvergenceTests
+    PRIVATE
+        GTest::gtest_main
+)
+
+target_compile_definitions(DiscoveryConvergenceTests
+    PRIVATE
+        ASFW_HOST_TEST
+)
+
+target_include_directories(DiscoveryConvergenceTests PRIVATE ${ASFW_COMMON_INCLUDES})
+
+gtest_discover_tests(DiscoveryConvergenceTests)
 
 add_executable(ROMScanNodeStateMachineTests
     "${ASFW_TESTS_DIR}/ROMScanNodeStateMachineTests.cpp"

--- a/tests/ConfigROMStoreConcurrencyTests.cpp
+++ b/tests/ConfigROMStoreConcurrencyTests.cpp
@@ -20,6 +20,18 @@ ASFW::Discovery::ConfigROM MakeROM(ASFW::Discovery::Generation gen,
     return rom;
 }
 
+ASFW::Discovery::ConfigROM MakeSBP2ROM(ASFW::Discovery::Generation gen,
+                                       uint8_t nodeId,
+                                       ASFW::Discovery::Guid64 guid) {
+    auto rom = MakeROM(gen, nodeId, guid);
+    ASFW::Discovery::UnitDirectory unit{};
+    unit.unitSpecId = 0x00609E;
+    unit.unitSwVersion = 0x010483;
+    rom.unitDirectories.push_back(unit);
+    rom.rawQuadlets.resize(34, 0);
+    return rom;
+}
+
 } // namespace
 
 TEST(ConfigROMStoreConcurrencyTests, ConcurrentInsertAndLookupDoesNotCrash) {
@@ -55,4 +67,39 @@ TEST(ConfigROMStoreConcurrencyTests, ConcurrentInsertAndLookupDoesNotCrash) {
     for (auto& thread : threads) {
         thread.join();
     }
+}
+
+TEST(ConfigROMStoreConcurrencyTests, LatestLookupPrefersPreviousProfileOverNewerPartialROM) {
+    ASFW::Discovery::ConfigROMStore store;
+    constexpr ASFW::Discovery::Guid64 kGuid = 0x0090b54001ffffffULL;
+
+    store.Insert(MakeSBP2ROM(ASFW::Discovery::Generation{2}, 0, kGuid));
+    store.Insert(MakeROM(ASFW::Discovery::Generation{3}, 0, kGuid));
+
+    const auto* latest = store.FindLatestForNode(0);
+    ASSERT_NE(latest, nullptr);
+    EXPECT_EQ(latest->gen.value, 2u);
+    EXPECT_EQ(latest->unitDirectories.size(), 1u);
+
+    const auto* byGuid = store.FindByGuid(kGuid);
+    ASSERT_NE(byGuid, nullptr);
+    EXPECT_EQ(byGuid->gen.value, 2u);
+    EXPECT_EQ(byGuid->unitDirectories.size(), 1u);
+}
+
+TEST(ConfigROMStoreConcurrencyTests, LatestLookupUsesNewerProfileWhenItCompletes) {
+    ASFW::Discovery::ConfigROMStore store;
+    constexpr ASFW::Discovery::Guid64 kGuid = 0x0090b54001ffffffULL;
+
+    store.Insert(MakeSBP2ROM(ASFW::Discovery::Generation{2}, 0, kGuid));
+    store.Insert(MakeROM(ASFW::Discovery::Generation{3}, 0, kGuid));
+    store.Insert(MakeSBP2ROM(ASFW::Discovery::Generation{4}, 0, kGuid));
+
+    const auto* latest = store.FindLatestForNode(0);
+    ASSERT_NE(latest, nullptr);
+    EXPECT_EQ(latest->gen.value, 4u);
+
+    const auto* byGuid = store.FindByGuid(kGuid);
+    ASSERT_NE(byGuid, nullptr);
+    EXPECT_EQ(byGuid->gen.value, 4u);
 }

--- a/tests/ConfigROMStoreConcurrencyTests.cpp
+++ b/tests/ConfigROMStoreConcurrencyTests.cpp
@@ -87,6 +87,21 @@ TEST(ConfigROMStoreConcurrencyTests, LatestLookupPrefersPreviousProfileOverNewer
     EXPECT_EQ(byGuid->unitDirectories.size(), 1u);
 }
 
+TEST(ConfigROMStoreConcurrencyTests, LatestLookupDoesNotReuseProfileAcrossDifferentGuid) {
+    ASFW::Discovery::ConfigROMStore store;
+    constexpr ASFW::Discovery::Guid64 kOldGuid = 0x0090b54001ffffffULL;
+    constexpr ASFW::Discovery::Guid64 kNewGuid = 0x00a0c91002000000ULL;
+
+    store.Insert(MakeSBP2ROM(ASFW::Discovery::Generation{2}, 0, kOldGuid));
+    store.Insert(MakeROM(ASFW::Discovery::Generation{3}, 0, kNewGuid));
+
+    const auto* latest = store.FindLatestForNode(0);
+    ASSERT_NE(latest, nullptr);
+    EXPECT_EQ(latest->gen.value, 3u);
+    EXPECT_EQ(latest->bib.guid, kNewGuid);
+    EXPECT_TRUE(latest->unitDirectories.empty());
+}
+
 TEST(ConfigROMStoreConcurrencyTests, LatestLookupUsesNewerProfileWhenItCompletes) {
     ASFW::Discovery::ConfigROMStore store;
     constexpr ASFW::Discovery::Guid64 kGuid = 0x0090b54001ffffffULL;

--- a/tests/DiscoveryConvergenceTests.cpp
+++ b/tests/DiscoveryConvergenceTests.cpp
@@ -1,0 +1,54 @@
+#include "Discovery/DiscoveryConvergence.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+ASFW::Driver::TopologySnapshot MakeTopologyWithRemoteLinkActiveNode() {
+    ASFW::Driver::TopologySnapshot snapshot{};
+    snapshot.generation = 42;
+    snapshot.localNodeId = 1;
+    snapshot.nodeCount = 2;
+    snapshot.nodes = {
+        ASFW::Driver::TopologyNode{.nodeId = 0, .linkActive = true},
+        ASFW::Driver::TopologyNode{.nodeId = 1, .linkActive = true},
+    };
+    return snapshot;
+}
+
+TEST(DiscoveryConvergenceTests, ZeroRomScanIsInconclusiveWhenTopologyStillHasRemoteNode) {
+    const auto snapshot = MakeTopologyWithRemoteLinkActiveNode();
+
+    EXPECT_TRUE(ASFW::Discovery::IsZeroRomScanInconclusive(
+        ASFW::Discovery::Generation{42}, /*romCount=*/0, snapshot));
+}
+
+TEST(DiscoveryConvergenceTests, NonEmptyRomScanIsConclusive) {
+    const auto snapshot = MakeTopologyWithRemoteLinkActiveNode();
+
+    EXPECT_FALSE(ASFW::Discovery::IsZeroRomScanInconclusive(
+        ASFW::Discovery::Generation{42}, /*romCount=*/1, snapshot));
+}
+
+TEST(DiscoveryConvergenceTests, ZeroRomScanIsConclusiveWhenTopologyHasNoRemoteNode) {
+    ASFW::Driver::TopologySnapshot snapshot{};
+    snapshot.generation = 42;
+    snapshot.localNodeId = 1;
+    snapshot.nodeCount = 1;
+    snapshot.nodes = {
+        ASFW::Driver::TopologyNode{.nodeId = 1, .linkActive = true},
+    };
+
+    EXPECT_FALSE(ASFW::Discovery::IsZeroRomScanInconclusive(
+        ASFW::Discovery::Generation{42}, /*romCount=*/0, snapshot));
+}
+
+TEST(DiscoveryConvergenceTests, StaleTopologyGenerationIsConclusive) {
+    auto snapshot = MakeTopologyWithRemoteLinkActiveNode();
+    snapshot.generation = 41;
+
+    EXPECT_FALSE(ASFW::Discovery::IsZeroRomScanInconclusive(
+        ASFW::Discovery::Generation{42}, /*romCount=*/0, snapshot));
+}
+
+} // namespace

--- a/tests/FCPPacketParsingTests.cpp
+++ b/tests/FCPPacketParsingTests.cpp
@@ -95,6 +95,23 @@ TEST_F(FCPPacketParsingTest, RealPacket_FCPResponse_SubunitInfo) {
         << "ASFW and Linux implementations should produce identical results";
 }
 
+TEST_F(FCPPacketParsingTest, RealPacket_FCPResponse_DataLengthUsesOHCILittleEndianOrder) {
+    // Same real FCP packet as above. Q3 bytes in AR DMA memory are:
+    //   00 00 08 00
+    // which represents data_length=8, extended_tcode=0.
+    const uint8_t realPacket[] = {
+        0x10, 0x7D, 0xC0, 0xFF,
+        0xFF, 0xFF, 0xC2, 0xFF,
+        0x00, 0x0D, 0x00, 0xF0,
+        0x00, 0x00, 0x08, 0x00,
+    };
+
+    std::span<const uint8_t> header(realPacket, 16);
+    EXPECT_EQ(8u, ExtractDataLength(header))
+        << "OHCI AR DMA stores Q3 little-endian in memory, so block data_length "
+           "must decode to 8 bytes for the real FCP packet";
+}
+
 TEST_F(FCPPacketParsingTest, RealPacket_FCPResponse_Retry1) {
     // Second FCP response from logs (timestamp 13:34:48.266683+0100)
     // Same SUBUNIT_INFO response, different tLabel

--- a/tests/ROMScanNodeStateMachineTests.cpp
+++ b/tests/ROMScanNodeStateMachineTests.cpp
@@ -29,10 +29,22 @@ TEST(ROMScanNodeStateMachineTests, RejectsInvalidTransition) {
     EXPECT_EQ(node.CurrentState(), ROMScanNodeStateMachine::State::Idle);
 }
 
+TEST(ROMScanNodeStateMachineTests, AcceptsSlowPublishRetryTransitions) {
+    ROMScanNodeStateMachine node(6, Generation{12}, FwSpeed::S100, 2);
+
+    EXPECT_TRUE(node.TransitionTo(ROMScanNodeStateMachine::State::ReadingBIB));
+    EXPECT_TRUE(node.TransitionTo(ROMScanNodeStateMachine::State::WaitingRepublish));
+    EXPECT_TRUE(node.TransitionTo(ROMScanNodeStateMachine::State::ReadingRootDir));
+    EXPECT_TRUE(node.TransitionTo(ROMScanNodeStateMachine::State::WaitingRepublish));
+    EXPECT_TRUE(node.TransitionTo(ROMScanNodeStateMachine::State::Idle));
+    EXPECT_EQ(node.CurrentState(), ROMScanNodeStateMachine::State::Idle);
+}
+
 TEST(ROMScanNodeStateMachineTests, ResetForGenerationReinitializesNodeData) {
     ROMScanNodeStateMachine node(6, Generation{12}, FwSpeed::S100, 2);
     node.MutableROM().vendorName = "X";
     node.SetBIBInProgress(true);
+    node.SetSlowPublishRetriesLeft(3);
     node.ForceState(ROMScanNodeStateMachine::State::Failed);
 
     node.ResetForGeneration(Generation{20}, 7, FwSpeed::S200, 4);
@@ -45,4 +57,5 @@ TEST(ROMScanNodeStateMachineTests, ResetForGenerationReinitializesNodeData) {
     EXPECT_EQ(node.ROM().nodeId, 7);
     EXPECT_TRUE(node.ROM().vendorName.empty());
     EXPECT_FALSE(node.BIBInProgress());
+    EXPECT_EQ(node.SlowPublishRetriesLeft(), 0);
 }

--- a/tests/ROMScannerCompletionTests.cpp
+++ b/tests/ROMScannerCompletionTests.cpp
@@ -178,10 +178,11 @@ public:
 // Helper to create minimal BIB (Bus Info Block) for testing
 // Q0: info_length=1 (minimal ROM), crc_length=1, crc=valid
 // Format: [31:24]=info_length, [23:16]=crc_length, [15:0]=crc
-std::vector<uint32_t> CreateMinimalBIB() {
+std::vector<uint32_t> CreateMinimalBIB(uint64_t guid = 0) {
     // Minimal BIB: header quadlet + 4 quadlets of zeros
     // info_length=4 (standard BIB), crc_length=4 (minimal total ROM), crc=0x0000
-    return {0x04040000, 0, 0, 0, 0};
+    return {0x04040000, 0, 0, static_cast<uint32_t>(guid >> 32),
+            static_cast<uint32_t>(guid & 0xFFFFFFFF)};
 }
 
 // Helper to create full BIB with GUID
@@ -261,6 +262,135 @@ TEST(ROMScannerCompletion, ManualRead_MinimalROM_InvokesCallbackImmediately) {
     EXPECT_EQ(completedROMs.size(), 1u);
     EXPECT_EQ(completedROMs[0].nodeId, 1);
     EXPECT_EQ(completedROMs[0].gen.value, 42u);
+}
+
+TEST(ROMScannerCompletion, ManualRead_NikonMinimalROM_ProbesRootDirBeforeCompletion) {
+    MockAsyncSubsystem mockAsync;
+    SpeedPolicy speedPolicy;
+
+    bool callbackInvoked = false;
+    bool hadBusyNodes = false;
+    std::vector<ConfigROM> completedROMs;
+    std::mutex mtx;
+    std::condition_variable cv;
+
+    constexpr uint64_t kNikonGuid = 0x0090B54001FFFFFFULL;
+
+    ROMScannerParams params{};
+    params.doIRMCheck = false;
+    ROMScanner scanner(mockAsync, speedPolicy, params);
+
+    TopologySnapshot topology;
+    topology.generation = 43;
+    topology.busBase16 = 0xFFC0;
+    topology.nodes.push_back({.nodeId = 1, .linkActive = true});
+
+    ROMScanRequest request{};
+    request.gen = Generation{topology.generation};
+    request.topology = topology;
+    request.localNodeId = 0;
+    request.targetNodes = {1};
+
+    ScanCompletionCallback onComplete = [&](Generation /*gen*/, std::vector<ConfigROM> roms,
+                                            bool busy) {
+        std::lock_guard lock(mtx);
+        callbackInvoked = true;
+        hadBusyNodes = busy;
+        completedROMs = std::move(roms);
+        cv.notify_one();
+    };
+
+    ASSERT_TRUE(scanner.Start(request, onComplete));
+    mockAsync.WaitForPendingReads(1);
+
+    mockAsync.SimulateFullBIBSuccess(CreateMinimalBIB(kNikonGuid));
+
+    EXPECT_FALSE(callbackInvoked) << "Nikon minimal ROM should not complete immediately";
+
+    mockAsync.WaitForPendingReads(5);
+    EXPECT_EQ(mockAsync.GetPendingReadCount(), 5u)
+        << "Compatibility path should schedule a root directory probe";
+    EXPECT_EQ(mockAsync.pendingReads_[4].address.addressLo,
+              ASFW::FW::ConfigROMAddr::kAddressLo + 20u);
+
+    const std::vector<uint32_t> rootDir = {
+        0x00020000,
+        0x03000001,
+        0x17000002,
+    };
+    mockAsync.SimulateSequentialReads(4, rootDir);
+
+    {
+        std::unique_lock lock(mtx);
+        cv.wait_for(lock, std::chrono::seconds(1), [&callbackInvoked] { return callbackInvoked; });
+    }
+
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_TRUE(hadBusyNodes);
+    ASSERT_EQ(completedROMs.size(), 1u);
+    EXPECT_EQ(completedROMs[0].bib.guid, kNikonGuid);
+    EXPECT_FALSE(completedROMs[0].rootDirMinimal.empty());
+}
+
+TEST(ROMScannerCompletion, ManualRead_NikonMinimalROM_RootDirProbeTimeoutsThenCompletesMinimal) {
+    MockAsyncSubsystem mockAsync;
+    SpeedPolicy speedPolicy;
+
+    bool callbackInvoked = false;
+    bool hadBusyNodes = false;
+    std::vector<ConfigROM> completedROMs;
+    std::mutex mtx;
+    std::condition_variable cv;
+
+    constexpr uint64_t kNikonGuid = 0x0090B54001FFFFFFULL;
+
+    ROMScannerParams params{};
+    params.doIRMCheck = false;
+    ROMScanner scanner(mockAsync, speedPolicy, params);
+
+    TopologySnapshot topology;
+    topology.generation = 44;
+    topology.busBase16 = 0xFFC0;
+    topology.nodes.push_back({.nodeId = 1, .linkActive = true});
+
+    ROMScanRequest request{};
+    request.gen = Generation{topology.generation};
+    request.topology = topology;
+    request.localNodeId = 0;
+    request.targetNodes = {1};
+
+    ScanCompletionCallback onComplete = [&](Generation /*gen*/, std::vector<ConfigROM> roms,
+                                            bool busy) {
+        std::lock_guard lock(mtx);
+        callbackInvoked = true;
+        hadBusyNodes = busy;
+        completedROMs = std::move(roms);
+        cv.notify_one();
+    };
+
+    ASSERT_TRUE(scanner.Start(request, onComplete));
+    mockAsync.WaitForPendingReads(1);
+
+    mockAsync.SimulateFullBIBSuccess(CreateMinimalBIB(kNikonGuid));
+    EXPECT_FALSE(callbackInvoked);
+
+    for (size_t attempt = 0; attempt < 4; ++attempt) {
+        mockAsync.WaitForPendingReads(5 + attempt);
+        EXPECT_EQ(mockAsync.pendingReads_[4 + attempt].address.addressLo,
+                  ASFW::FW::ConfigROMAddr::kAddressLo + 20u);
+        mockAsync.SimulateReadTimeout(4 + attempt);
+    }
+
+    {
+        std::unique_lock lock(mtx);
+        cv.wait_for(lock, std::chrono::seconds(1), [&callbackInvoked] { return callbackInvoked; });
+    }
+
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_TRUE(hadBusyNodes);
+    ASSERT_EQ(completedROMs.size(), 1u);
+    EXPECT_EQ(completedROMs[0].bib.guid, kNikonGuid);
+    EXPECT_TRUE(completedROMs[0].rootDirMinimal.empty());
 }
 
 TEST(ROMScannerCompletion, ManualRead_FullROM_InvokesCallbackAfterBothReads) {
@@ -375,6 +505,7 @@ TEST(ROMScannerCompletion, ManualRead_Timeout_InvokesCallbackAfterRetryExhaustio
     std::condition_variable cv;
 
     ROMScannerParams params{};
+    params.startSpeed = FwSpeed::S100;
     params.doIRMCheck = false;
     ROMScanner scanner(mockAsync, speedPolicy, params);
 
@@ -419,6 +550,63 @@ TEST(ROMScannerCompletion, ManualRead_Timeout_InvokesCallbackAfterRetryExhaustio
     EXPECT_TRUE(hadBusyNodes);
 
     // No ROMs should be available (read failed)
+    EXPECT_EQ(completedROMs.size(), 0u);
+}
+
+TEST(ROMScannerCompletion, ManualRead_DefaultS400FallbackInvokesCallbackAfterFinalExhaustion) {
+    MockAsyncSubsystem mockAsync;
+    SpeedPolicy speedPolicy;
+
+    bool callbackInvoked = false;
+    bool hadBusyNodes = false;
+    std::vector<ConfigROM> completedROMs;
+    std::mutex mtx;
+    std::condition_variable cv;
+
+    ROMScannerParams params{};
+    params.doIRMCheck = false;
+    ROMScanner scanner(mockAsync, speedPolicy, params);
+
+    TopologySnapshot topology;
+    topology.generation = 8;
+    topology.busBase16 = 0xFFC0;
+    topology.nodes.push_back({.nodeId = 4, .linkActive = true});
+
+    ROMScanRequest request{};
+    request.gen = Generation{topology.generation};
+    request.topology = topology;
+    request.localNodeId = 0;
+    request.targetNodes = {4};
+
+    ScanCompletionCallback onComplete = [&](Generation /*gen*/, std::vector<ConfigROM> roms, bool busy) {
+        std::lock_guard lock(mtx);
+        callbackInvoked = true;
+        hadBusyNodes = busy;
+        completedROMs = std::move(roms);
+        cv.notify_one();
+    };
+
+    const bool initiated = scanner.Start(request, onComplete);
+    ASSERT_TRUE(initiated);
+
+    constexpr size_t kTimeoutsToExhaustS400S200S100 = 9;
+    for (size_t i = 0; i < kTimeoutsToExhaustS400S200S100; ++i) {
+        mockAsync.WaitForPendingReads(i + 1);
+        mockAsync.SimulateReadTimeout(i);
+        if (i + 1 < kTimeoutsToExhaustS400S200S100) {
+            mockAsync.WaitForPendingReads(i + 2);
+            std::lock_guard lock(mtx);
+            EXPECT_FALSE(callbackInvoked) << "Callback fired before final speed fallback exhaustion";
+        }
+    }
+
+    {
+        std::unique_lock lock(mtx);
+        cv.wait_for(lock, std::chrono::seconds(1), [&callbackInvoked] { return callbackInvoked; });
+    }
+
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_TRUE(hadBusyNodes);
     EXPECT_EQ(completedROMs.size(), 0u);
 }
 

--- a/tests/ResponseSenderHeaderFormatTests.cpp
+++ b/tests/ResponseSenderHeaderFormatTests.cpp
@@ -37,6 +37,8 @@ constexpr uint32_t OHCI_AT_Q1_RCODE_SHIFT = 12;
 
 // Transaction codes
 constexpr uint8_t TCODE_WRITE_RESPONSE = 0x2;
+constexpr uint8_t TCODE_READ_QUADLET_RESPONSE = 0x6;
+constexpr uint8_t TCODE_READ_BLOCK_RESPONSE = 0x7;
 
 // Speed codes
 constexpr uint8_t SPEED_S400 = 0x02;
@@ -82,6 +84,54 @@ void BuildWriteResponseHeader_OHCIFormat(
 
     // Q2: reserved for responses
     header[2] = 0;
+}
+
+void BuildReadQuadletResponseHeader_OHCIFormat(
+    uint16_t destID,
+    uint8_t tLabel,
+    uint8_t rcode,
+    uint32_t quadletData,
+    uint32_t header[4])
+{
+    constexpr uint8_t kSrcBusID = 0;
+    constexpr uint8_t kSpeed = SPEED_S400;
+    constexpr uint8_t kRetry = RETRY_X;
+    constexpr uint8_t kPriority = 0;
+
+    header[0] = (static_cast<uint32_t>(kSrcBusID & 0x01) << OHCI_AT_Q0_SRCBUSID_SHIFT) |
+                (static_cast<uint32_t>(kSpeed & 0x07) << OHCI_AT_Q0_SPEED_SHIFT) |
+                (static_cast<uint32_t>(tLabel & 0x3F) << OHCI_AT_Q0_TLABEL_SHIFT) |
+                (static_cast<uint32_t>(kRetry & 0x03) << OHCI_AT_Q0_RETRY_SHIFT) |
+                (static_cast<uint32_t>(TCODE_READ_QUADLET_RESPONSE & 0x0F) << OHCI_AT_Q0_TCODE_SHIFT) |
+                (static_cast<uint32_t>(kPriority) & OHCI_AT_Q0_PRIORITY_MASK);
+    header[1] = (static_cast<uint32_t>(destID) << OHCI_AT_Q1_DESTID_SHIFT) |
+                (static_cast<uint32_t>(rcode & 0x0F) << OHCI_AT_Q1_RCODE_SHIFT);
+    header[2] = 0;
+    header[3] = quadletData;
+}
+
+void BuildReadBlockResponseHeader_OHCIFormat(
+    uint16_t destID,
+    uint8_t tLabel,
+    uint8_t rcode,
+    uint16_t dataLength,
+    uint32_t header[4])
+{
+    constexpr uint8_t kSrcBusID = 0;
+    constexpr uint8_t kSpeed = SPEED_S400;
+    constexpr uint8_t kRetry = RETRY_X;
+    constexpr uint8_t kPriority = 0;
+
+    header[0] = (static_cast<uint32_t>(kSrcBusID & 0x01) << OHCI_AT_Q0_SRCBUSID_SHIFT) |
+                (static_cast<uint32_t>(kSpeed & 0x07) << OHCI_AT_Q0_SPEED_SHIFT) |
+                (static_cast<uint32_t>(tLabel & 0x3F) << OHCI_AT_Q0_TLABEL_SHIFT) |
+                (static_cast<uint32_t>(kRetry & 0x03) << OHCI_AT_Q0_RETRY_SHIFT) |
+                (static_cast<uint32_t>(TCODE_READ_BLOCK_RESPONSE & 0x0F) << OHCI_AT_Q0_TCODE_SHIFT) |
+                (static_cast<uint32_t>(kPriority) & OHCI_AT_Q0_PRIORITY_MASK);
+    header[1] = (static_cast<uint32_t>(destID) << OHCI_AT_Q1_DESTID_SHIFT) |
+                (static_cast<uint32_t>(rcode & 0x0F) << OHCI_AT_Q1_RCODE_SHIFT);
+    header[2] = 0;
+    header[3] = static_cast<uint32_t>(dataLength) << 16;
 }
 
 /**
@@ -264,4 +314,39 @@ TEST_F(ResponseSenderHeaderFormatTest, Regression_TCode_AtCorrectPosition) {
     uint8_t tCode = (header[0] >> 4) & 0x0F;
     EXPECT_EQ(TCODE_WRITE_RESPONSE, tCode)
         << "tCode should be WRITE_RESPONSE (0x2) at Q0 bits[7:4]";
+}
+
+TEST_F(ResponseSenderHeaderFormatTest, ReadQuadletResponse_HasExpectedTCodeAndData) {
+    uint32_t header[4]{};
+    constexpr uint32_t kQuadletData = 0xA1B2C3D4;
+    BuildReadQuadletResponseHeader_OHCIFormat(
+        kRemoteNodeID,
+        kTLabel,
+        kRCodeComplete,
+        kQuadletData,
+        header);
+
+    const uint8_t tCode = (header[0] >> 4) & 0x0F;
+    const uint8_t rCode = (header[1] >> 12) & 0x0F;
+    EXPECT_EQ(TCODE_READ_QUADLET_RESPONSE, tCode);
+    EXPECT_EQ(kRCodeComplete, rCode);
+    EXPECT_EQ(kQuadletData, header[3]);
+}
+
+TEST_F(ResponseSenderHeaderFormatTest, ReadBlockResponse_HasExpectedTCodeAndLength) {
+    uint32_t header[4]{};
+    constexpr uint16_t kDataLength = 32;
+    BuildReadBlockResponseHeader_OHCIFormat(
+        kRemoteNodeID,
+        kTLabel,
+        kRCodeComplete,
+        kDataLength,
+        header);
+
+    const uint8_t tCode = (header[0] >> 4) & 0x0F;
+    const uint8_t rCode = (header[1] >> 12) & 0x0F;
+    const uint16_t dataLength = static_cast<uint16_t>((header[3] >> 16) & 0xFFFF);
+    EXPECT_EQ(TCODE_READ_BLOCK_RESPONSE, tCode);
+    EXPECT_EQ(kRCodeComplete, rCode);
+    EXPECT_EQ(kDataLength, dataLength);
 }

--- a/tests/TransactionStorageTests.cpp
+++ b/tests/TransactionStorageTests.cpp
@@ -1,0 +1,51 @@
+#include "UserClient/Storage/TransactionStorage.hpp"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+
+namespace {
+
+TEST(TransactionStorageTests, StoresCompletePayloadBeyondLegacy512ByteLimit) {
+    ASFW::UserClient::TransactionStorage storage;
+    ASSERT_TRUE(storage.IsValid());
+
+    std::array<std::uint8_t, 640> payload{};
+    for (std::size_t i = 0; i < payload.size(); ++i) {
+        payload[i] = static_cast<std::uint8_t>(i & 0xffU);
+    }
+
+    EXPECT_TRUE(storage.StoreResult(0x1234, 7, 0x11, payload.data(),
+                                    static_cast<std::uint32_t>(payload.size())));
+
+    storage.Lock();
+    ASFW::UserClient::TransactionResult* result = storage.FindResult(0x1234);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result->status, 7U);
+    EXPECT_EQ(result->responseCode, 0x11U);
+    ASSERT_EQ(result->dataLength, payload.size());
+    ASSERT_NE(result->Data(), nullptr);
+    for (std::size_t i = 0; i < payload.size(); ++i) {
+        EXPECT_EQ(result->Data()[i], payload[i]) << "byte " << i;
+    }
+    storage.Unlock();
+}
+
+TEST(TransactionStorageTests, PreservesStatusAndEmptyPayload) {
+    ASFW::UserClient::TransactionStorage storage;
+    ASSERT_TRUE(storage.IsValid());
+
+    EXPECT_TRUE(storage.StoreResult(0x4321, 5, 0x04, nullptr, 0));
+
+    storage.Lock();
+    ASFW::UserClient::TransactionResult* result = storage.FindResult(0x4321);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result->status, 5U);
+    EXPECT_EQ(result->responseCode, 0x04U);
+    EXPECT_EQ(result->dataLength, 0U);
+    EXPECT_EQ(result->Data(), nullptr);
+    storage.Unlock();
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

This PR extracts the async, discovery, and bus-reset foundation fixes from the larger bring-up branch so they can be reviewed independently before higher-level protocol work.

### Async TX/RX Foundations

- Fix packet helper behavior used by async request/response routing
- Harden packet routing for request handlers and response sender paths
- Preserve response matching correctness across full generation values
- Retain full transaction response payloads instead of truncating larger results

### Bus Reset & Controller Bring-Up

- Add bounded recovery for manual resets that do not produce a bus-reset IRQ
- Delay discovery after accepted topology using the Apple-style scan delay
- Track reset diagnostics needed by recovery decisions
- Improve gap-count policy for unknown previous gap state and two-node local-root topologies
- Apply local contender eligibility while keeping root delegation policy-controlled

### Config ROM & Discovery

- Improve ROM scan fallback and completion behavior across speed retries
- Keep existing devices during inconclusive zero-ROM scans when topology still shows a remote link-active node
- Add discovery convergence checks to prevent premature device loss
- Extend device/unit discovery metadata and Swift parsing for the updated wire format

### Tests

- Async packet serialization compatibility tests
- Response sender header format tests
- Bus manager gap optimization tests
- Bus reset coordinator recovery tests
- Discovery convergence tests
- ROM scanner completion and node state machine tests
- Transaction storage tests

## Why this PR

These changes are shared foundations for subsequent protocol work, but they are useful and reviewable on their own. Keeping them separate reduces the follow-up PR size and lets reviewers focus first on async response handling, bus reset recovery, and discovery convergence.

This PR intentionally does not include higher-level protocol session/command plumbing, debug UI, local diagnostic scripts, install helpers, or documentation-only planning notes.

## Verification

```
cmake -S . -B build-pr1 -DCMAKE_BUILD_TYPE=Debug
cmake --build build-pr1 --target BusManagerGapOptimizationTests BusResetCoordinatorTests DiscoveryConvergenceTests ROMScanNodeStateMachineTests ROMScannerCompletionTests ResponseSenderHeaderFormatTests TransactionStorageTests ASFWPacketTests --parallel 8
```

Directly ran:

```
build-pr1/tests/BusManagerGapOptimizationTests
build-pr1/tests/BusResetCoordinatorTests
build-pr1/tests/DiscoveryConvergenceTests
build-pr1/tests/ROMScanNodeStateMachineTests
build-pr1/tests/ROMScannerCompletionTests
build-pr1/tests/ResponseSenderHeaderFormatTests
build-pr1/tests/TransactionStorageTests
build-pr1/tests/ASFWPacketTests
```

Also verified with:

```
xcodebuild -project ASFW.xcodeproj -scheme ASFW -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
```

The Xcode build succeeds. Existing Swift warnings and a CoreSimulator version warning are still present, but they do not block the build.
