### PR TITLE
FW-65: extract WaitForAsyncResult into a reusable sync/async bridge

### DIFF
--- a/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 ASFireWire Project
 
 #include "DiceDuplexRestartCoordinator.hpp"
+#include "SyncAsyncBridge.hpp"
 
 #include "../../Core/AudioRuntimeRegistry.hpp"
 #include "../../Model/ASFWAudioDevice.hpp"
@@ -47,7 +48,6 @@ constexpr uint8_t kDefaultItChannel = 0;
 constexpr uint32_t kPlaybackBandwidthUnits = 320;
 constexpr uint32_t kCaptureBandwidthUnits = 576;
 constexpr uint32_t kClockRequestWaitTimeoutMs = 15000;
-constexpr uint32_t kWaitPollMs = 10;
 
 [[nodiscard]] uint64_t UptimeMilliseconds() noexcept {
     mach_timebase_info_data_t timebase{};
@@ -534,54 +534,6 @@ void LogTerminal(const DiceRestartSession& session) noexcept {
                 session.guid,
                 session.restartId,
                 GenerationValue(session.topologyGeneration));
-}
-
-template <typename T>
-struct SyncResult {
-    IOReturn status{kIOReturnTimeout};
-    T value{};
-};
-
-template <typename T, typename StartFn>
-SyncResult<T> WaitForAsyncResult(StartFn&& fn,
-                                 uint32_t timeoutMs,
-                                 IOReturn timeoutStatus,
-                                 const std::atomic<bool>* cancel = nullptr) noexcept {
-    struct WaitState {
-        std::atomic<bool> done{false};
-        SyncResult<T> result{};
-    };
-
-    auto state = std::make_shared<WaitState>();
-    fn([state](IOReturn status, T value) {
-        state->result.status = status;
-        state->result.value = std::move(value);
-        state->done.store(true, std::memory_order_release);
-    });
-
-    for (uint32_t waited = 0; waited < timeoutMs; waited += kWaitPollMs) {
-        if (state->done.load(std::memory_order_acquire)) {
-            return state->result;
-        }
-        // FW-61: abort the blocking bridge promptly on teardown so the dice queue drains
-        // fast (instead of running to timeout) and the in-flight op issues no more MMIO.
-        // The completion that would set `done` is delivered on the core queue, which is
-        // blocked in DispatchSync during teardown, so cancel, not done, is what unblocks us.
-        if (cancel != nullptr && cancel->load(std::memory_order_acquire)) {
-            SyncResult<T> aborted{};
-            aborted.status = kIOReturnAborted;
-            return aborted;
-        }
-        IOSleep(kWaitPollMs);
-    }
-
-    if (state->done.load(std::memory_order_acquire)) {
-        return state->result;
-    }
-
-    SyncResult<T> timeout{};
-    timeout.status = timeoutStatus;
-    return timeout;
 }
 
 inline uint8_t ReadLocalSid(Driver::HardwareInterface& hw) noexcept {

--- a/ASFWDriver/Audio/Protocols/Backends/SyncAsyncBridge.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/SyncAsyncBridge.hpp
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2026 ASFireWire Project
+//
+// SyncAsyncBridge.hpp
+//
+// A reusable synchronous/asynchronous bridge (FW-65). WaitForAsyncResult starts an
+// async operation and blocks the calling thread, polling a shared completion flag until
+// the operation completes, a teardown cancel token fires (FW-61), or a timeout elapses.
+//
+// The definition bodies are copied verbatim from DiceDuplexRestartCoordinator.cpp (only the
+// linkage is upgraded — anonymous-namespace `constexpr` to header `inline constexpr`) so it
+// can be reused by both the DICE duplex path and (later) the AV/C path. Behaviour is
+// intentionally unchanged: same 10 ms poll interval, same cancel-token semantics, same
+// timeout mapping. This move must not alter any observable behaviour.
+
+#pragma once
+
+#include <DriverKit/IOLib.h>
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+namespace ASFW::Audio {
+
+// Poll interval for the blocking bridge, in milliseconds. Kept identical to the value the
+// helper used inside the coordinator; do not change without a behaviour review. `inline`
+// so the single definition is shared across every TU that includes this header.
+//
+// Note: this is distinct from DiceDuplexRestartCoordinator's own `kSyncBridgePollMs`, which
+// paces the coordinator's separate GUID/clock polling loops. The two are independent
+// constants that happen to both be 10 ms — do not unify them without a behaviour review.
+inline constexpr uint32_t kWaitPollMs = 10;
+
+template <typename T>
+struct SyncResult {
+    IOReturn status{kIOReturnTimeout};
+    T value{};
+};
+
+template <typename T, typename StartFn>
+SyncResult<T> WaitForAsyncResult(StartFn&& fn,
+                                 uint32_t timeoutMs,
+                                 IOReturn timeoutStatus,
+                                 const std::atomic<bool>* cancel = nullptr) noexcept {
+    struct WaitState {
+        std::atomic<bool> done{false};
+        SyncResult<T> result{};
+    };
+
+    auto state = std::make_shared<WaitState>();
+    fn([state](IOReturn status, T value) {
+        state->result.status = status;
+        state->result.value = std::move(value);
+        state->done.store(true, std::memory_order_release);
+    });
+
+    for (uint32_t waited = 0; waited < timeoutMs; waited += kWaitPollMs) {
+        if (state->done.load(std::memory_order_acquire)) {
+            return state->result;
+        }
+        // FW-61: abort the blocking bridge promptly on teardown so the dice queue drains
+        // fast (instead of running to timeout) and the in-flight op issues no more MMIO.
+        // The completion that would set `done` is delivered on the core queue, which is
+        // blocked in DispatchSync during teardown, so cancel, not done, is what unblocks us.
+        if (cancel != nullptr && cancel->load(std::memory_order_acquire)) {
+            SyncResult<T> aborted{};
+            aborted.status = kIOReturnAborted;
+            return aborted;
+        }
+        IOSleep(kWaitPollMs);
+    }
+
+    if (state->done.load(std::memory_order_acquire)) {
+        return state->result;
+    }
+
+    SyncResult<T> timeout{};
+    timeout.status = timeoutStatus;
+    return timeout;
+}
+
+} // namespace ASFW::Audio

--- a/tests/devices/CMakeLists.txt
+++ b/tests/devices/CMakeLists.txt
@@ -55,6 +55,11 @@ add_device_test(DiceDuplexRestartCoordinatorTests
     "${ASFW_DRIVER_DIR}/Bus/IRM/IRMClient.cpp"
 )
 
+# FW-65: sync/async bridge (WaitForAsyncResult) characterization tests (header-only)
+add_device_test(WaitForAsyncResultTests
+    WaitForAsyncResultTests.cpp
+)
+
 # Apogee protocol boolean control mapping tests
 add_device_test(ApogeeBooleanControlMappingTests
     ApogeeBooleanControlMappingTests.cpp

--- a/tests/devices/WaitForAsyncResultTests.cpp
+++ b/tests/devices/WaitForAsyncResultTests.cpp
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2026 ASFireWire Project
+//
+// FW-65 characterization tests for the WaitForAsyncResult sync/async bridge.
+//
+// These lock the exact observable behaviour of the helper extracted from
+// DiceDuplexRestartCoordinator.cpp into SyncAsyncBridge.hpp, so the move is provably
+// behaviour-preserving. Every timeout here is small (<= 60 ms) because the host mock
+// IOSleep is a real std::this_thread::sleep_for.
+
+#include <gtest/gtest.h>
+
+#include "Audio/Protocols/Backends/SyncAsyncBridge.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <utility>
+
+namespace {
+
+using ASFW::Audio::SyncResult;
+using ASFW::Audio::WaitForAsyncResult;
+
+// A completion delivered synchronously before any timeout is forwarded verbatim.
+TEST(WaitForAsyncResultTests, SuccessBeforeTimeout) {
+    const auto r = WaitForAsyncResult<int>(
+        [](auto cb) { cb(kIOReturnSuccess, 42); }, 60, kIOReturnTimeout);
+    EXPECT_EQ(r.status, kIOReturnSuccess);
+    EXPECT_EQ(r.value, 42);
+}
+
+// A non-success completion status is forwarded verbatim, paired with its value. This is
+// what drives the coordinator's rollback FSM, so it must not be flattened to a sentinel.
+TEST(WaitForAsyncResultTests, ErrorStatusForwardedVerbatim) {
+    const auto r = WaitForAsyncResult<int>(
+        [](auto cb) { cb(kIOReturnNoDevice, 7); }, 60, kIOReturnTimeout);
+    EXPECT_EQ(r.status, kIOReturnNoDevice);
+    EXPECT_EQ(r.value, 7);
+}
+
+// No completion -> the caller-supplied timeout status and a default-constructed value.
+TEST(WaitForAsyncResultTests, TimeoutReturnsSuppliedStatusAndDefaultValue) {
+    const auto r = WaitForAsyncResult<int>(
+        [](auto) { /* never completes */ }, 30, kIOReturnTimeout);
+    EXPECT_EQ(r.status, kIOReturnTimeout);
+    EXPECT_EQ(r.value, 0);
+}
+
+// The timeout status is whatever the caller passes, not hard-coded to kIOReturnTimeout.
+TEST(WaitForAsyncResultTests, TimeoutStatusIsCallerSupplied) {
+    const auto r = WaitForAsyncResult<int>(
+        [](auto) {}, 30, kIOReturnError);
+    EXPECT_EQ(r.status, kIOReturnError);
+}
+
+// Cancel token set while waiting -> aborts promptly (not at timeout) with kIOReturnAborted.
+// This is the FW-61 teardown unblock: the completion cannot arrive during teardown, so
+// cancel, not done, is what releases the waiter.
+TEST(WaitForAsyncResultTests, CancelDuringWaitReturnsAborted) {
+    std::atomic<bool> cancel{false};
+    std::thread setter([&cancel] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(15));
+        cancel.store(true, std::memory_order_release);
+    });
+
+    const auto start = std::chrono::steady_clock::now();
+    const auto r = WaitForAsyncResult<int>(
+        [](auto) { /* never completes */ }, 5000, kIOReturnTimeout, &cancel);
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+    setter.join();
+
+    EXPECT_EQ(r.status, kIOReturnAborted);
+    EXPECT_EQ(r.value, 0);
+    // Aborted long before the 5 s timeout would have elapsed.
+    EXPECT_LT(elapsed, std::chrono::milliseconds(2000));
+}
+
+// Cancel already set before the call -> aborts on the first loop iteration (cancel wins
+// over a still-pending operation).
+TEST(WaitForAsyncResultTests, CancelSetBeforeCallReturnsAborted) {
+    std::atomic<bool> cancel{true};
+    const auto start = std::chrono::steady_clock::now();
+    const auto r = WaitForAsyncResult<int>(
+        [](auto) {}, 5000, kIOReturnTimeout, &cancel);
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+    EXPECT_EQ(r.status, kIOReturnAborted);
+    EXPECT_LT(elapsed, std::chrono::milliseconds(2000));
+}
+
+// cancel == nullptr is safe (no dereference) and normal completion still works.
+TEST(WaitForAsyncResultTests, CancelNullptrIsSafe) {
+    const auto r = WaitForAsyncResult<int>(
+        [](auto cb) { cb(kIOReturnSuccess, 5); }, 60, kIOReturnTimeout, nullptr);
+    EXPECT_EQ(r.status, kIOReturnSuccess);
+    EXPECT_EQ(r.value, 5);
+}
+
+// A completion delivered asynchronously during the wait (from another thread) is picked up
+// by the poll loop and returned. Also exercises the by-value [state] capture: the callback
+// (holding the shared WaitState) outlives the WaitForAsyncResult frame via the worker
+// thread, so writing to the result is safe.
+TEST(WaitForAsyncResultTests, CompletionDuringWaitIsDelivered) {
+    std::thread worker;
+    const auto r = WaitForAsyncResult<int>(
+        [&worker](auto cb) {
+            worker = std::thread([cb = std::move(cb)]() mutable {
+                std::this_thread::sleep_for(std::chrono::milliseconds(20));
+                cb(kIOReturnSuccess, 99);
+            });
+        },
+        200, kIOReturnTimeout);
+    worker.join();
+    EXPECT_EQ(r.status, kIOReturnSuccess);
+    EXPECT_EQ(r.value, 99);
+}
+
+// timeoutMs == 0: the poll loop body never executes (0 < 0 is false), so the ONLY path that
+// can observe an inline completion is the post-loop final done.load(). A synchronous
+// completion must still be returned. This deterministically pins the final load that an
+// over-eager "dead code" cleanup would delete.
+TEST(WaitForAsyncResultTests, FinalLoadCatchesInlineCompletionWhenLoopSkipped) {
+    const auto r = WaitForAsyncResult<int>(
+        [](auto cb) { cb(kIOReturnSuccess, 77); }, 0, kIOReturnTimeout);
+    EXPECT_EQ(r.status, kIOReturnSuccess);
+    EXPECT_EQ(r.value, 77);
+}
+
+// timeoutMs == 0 with no completion -> immediate timeout.
+TEST(WaitForAsyncResultTests, ZeroTimeoutWithoutCompletionReturnsTimeout) {
+    const auto r = WaitForAsyncResult<int>([](auto) {}, 0, kIOReturnTimeout);
+    EXPECT_EQ(r.status, kIOReturnTimeout);
+    EXPECT_EQ(r.value, 0);
+}
+
+} // namespace


### PR DESCRIPTION
# FW-65: extract WaitForAsyncResult into a reusable sync/async bridge

Step 1 of FW-64. Behaviour-preserving mechanical move — no wire/timing/semantic change.

## What

Lifts the `WaitForAsyncResult<T>` poll-with-cancel-token helper (and its `SyncResult<T>` +
`kWaitPollMs`) out of `DiceDuplexRestartCoordinator.cpp`'s anonymous namespace into a
standalone header, `Audio/Protocols/Backends/SyncAsyncBridge.hpp`, so the DICE duplex path
and (later) the AV/C path can share it.

## Behaviour-preserving

- Definition bodies copied **byte-identical** — same 10 ms poll, same acquire/release
  ordering, same post-loop final `done` load, same timeout mapping, same **FW-61 cancel-token
  teardown** (`const std::atomic<bool>* cancel` → `kIOReturnAborted`).
- Placed in `namespace ASFW::Audio`, so the **6 call sites are textually unchanged** (no
  using-decls). Only linkage upgrades: anon-namespace `constexpr` → header `inline constexpr`.
- The coordinator's own `kSyncBridgePollMs` / `kSyncBridgeTimeoutMs` (separate polling loops)
  are untouched.

## Tests

New `tests/devices/WaitForAsyncResultTests.cpp` — 10 characterization tests locking the
observable contract (success/error forwarding, caller-supplied timeout status + default
value, cancel-during-wait / cancel-before / nullptr-safe, async completion delivery, the
final-load-on-loop-skip, zero timeout). Host tests, no hardware.

## Verification

- `WaitForAsyncResultTests`: 10/10
- `DiceDuplexRestartCoordinatorTests`: still 20/20 (unchanged)
- Full host suite: **1153/1153** (was 1143 + 10 new)

## Two things worth a glance (non-blocking)

1. **Namespace `ASFW::Audio`** (minimal — keeps call sites unchanged). A dedicated
   sub-namespace would be cleaner for the AV/C reuse but touches call sites, so it'd belong
   in a later ticket, not this pure-move diff. Happy to change if you'd prefer.
2. **Ticket wording:** FW-65 mentions `kSyncBridgePollMs`; the extracted helper actually uses
   a separate `kWaitPollMs` (both 10 ms, independent constants). No code change — just
   flagging so FW-70 doesn't inherit the ambiguity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
