### PR TITLE
fix(ci): isolate LLVM profile outputs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Run Tests
         run: |
           cd build/tests
-          ctest --output-on-failure -j$(sysctl -n hw.ncpu)
+          LLVM_PROFILE_FILE="$PWD/%p-%m.profraw" ctest --output-on-failure -j$(sysctl -n hw.ncpu)
 
       - name: Process C++ Coverage
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: macos-26
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      LLVM_PROFILE_FILE: ${{ github.workspace }}/build/tests/%p-%m.profraw
     steps:
       - uses: actions/checkout@v4
         with:
@@ -101,7 +102,7 @@ jobs:
       - name: Run Tests
         run: |
           cd build/tests
-          LLVM_PROFILE_FILE="$PWD/%p-%m.profraw" ctest --output-on-failure -j$(sysctl -n hw.ncpu)
+          ctest --output-on-failure -j$(sysctl -n hw.ncpu)
 
       - name: Process C++ Coverage
         run: |


### PR DESCRIPTION
## Summary

This PR makes the C++ coverage step deterministic when tests run in parallel. The workflow currently lets every instrumented test process write to the default `default.profraw`, which can produce mismatched or corrupted profile data under `ctest -j`.

Setting `LLVM_PROFILE_FILE` to include process/module placeholders gives each test process its own profile output before `llvm-profdata merge`.

## Context

This showed up on #19 after all 480 tests passed, when coverage processing failed with:

```
warning: build/tests/default.profraw: unrecognized instrumentation profile encoding format
error: no profile can be merged
```

A previous successful run on the same source tree already reported mismatched profile data, so this is a CI coverage stability fix rather than a product-code change.

## Verification

```
git diff --check
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-and-test.yml"); puts "yaml ok"'
```
