### PR TITLE
Use Float32 for RX capture path

### DIFF
--- a/ASFWDriver/Audio/Core/AudioEndpointRuntime.hpp
+++ b/ASFWDriver/Audio/Core/AudioEndpointRuntime.hpp
@@ -322,7 +322,7 @@ private:
         directOutputBase_ = reinterpret_cast<const float*>(
             static_cast<uintptr_t>(directOutputMap_->GetAddress()));
         directOutputBytes_ = directOutputMap_->GetLength();
-        directInputBase_ = reinterpret_cast<int32_t*>(
+        directInputBase_ = reinterpret_cast<float*>(
             static_cast<uintptr_t>(directInputMap_->GetAddress()));
         directInputBytes_ = directInputMap_->GetLength();
         directControl_ = reinterpret_cast<Runtime::AudioTransportControlBlock*>(
@@ -507,7 +507,7 @@ private:
     uint64_t directOutputBytes_{0};
     uint32_t directOutputCapacityFrames_{0};
     uint32_t directOutputChannels_{0};
-    int32_t* directInputBase_{nullptr};
+    float* directInputBase_{nullptr};
     uint64_t directInputBytes_{0};
     uint32_t directInputCapacityFrames_{0};
     uint32_t directInputChannels_{0};

--- a/ASFWDriver/Audio/DriverKit/ASFWAudioDriverDirect.cpp
+++ b/ASFWDriver/Audio/DriverKit/ASFWAudioDriverDirect.cpp
@@ -304,7 +304,7 @@ bool BindDirectAudioSkeleton(ASFWAudioDriver_IVars& ivars) noexcept {
         .guid = ivars.device.guid,
         .sampleRateHz = static_cast<uint32_t>(ivars.device.currentSampleRate),
         .memory = ASFW::Audio::Runtime::AudioStreamMemory{
-            .inputBase = reinterpret_cast<int32_t*>(static_cast<uintptr_t>(ivars.inputMap->GetAddress())),
+            .inputBase = reinterpret_cast<float*>(static_cast<uintptr_t>(ivars.inputMap->GetAddress())),
             .outputBase = reinterpret_cast<const float*>(static_cast<uintptr_t>(ivars.outputMap->GetAddress())),
             .inputFrameCapacity = inputFrameCapacity,
             .outputFrameCapacity = outputFrameCapacity,

--- a/ASFWDriver/Audio/DriverKit/ASFWAudioDriverGraph.cpp
+++ b/ASFWDriver/Audio/DriverKit/ASFWAudioDriverGraph.cpp
@@ -85,21 +85,6 @@ void CopyParsedConfigToDeviceState(const ASFW::Isoch::Audio::ParsedAudioDriverCo
     return kIOReturnSuccess;
 }
 
-void FillPcm24Format(IOUserAudioStreamBasicDescription& fmt,
-                     double sampleRate,
-                     uint32_t channels) noexcept {
-    fmt.mSampleRate = sampleRate;
-    fmt.mFormatID = IOUserAudioFormatID::LinearPCM;
-    fmt.mFormatFlags = static_cast<IOUserAudioFormatFlags>(
-        static_cast<uint32_t>(IOUserAudioFormatFlags::FormatFlagIsSignedInteger) |
-        static_cast<uint32_t>(IOUserAudioFormatFlags::FormatFlagsNativeEndian));
-    fmt.mBytesPerPacket = sizeof(int32_t) * channels;
-    fmt.mFramesPerPacket = 1;
-    fmt.mBytesPerFrame = sizeof(int32_t) * channels;
-    fmt.mChannelsPerFrame = channels;
-    fmt.mBitsPerChannel = 24;
-}
-
 void FillFloat32Format(IOUserAudioStreamBasicDescription& fmt,
                        double sampleRate,
                        uint32_t channels) noexcept {
@@ -243,7 +228,7 @@ kern_return_t BuildAudioGraph(ASFWAudioDriver& driver,
              ? "blocking" : "non-blocking");
 
     ASFW_LOG(Audio,
-             "ASFWAudioDriver: Forcing single advertised format: input=24-bit integer output=Float32");
+             "ASFWAudioDriver: Forcing single advertised format: input=Float32 output=Float32");
     ASFW_LOG(Audio,
              "ASFWAudioDriver: Effective runtime channels: input=%u output=%u aggregate=%u",
              ivars.device.inputChannelCount,
@@ -324,12 +309,12 @@ kern_return_t BuildAudioGraph(ASFWAudioDriver& driver,
     IOUserAudioStreamBasicDescription outputFormats[8] = {};
     const uint32_t formatCount = ivars.device.sampleRateCount > 8 ? 8 : ivars.device.sampleRateCount;
     for (uint32_t i = 0; i < formatCount; i++) {
-        FillPcm24Format(inputFormats[i], ivars.device.sampleRates[i], ivars.device.inputChannelCount);
+        FillFloat32Format(inputFormats[i], ivars.device.sampleRates[i], ivars.device.inputChannelCount);
         FillFloat32Format(outputFormats[i], ivars.device.sampleRates[i], ivars.device.outputChannelCount);
     }
 
     ASFW_LOG(Audio,
-             "ASFWAudioDriver: Created %u stream formats input=int24/%u ch output=float32/%u ch",
+             "ASFWAudioDriver: Created %u stream formats input=float32/%u ch output=float32/%u ch",
              formatCount,
              ivars.device.inputChannelCount,
              ivars.device.outputChannelCount);

--- a/ASFWDriver/Audio/DriverKit/Runtime/AudioStreamMemory.hpp
+++ b/ASFWDriver/Audio/DriverKit/Runtime/AudioStreamMemory.hpp
@@ -11,7 +11,7 @@ enum class AudioSampleStorage : uint32_t {
 };
 
 struct AudioStreamMemory final {
-    int32_t* inputBase{nullptr};
+    float* inputBase{nullptr};
     const float* outputBase{nullptr};
 
     uint32_t inputFrameCapacity{0};
@@ -38,7 +38,7 @@ struct AudioStreamMemory final {
         return HasInput() || HasOutput();
     }
 
-    [[nodiscard]] int32_t* InputFrame(uint64_t absoluteFrame) const noexcept {
+    [[nodiscard]] float* InputFrame(uint64_t absoluteFrame) const noexcept {
         if (!HasInput()) {
             return nullptr;
         }

--- a/ASFWDriver/Audio/DriverKit/Runtime/DirectAudioBindingSource.hpp
+++ b/ASFWDriver/Audio/DriverKit/Runtime/DirectAudioBindingSource.hpp
@@ -9,7 +9,7 @@ namespace ASFW::Audio::Runtime {
 struct DirectAudioBindingSnapshot {
     uint64_t generation{0};
 
-    int32_t* inputBase{nullptr};
+    float* inputBase{nullptr};
     uint64_t inputBytes{0};
     uint32_t inputFrames{0};
     uint32_t inputChannels{0};

--- a/ASFWDriver/Audio/Engine/Direct/DirectInputWriter.hpp
+++ b/ASFWDriver/Audio/Engine/Direct/DirectInputWriter.hpp
@@ -23,7 +23,7 @@ public:
         return binding_ != nullptr && binding_->HasInput();
     }
 
-    [[nodiscard]] int32_t* Frame(uint64_t absoluteFrame) const noexcept {
+    [[nodiscard]] float* Frame(uint64_t absoluteFrame) const noexcept {
         if (!IsBound()) {
             return nullptr;
         }

--- a/ASFWDriver/Audio/Engine/Direct/Rx/DirectRxPacketDecoder.hpp
+++ b/ASFWDriver/Audio/Engine/Direct/Rx/DirectRxPacketDecoder.hpp
@@ -2,23 +2,49 @@
 
 #include "DirectRxTypes.hpp"
 #include "../../../Wire/AM824/AM824Decoder.hpp"
-#include "../../../Wire/RawPcm24In32/RawPcm24In32Decoder.hpp"
 #include <cstdint>
 
 namespace ASFW::AudioEngine::Direct::Rx {
+
+namespace Detail {
+
+[[nodiscard]] constexpr float Signed24ToFloat32(int32_t sample) noexcept {
+    if (sample <= -8388608) {
+        return -1.0f;
+    }
+    return static_cast<float>(sample) / 8388607.0f;
+}
+
+[[nodiscard]] inline float DecodeAm824SlotToFloat32(uint32_t wireQuadlet) noexcept {
+    auto sample = ASFW::Isoch::AM824Decoder::DecodeSample(wireQuadlet);
+    return sample ? Signed24ToFloat32(*sample) : 0.0f;
+}
+
+[[nodiscard]] inline float DecodeRawSlotAsLabeledMBLAToFloat32(uint32_t wireQuadlet) noexcept {
+    const uint32_t hostQuadlet = OSSwapBigToHostInt32(wireQuadlet);
+    // Saffire raw capture carries native signed 24-in-32 slots. Normalize it
+    // to an AM824 MBLA slot by adding the 0x40 label at the wire/content seam;
+    // cross-validated with Linux amdtp-am824.c:170 and :200.
+    const uint32_t labeledHostQuadlet =
+        0x40000000u | (hostQuadlet & 0x00FFFFFFu);
+    return DecodeAm824SlotToFloat32(OSSwapHostToBigInt32(labeledHostQuadlet));
+}
+
+} // namespace Detail
 
 inline void DecodeDirectRxFrame(const uint32_t* inWireQuadlets,
                                 uint32_t pcmChannels,
                                 uint32_t am824Slots,
                                 ASFW::Encoding::AudioWireFormat format,
-                                int32_t* outPcmFrame) noexcept {
+                                float* outPcmFrame) noexcept {
+    (void)am824Slots;
     for (uint32_t ch = 0; ch < pcmChannels; ++ch) {
         if (format == ASFW::Encoding::AudioWireFormat::kRawPcm24In32) {
-            auto sample = ASFW::Encoding::RawPcm24In32::Decode(inWireQuadlets[ch]);
-            outPcmFrame[ch] = sample ? *sample : 0;
+            outPcmFrame[ch] =
+                Detail::DecodeRawSlotAsLabeledMBLAToFloat32(inWireQuadlets[ch]);
         } else {
-            auto sample = ASFW::Isoch::AM824Decoder::DecodeSample(inWireQuadlets[ch]);
-            outPcmFrame[ch] = sample ? *sample : 0;
+            outPcmFrame[ch] =
+                Detail::DecodeAm824SlotToFloat32(inWireQuadlets[ch]);
         }
     }
 }

--- a/ASFWDriver/Audio/Engine/Direct/Rx/RxAudioPacketProcessor.cpp
+++ b/ASFWDriver/Audio/Engine/Direct/Rx/RxAudioPacketProcessor.cpp
@@ -75,7 +75,7 @@ RxAudioPacketProcessorResult RxAudioPacketProcessor::ProcessPacket(const uint8_t
     // If armed: decode quadlets directly to ADK input memory
     const uint32_t* dataBlocks = &quadlets[2];
     for (size_t i = 0; i < eventCount; ++i) {
-        int32_t* frameOut = writer_.Frame(absoluteFrame + i);
+        float* frameOut = writer_.Frame(absoluteFrame + i);
         if (!frameOut) {
             result.status = DirectRxWriteStatus::kInvalidRange;
             return result;

--- a/ASFWDriver/Isoch/Receive/IsochReceiveContext.cpp
+++ b/ASFWDriver/Isoch/Receive/IsochReceiveContext.cpp
@@ -190,7 +190,7 @@ uint32_t IsochReceiveContext::Poll() {
                     directInputView_.memory.inputBase = snapshot.inputBase;
                     directInputView_.memory.inputFrameCapacity = snapshot.inputFrames;
                     directInputView_.memory.inputChannels = snapshot.inputChannels;
-                    directInputView_.memory.storage = ASFW::Audio::Runtime::AudioSampleStorage::kInt32Native;
+                    directInputView_.memory.storage = ASFW::Audio::Runtime::AudioSampleStorage::kFloat32Native;
                     directInputView_.control = snapshot.control;
                     directInputView_.deviceToHostAm824Slots = am824Slots_ > 0 ? am824Slots_ : snapshot.inputChannels;
                     directInputView_.hostToDeviceAm824Slots = snapshot.outputChannels;

--- a/tests/audio/AudioRuntime/AudioGraphBindingTests.cpp
+++ b/tests/audio/AudioRuntime/AudioGraphBindingTests.cpp
@@ -17,7 +17,7 @@ using ASFW::Audio::Runtime::AudioWireFormat;
 
 AudioGraphBinding MakeBinding(AudioTransportControlBlock* control,
                               IOUserAudioDevice* audioDevice,
-                              int32_t* input,
+                              float* input,
                               const float* output) {
     return AudioGraphBinding{
         .guid = 0x1122334455667788ULL,
@@ -42,7 +42,7 @@ AudioGraphBinding MakeBinding(AudioTransportControlBlock* control,
 TEST(AudioGraphBindingTests, InvalidWithoutGuid) {
     AudioTransportControlBlock control{};
     IOUserAudioDevice audioDevice{};
-    std::array<int32_t, 16> input{};
+    std::array<float, 16> input{};
 
     auto binding = MakeBinding(&control, &audioDevice, input.data(), nullptr);
     binding.guid = 0;
@@ -53,7 +53,7 @@ TEST(AudioGraphBindingTests, InvalidWithoutGuid) {
 TEST(AudioGraphBindingTests, InvalidWithoutSampleRate) {
     AudioTransportControlBlock control{};
     IOUserAudioDevice audioDevice{};
-    std::array<int32_t, 16> input{};
+    std::array<float, 16> input{};
 
     auto binding = MakeBinding(&control, &audioDevice, input.data(), nullptr);
     binding.sampleRateHz = 0;
@@ -63,7 +63,7 @@ TEST(AudioGraphBindingTests, InvalidWithoutSampleRate) {
 
 TEST(AudioGraphBindingTests, InvalidWithoutControl) {
     IOUserAudioDevice audioDevice{};
-    std::array<int32_t, 16> input{};
+    std::array<float, 16> input{};
 
     const auto binding = MakeBinding(nullptr, &audioDevice, input.data(), nullptr);
 
@@ -72,7 +72,7 @@ TEST(AudioGraphBindingTests, InvalidWithoutControl) {
 
 TEST(AudioGraphBindingTests, InvalidWithoutAudioDevice) {
     AudioTransportControlBlock control{};
-    std::array<int32_t, 16> input{};
+    std::array<float, 16> input{};
 
     const auto binding = MakeBinding(&control, nullptr, input.data(), nullptr);
 
@@ -82,7 +82,7 @@ TEST(AudioGraphBindingTests, InvalidWithoutAudioDevice) {
 TEST(AudioGraphBindingTests, ValidWithInputOnly) {
     AudioTransportControlBlock control{};
     IOUserAudioDevice audioDevice{};
-    std::array<int32_t, 16> input{};
+    std::array<float, 16> input{};
 
     const auto binding = MakeBinding(&control, &audioDevice, input.data(), nullptr);
 
@@ -106,7 +106,7 @@ TEST(AudioGraphBindingTests, ValidWithOutputOnly) {
 TEST(AudioGraphBindingTests, ValidWithDuplex) {
     AudioTransportControlBlock control{};
     IOUserAudioDevice audioDevice{};
-    std::array<int32_t, 16> input{};
+    std::array<float, 16> input{};
     std::array<float, 16> output{};
 
     const auto binding = MakeBinding(&control, &audioDevice, input.data(), output.data());

--- a/tests/audio/AudioRuntime/AudioStreamMemoryTests.cpp
+++ b/tests/audio/AudioRuntime/AudioStreamMemoryTests.cpp
@@ -10,7 +10,7 @@ namespace {
 using ASFW::Audio::Runtime::AudioStreamMemory;
 
 TEST(AudioStreamMemoryTests, InputFrameWrapsByFrameCapacityAndUsesChannelStride) {
-    std::array<int32_t, 8> input{};
+    std::array<float, 8> input{};
 
     const AudioStreamMemory memory{
         .inputBase = input.data(),
@@ -50,7 +50,7 @@ TEST(AudioStreamMemoryTests, MissingBuffersReturnNullAndReportInvalidDirections)
 }
 
 TEST(AudioStreamMemoryTests, MemoryIsValidWithEitherDirection) {
-    std::array<int32_t, 2> input{};
+    std::array<float, 2> input{};
     std::array<float, 2> output{};
 
     const AudioStreamMemory inputOnly{

--- a/tests/audio/AudioRuntime/DirectAudioDebugSnapshotTests.cpp
+++ b/tests/audio/AudioRuntime/DirectAudioDebugSnapshotTests.cpp
@@ -26,7 +26,7 @@ using ASFW::Audio::Runtime::ShouldLogDirectAudioDebugSnapshot;
 TEST(DirectAudioDebugSnapshotTests, CapturesBindingCountersAndCursors) {
     AudioTransportControlBlock control{};
     IOUserAudioDevice audioDevice{};
-    std::array<int32_t, 16> input{};
+    std::array<float, 16> input{};
     std::array<float, 16> output{};
 
     const AudioGraphBinding binding{

--- a/tests/audio/AudioRuntime/DirectAudioEngineTests.cpp
+++ b/tests/audio/AudioRuntime/DirectAudioEngineTests.cpp
@@ -21,7 +21,7 @@ using ASFW::AudioEngine::Direct::FireWireAudioEngine;
 
 AudioGraphBinding MakeDuplexBinding(AudioTransportControlBlock& control,
                                     IOUserAudioDevice& audioDevice,
-                                    int32_t* input,
+                                    float* input,
                                     const float* output) {
     return AudioGraphBinding{
         .guid = 0x1122334455667788ULL,
@@ -55,7 +55,7 @@ void PublishPlaybackWriteEnd(AudioTransportControlBlock& control,
 TEST(DirectAudioEngineTests, BindValidGraphBindsSubcomponents) {
     AudioTransportControlBlock control{};
     IOUserAudioDevice audioDevice{};
-    std::array<int32_t, 16> input{};
+    std::array<float, 16> input{};
     std::array<float, 16> output{};
     FireWireAudioEngine engine{};
 
@@ -72,7 +72,7 @@ TEST(DirectAudioEngineTests, BindValidGraphBindsSubcomponents) {
 TEST(DirectAudioEngineTests, BindInvalidGraphClearsState) {
     AudioTransportControlBlock control{};
     IOUserAudioDevice audioDevice{};
-    std::array<int32_t, 16> input{};
+    std::array<float, 16> input{};
     std::array<float, 16> output{};
     FireWireAudioEngine engine{};
 
@@ -91,7 +91,7 @@ TEST(DirectAudioEngineTests, BindInvalidGraphClearsState) {
 TEST(DirectAudioEngineTests, UnbindClearsState) {
     AudioTransportControlBlock control{};
     IOUserAudioDevice audioDevice{};
-    std::array<int32_t, 16> input{};
+    std::array<float, 16> input{};
     std::array<float, 16> output{};
     FireWireAudioEngine engine{};
 
@@ -108,7 +108,7 @@ TEST(DirectAudioEngineTests, UnbindClearsState) {
 TEST(DirectAudioEngineTests, OutputReaderUsesPlaybackRingCursorAvailability) {
     AudioTransportControlBlock control{};
     IOUserAudioDevice audioDevice{};
-    std::array<int32_t, 16> input{};
+    std::array<float, 16> input{};
     std::array<float, 16> output{};
     FireWireAudioEngine engine{};
 
@@ -126,7 +126,7 @@ TEST(DirectAudioEngineTests, OutputReaderUsesPlaybackRingCursorAvailability) {
 TEST(DirectAudioEngineTests, OutputReaderRejectsOverflowingFrameRange) {
     AudioTransportControlBlock control{};
     IOUserAudioDevice audioDevice{};
-    std::array<int32_t, 16> input{};
+    std::array<float, 16> input{};
     std::array<float, 16> output{};
     FireWireAudioEngine engine{};
 

--- a/tests/audio/IsochRxTimingTests.cpp
+++ b/tests/audio/IsochRxTimingTests.cpp
@@ -1,10 +1,12 @@
 #include <gtest/gtest.h>
 
+#include "Audio/DriverKit/Runtime/AudioGraphBinding.hpp"
 #include "Audio/Engine/Direct/DirectInputWriter.hpp"
 #include "Audio/Engine/Direct/Rx/RxAudioPacketProcessor.hpp"
 #include "Isoch/Receive/IsochRxTiming.hpp"
 
 #include <array>
+#include <atomic>
 #include <cstdint>
 
 namespace {
@@ -15,6 +17,24 @@ uint32_t EncodeCycleTimer(uint32_t seconds,
     return (seconds << ASFW::Timing::kCycleTimerSecondsShift) |
            (cycle << ASFW::Timing::kCycleTimerCyclesShift) |
            offset;
+}
+
+void WriteBE32(uint8_t* dest, uint32_t value) {
+    dest[0] = static_cast<uint8_t>(value >> 24);
+    dest[1] = static_cast<uint8_t>(value >> 16);
+    dest[2] = static_cast<uint8_t>(value >> 8);
+    dest[3] = static_cast<uint8_t>(value);
+}
+
+template <size_t PacketSize>
+void FillTwoChannelAmdtpPacket(std::array<uint8_t, PacketSize>& packet,
+                               uint32_t slot0,
+                               uint32_t slot1) {
+    static_assert(PacketSize >= 8 + 8 + 8);
+    WriteBE32(packet.data() + 8, 0x02020000u);
+    WriteBE32(packet.data() + 12, 0x9002FFFFu);
+    WriteBE32(packet.data() + 16, slot0);
+    WriteBE32(packet.data() + 20, slot1);
 }
 
 } // namespace
@@ -121,4 +141,84 @@ TEST(IsochRxTimingTests, PacketProcessorReturnsReceiveTimestamp) {
     EXPECT_EQ(result.receiveCycleTimestamp, 0xA123u);
     EXPECT_EQ(result.syt, 0x40B0u);
     EXPECT_EQ(result.framesDecoded, 1u);
+}
+
+TEST(IsochRxTimingTests, PacketProcessorWritesAM824CaptureAsFloat32) {
+    constexpr size_t kFrames = 1;
+    constexpr size_t kDbs = 2;
+    alignas(4) std::array<uint8_t, 8 + 8 + (kFrames * kDbs * 4)> packet{};
+    FillTwoChannelAmdtpPacket(packet, 0x40000000u, 0x407FFFFFu);
+
+    std::array<float, 8> input{};
+    ASFW::Audio::Runtime::AudioTransportControlBlock control{};
+    const ASFW::Audio::Runtime::AudioGraphBinding binding{
+        .sampleRateHz = 48000,
+        .memory = ASFW::Audio::Runtime::AudioStreamMemory{
+            .inputBase = input.data(),
+            .inputFrameCapacity = 4,
+            .inputChannels = 2,
+        },
+        .control = &control,
+        .deviceToHostAm824Slots = kDbs,
+    };
+
+    ASFW::AudioEngine::Direct::DirectInputWriter writer;
+    writer.Bind(&binding);
+    ASFW::AudioEngine::Direct::Rx::RxAudioPacketProcessor processor(
+        writer);
+
+    const auto result = processor.ProcessPacket(
+        packet.data(),
+        packet.size(),
+        0,
+        2,
+        kDbs,
+        ASFW::Encoding::AudioWireFormat::kAM824);
+
+    EXPECT_EQ(result.status,
+              ASFW::AudioEngine::Direct::Rx::DirectRxWriteStatus::kAvailable);
+    EXPECT_EQ(result.framesDecoded, 1u);
+    EXPECT_FLOAT_EQ(input[0], 0.0f);
+    EXPECT_FLOAT_EQ(input[1], 1.0f);
+    EXPECT_EQ(control.inputProducedEndFrame.load(std::memory_order_acquire),
+              1u);
+}
+
+TEST(IsochRxTimingTests, PacketProcessorAddsAM824LabelForRawSaffireCapture) {
+    constexpr size_t kFrames = 1;
+    constexpr size_t kDbs = 2;
+    alignas(4) std::array<uint8_t, 8 + 8 + (kFrames * kDbs * 4)> packet{};
+    FillTwoChannelAmdtpPacket(packet, 0x007FFFFFu, 0xFF800000u);
+
+    std::array<float, 8> input{};
+    ASFW::Audio::Runtime::AudioTransportControlBlock control{};
+    const ASFW::Audio::Runtime::AudioGraphBinding binding{
+        .sampleRateHz = 48000,
+        .memory = ASFW::Audio::Runtime::AudioStreamMemory{
+            .inputBase = input.data(),
+            .inputFrameCapacity = 4,
+            .inputChannels = 2,
+        },
+        .control = &control,
+        .deviceToHostAm824Slots = kDbs,
+    };
+
+    ASFW::AudioEngine::Direct::DirectInputWriter writer;
+    writer.Bind(&binding);
+    ASFW::AudioEngine::Direct::Rx::RxAudioPacketProcessor processor(
+        writer);
+
+    const auto result = processor.ProcessPacket(
+        packet.data(),
+        packet.size(),
+        0,
+        2,
+        kDbs,
+        ASFW::Encoding::AudioWireFormat::kRawPcm24In32);
+
+    EXPECT_EQ(result.status,
+              ASFW::AudioEngine::Direct::Rx::DirectRxWriteStatus::kAvailable);
+    EXPECT_EQ(result.framesDecoded, 1u);
+    EXPECT_FLOAT_EQ(input[0], 1.0f);
+    EXPECT_FLOAT_EQ(input[1], -1.0f);
 }

--- a/tests/devices/DiceDuplexRestartCoordinatorTests.cpp
+++ b/tests/devices/DiceDuplexRestartCoordinatorTests.cpp
@@ -150,7 +150,7 @@ public:
     bool CopyDirectAudioBinding(ASFW::Audio::Runtime::DirectAudioBindingSnapshot& out) noexcept override {
         out.generation = 1;
         out.valid = true;
-        out.inputBase = reinterpret_cast<int32_t*>(0x1234);
+        out.inputBase = reinterpret_cast<float*>(0x1234);
         out.inputFrames = 512;
         out.inputChannels = 8;
         out.outputBase = reinterpret_cast<const float*>(0x5678);


### PR DESCRIPTION
## Summary

- Advertise RX/input physical stream format as native Float32 to match the already-working TX/output path.
- Convert the direct RX capture binding and writer path to write `float*` input buffers.
- Keep AM824/raw handling at the wire edge, including synthesizing the `0x40` MBLA label for Saffire raw RX slots before decoding.
- Update direct-audio runtime tests and add RX packet processor coverage for AM824 Float32 capture and raw Saffire label normalization.

## Validation

- `./build.sh --test-only` passed: 1089/1089 run tests.
- `ctest --test-dir build/tests_build -V -R IsochRxTiming` passed.
- `git diff --check` clean.
- Hardware verified on Focusrite Saffire: TX and RX both working; Audio MIDI shows input/output physical and virtual formats as Float32.
