### PR TITLE
Fix SBP-2 session-scheduler deadlock (kernel registry busy-timeout panic)

### DIFF
--- a/ASFWDriver/Protocols/SBP2/Session/DriverKitSessionScheduler.cpp
+++ b/ASFWDriver/Protocols/SBP2/Session/DriverKitSessionScheduler.cpp
@@ -129,16 +129,23 @@ SchedulerToken DriverKitSessionScheduler::ScheduleAfter(uint64_t delayNs,
         return kInvalidSchedulerToken;
     }
 
-    IOLockGuard guard(lock_);
-    SchedulerToken token = nextToken_++;
-    if (token == kInvalidSchedulerToken) {
+    SchedulerToken token;
+    uint64_t earliest;
+    OSSharedPtr<IOTimerDispatchSource> timer;
+    {
+        IOLockGuard guard(lock_);
         token = nextToken_++;
+        if (token == kInvalidSchedulerToken) {
+            token = nextToken_++;
+        }
+        pending_.emplace(token, PendingCallback{
+                                    .deadlineTicks = DeadlineTicksFromNow(delayNs),
+                                    .fn = std::move(fn),
+                                });
+        earliest = EarliestDeadlineLocked();
+        timer = timer_;
     }
-    pending_.emplace(token, PendingCallback{
-                                .deadlineTicks = DeadlineTicksFromNow(delayNs),
-                                .fn = std::move(fn),
-                            });
-    ArmNextLocked();
+    ArmTimerUnlocked(timer.get(), earliest);
     return token;
 #endif
 }
@@ -148,14 +155,26 @@ void DriverKitSessionScheduler::Cancel(SchedulerToken token) {
         return;
     }
 
-    IOLockGuard guard(lock_);
-    if (pending_.erase(token) > 0) {
-        ArmNextLocked();
+    uint64_t earliest = 0;
+    OSSharedPtr<IOTimerDispatchSource> timer;
+    bool changed = false;
+    {
+        IOLockGuard guard(lock_);
+        if (pending_.erase(token) > 0) {
+            changed = true;
+            earliest = EarliestDeadlineLocked();
+            timer = timer_;
+        }
+    }
+    if (changed) {
+        ArmTimerUnlocked(timer.get(), earliest);
     }
 }
 
 void DriverKitSessionScheduler::HandleTimerFired() noexcept {
     std::vector<std::function<void()>> due;
+    uint64_t earliest = 0;
+    OSSharedPtr<IOTimerDispatchSource> timer;
 
     {
         IOLockGuard guard(lock_);
@@ -168,8 +187,10 @@ void DriverKitSessionScheduler::HandleTimerFired() noexcept {
                 ++it;
             }
         }
-        ArmNextLocked();
+        earliest = EarliestDeadlineLocked();
+        timer = timer_;
     }
+    ArmTimerUnlocked(timer.get(), earliest);
 
     for (auto& fn : due) {
         if (fn) {
@@ -178,24 +199,33 @@ void DriverKitSessionScheduler::HandleTimerFired() noexcept {
     }
 }
 
-void DriverKitSessionScheduler::ArmNextLocked() noexcept {
-#ifdef ASFW_HOST_TEST
-    return;
-#else
-    if (!timer_ || pending_.empty()) {
-        return;
+uint64_t DriverKitSessionScheduler::EarliestDeadlineLocked() const noexcept {
+    if (pending_.empty()) {
+        return 0;
     }
-
     const auto next = std::min_element(
         pending_.begin(), pending_.end(),
         [](const auto& a, const auto& b) {
             return a.second.deadlineTicks < b.second.deadlineTicks;
         });
-    if (next == pending_.end()) {
+    return next == pending_.end() ? 0 : next->second.deadlineTicks;
+}
+
+void DriverKitSessionScheduler::ArmTimerUnlocked(IOTimerDispatchSource* timer,
+                                                 uint64_t deadlineTicks) noexcept {
+#ifdef ASFW_HOST_TEST
+    (void)timer;
+    (void)deadlineTicks;
+#else
+    if (timer == nullptr || deadlineTicks == 0) {
         return;
     }
-
-    (void)timer_->WakeAtTime(kIOTimerClockMachAbsoluteTime, next->second.deadlineTicks, 0);
+    // lock_ MUST NOT be held here. WakeAtTime is RPC-dispatched to the timer's
+    // queue (ASFWDriver-Default); that queue's completion handlers re-enter the
+    // scheduler and take lock_. Holding lock_ across this call deadlocked the
+    // user-client teardown queue against the driver queue and tripped the 60s
+    // IOKit registry busy-timeout kernel panic (2026-06-22).
+    (void)timer->WakeAtTime(kIOTimerClockMachAbsoluteTime, deadlineTicks, 0);
 #endif
 }
 

--- a/ASFWDriver/Protocols/SBP2/Session/DriverKitSessionScheduler.hpp
+++ b/ASFWDriver/Protocols/SBP2/Session/DriverKitSessionScheduler.hpp
@@ -47,7 +47,13 @@ private:
         std::function<void()> fn;
     };
 
-    void ArmNextLocked() noexcept;
+    // Earliest pending deadline in mach-absolute ticks (0 = none). Caller holds lock_.
+    [[nodiscard]] uint64_t EarliestDeadlineLocked() const noexcept;
+    // Arms the hardware timer. MUST be called WITHOUT lock_ held: WakeAtTime is
+    // RPC-dispatched to the timer's queue (ASFWDriver-Default), whose handlers
+    // re-enter the scheduler and take lock_. Holding lock_ across it is an AB-BA
+    // deadlock (kernel registry busy-timeout panic, 2026-06-22).
+    void ArmTimerUnlocked(IOTimerDispatchSource* timer, uint64_t deadlineTicks) noexcept;
     [[nodiscard]] uint64_t DeadlineTicksFromNow(uint64_t delayNs) const noexcept;
 
     IOLock* lock_{nullptr};


### PR DESCRIPTION
## Problem

A full kernel panic (`busy timeout (60s): multiple entries holding the
registry busy ... @IOService.cpp`) can be triggered during SBP-2 session
teardown. The dext wedges instead of terminating, the IOKit termination
queue backs up, and after 60s the registry-busy watchdog panics the machine.

Root cause is an AB-BA deadlock between the user-client queue and the driver
queue, over the `DriverKitSessionScheduler` lock:

- **`ASFWDriverUserClient-Default`** (teardown): `UserClient::Stop`
  → `SessionRegistry::ReleaseOwner` → `LoginSession::Logout`
  → `StartLogoutTimer` → `ScheduleAfter` → `ArmNextLocked`, which calls
  `timer_->WakeAtTime()` **while holding `lock_`**. `WakeAtTime` is
  RPC-dispatched to the timer's queue (`ASFWDriver-Default`), so the thread
  blocks waiting for that queue.
- **`ASFWDriver-Default`** (concurrent logout-write completion off the AR
  interrupt): `OnLogoutWriteComplete` → `StartLogoutTimer` → `ScheduleAfter`
  → tries to take `lock_`.

Thread A holds `lock_` and waits for the driver queue; the driver queue holds
nothing but is blocked trying to take `lock_`. Deadlock → panic.

## Fix

Move the `WakeAtTime()` call out of the critical section. `ArmNextLocked` is
split into:
- `EarliestDeadlineLocked()` — pure read of the next deadline under `lock_`.
- `ArmTimerUnlocked()` — calls `WakeAtTime()` with `lock_` released.

Each call site computes the deadline (and retains an `OSSharedPtr` to the
timer for lifetime safety) inside the lock, then arms outside it. The timer's
queue handlers can now take `lock_` while another thread arms, so the cycle
can't form.

## Testing

- All host C++ tests pass (1143/1143).
- Verified on hardware (macOS 26 / Tahoe, OHCI FireWire): 30 rapid
  login + forced-`Stop` teardown cycles with the patched dext — no panic,
  dext stayed responsive every cycle. The same teardown path reliably
  panicked the machine before the fix.

## Note

A benign residual race remains (two threads can arm concurrently, so the
timer may arm slightly late); it self-corrects on the next `HandleTimerFired`
re-arm and never drops a callback. Fully serializing arming onto the timer's
own queue is possible but pulls in lifetime concerns, left out of this
minimal fix.
