### PR TITLE
FW-66: extract recovery-policy classification into DiceRecoveryPolicy.hpp

### DIFF
--- a/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 ASFireWire Project
 
 #include "DiceDuplexRestartCoordinator.hpp"
+#include "DiceRecoveryPolicy.hpp"
 
 #include "../../Core/AudioRuntimeRegistry.hpp"
 #include "../../Model/ASFWAudioDevice.hpp"
@@ -17,6 +18,9 @@
 #include <utility>
 
 namespace ASFW::Audio {
+
+// FW-66: the recovery-policy classification vocabulary now lives in DiceRecoveryPolicy.hpp.
+using namespace ASFW::Audio::Backends;
 
 namespace {
 
@@ -63,59 +67,6 @@ constexpr uint32_t kWaitPollMs = 10;
 
 [[nodiscard]] bool IsValidIsoChannel(uint8_t channel) noexcept {
     return channel <= 0x3F;
-}
-
-enum class DiceRecoveryDisposition : uint8_t {
-    kIgnore,
-    kRestart,
-    kFailSession,
-};
-
-enum class DiceRecoveryPolicyReason : uint8_t {
-    kRunningWithFootprint,
-    kRetryableFailure,
-    kIdleWithoutFootprint,
-    kSuppressedByStop,
-    kIdleApplyInvalidated,
-    kMissingDependency,
-    kNonRetryableFailure,
-};
-
-struct DiceRecoveryContext {
-    DiceRestartReason triggerReason{DiceRestartReason::kManualReconfigure};
-    DiceRestartState state{DiceRestartState::kIdle};
-    DiceRestartPhase phase{DiceRestartPhase::kIdle};
-    bool stopRequested{false};
-    bool hasRestartIntent{false};
-    bool hasHostFootprint{false};
-    bool hasDeviceFootprint{false};
-    bool hasDiceRecord{false};
-    bool hasProtocol{false};
-    bool lastFailureRetryable{false};
-};
-
-struct DiceRecoveryDecision {
-    DiceRecoveryDisposition disposition{DiceRecoveryDisposition::kIgnore};
-    DiceRecoveryPolicyReason reason{DiceRecoveryPolicyReason::kIdleWithoutFootprint};
-};
-
-[[nodiscard]] constexpr DiceRestartState RestartStateForStartReason(
-    DiceRestartReason reason) noexcept {
-    switch (reason) {
-        case DiceRestartReason::kBusResetRebind:
-        case DiceRestartReason::kRecoverAfterTimingLoss:
-        case DiceRestartReason::kRecoverAfterCycleInconsistent:
-        case DiceRestartReason::kRecoverAfterLockLoss:
-        case DiceRestartReason::kRecoverAfterTxFault:
-            return DiceRestartState::kRecovering;
-        case DiceRestartReason::kInitialStart:
-        case DiceRestartReason::kSampleRateChange:
-        case DiceRestartReason::kClockSourceChange:
-        case DiceRestartReason::kManualReconfigure:
-            return DiceRestartState::kStarting;
-    }
-
-    return DiceRestartState::kStarting;
 }
 
 [[nodiscard]] AudioDuplexChannels ResolveDuplexChannelsForRecord(
@@ -235,120 +186,8 @@ struct DiceRecoveryDecision {
     return "Unknown";
 }
 
-[[nodiscard]] constexpr const char* ToString(DiceRecoveryDisposition disposition) noexcept {
-    switch (disposition) {
-        case DiceRecoveryDisposition::kIgnore: return "Ignore";
-        case DiceRecoveryDisposition::kRestart: return "Restart";
-        case DiceRecoveryDisposition::kFailSession: return "FailSession";
-    }
-    return "Unknown";
-}
-
-[[nodiscard]] constexpr const char* ToString(DiceRecoveryPolicyReason reason) noexcept {
-    switch (reason) {
-        case DiceRecoveryPolicyReason::kRunningWithFootprint: return "running_with_footprint";
-        case DiceRecoveryPolicyReason::kRetryableFailure: return "retryable_failure";
-        case DiceRecoveryPolicyReason::kIdleWithoutFootprint: return "idle_without_footprint";
-        case DiceRecoveryPolicyReason::kSuppressedByStop: return "suppressed_by_stop";
-        case DiceRecoveryPolicyReason::kIdleApplyInvalidated: return "idle_apply_invalidated";
-        case DiceRecoveryPolicyReason::kMissingDependency: return "missing_dependency";
-        case DiceRecoveryPolicyReason::kNonRetryableFailure: return "non_retryable_failure";
-    }
-    return "unknown";
-}
-
 [[nodiscard]] constexpr uint32_t GenerationValue(FW::Generation generation) noexcept {
     return generation.value;
-}
-
-[[nodiscard]] constexpr bool IsRetryableStatus(IOReturn status) noexcept {
-    return status == kIOReturnTimeout ||
-           status == kIOReturnAborted ||
-           status == kIOReturnNotReady ||
-           status == kIOReturnNoDevice;
-}
-
-[[nodiscard]] constexpr DiceRestartFailureCause FailureCauseForReason(
-    DiceRestartReason reason) noexcept {
-    switch (reason) {
-        case DiceRestartReason::kBusResetRebind: return DiceRestartFailureCause::kBusResetRebind;
-        case DiceRestartReason::kRecoverAfterTimingLoss: return DiceRestartFailureCause::kTimingLoss;
-        case DiceRestartReason::kRecoverAfterCycleInconsistent:
-            return DiceRestartFailureCause::kCycleInconsistent;
-        case DiceRestartReason::kRecoverAfterLockLoss: return DiceRestartFailureCause::kLockLoss;
-        case DiceRestartReason::kRecoverAfterTxFault: return DiceRestartFailureCause::kTxFault;
-        case DiceRestartReason::kInitialStart:
-        case DiceRestartReason::kSampleRateChange:
-        case DiceRestartReason::kClockSourceChange:
-        case DiceRestartReason::kManualReconfigure:
-            return DiceRestartFailureCause::kNone;
-    }
-    return DiceRestartFailureCause::kNone;
-}
-
-[[nodiscard]] constexpr bool IsRecoveryReason(DiceRestartReason reason) noexcept {
-    return FailureCauseForReason(reason) != DiceRestartFailureCause::kNone;
-}
-
-[[nodiscard]] constexpr DiceRecoveryDecision EvaluateRecoveryPolicy(
-    const DiceRecoveryContext& context) noexcept {
-    if (context.stopRequested || context.state == DiceRestartState::kStopping) {
-        return {
-            .disposition = DiceRecoveryDisposition::kIgnore,
-            .reason = DiceRecoveryPolicyReason::kSuppressedByStop,
-        };
-    }
-
-    if (context.state == DiceRestartState::kApplyingIdleClock) {
-        return {
-            .disposition = DiceRecoveryDisposition::kIgnore,
-            .reason = DiceRecoveryPolicyReason::kIdleApplyInvalidated,
-        };
-    }
-
-    const bool hasRestartFootprint =
-        context.hasRestartIntent || context.hasHostFootprint || context.hasDeviceFootprint;
-
-    if (!context.hasDiceRecord || !context.hasProtocol) {
-        const bool activeSession =
-            context.state == DiceRestartState::kStarting ||
-            context.state == DiceRestartState::kRunning ||
-            context.state == DiceRestartState::kRecovering ||
-            context.state == DiceRestartState::kFailed ||
-            hasRestartFootprint;
-        return {
-            .disposition = activeSession ? DiceRecoveryDisposition::kFailSession
-                                         : DiceRecoveryDisposition::kIgnore,
-            .reason = activeSession ? DiceRecoveryPolicyReason::kMissingDependency
-                                    : DiceRecoveryPolicyReason::kIdleWithoutFootprint,
-        };
-    }
-
-    if (context.state == DiceRestartState::kFailed) {
-        return {
-            .disposition = context.lastFailureRetryable
-                ? DiceRecoveryDisposition::kRestart
-                : DiceRecoveryDisposition::kFailSession,
-            .reason = context.lastFailureRetryable
-                ? DiceRecoveryPolicyReason::kRetryableFailure
-                : DiceRecoveryPolicyReason::kNonRetryableFailure,
-        };
-    }
-
-    if (context.state == DiceRestartState::kStarting ||
-        context.state == DiceRestartState::kRunning ||
-        context.state == DiceRestartState::kRecovering ||
-        hasRestartFootprint) {
-        return {
-            .disposition = DiceRecoveryDisposition::kRestart,
-            .reason = DiceRecoveryPolicyReason::kRunningWithFootprint,
-        };
-    }
-
-    return {
-        .disposition = DiceRecoveryDisposition::kIgnore,
-        .reason = DiceRecoveryPolicyReason::kIdleWithoutFootprint,
-    };
 }
 
 void LogFsmEvent(const char* eventName,

--- a/ASFWDriver/Audio/Protocols/Backends/DiceRecoveryPolicy.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceRecoveryPolicy.hpp
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2026 ASFireWire Project
+//
+// DiceRecoveryPolicy.hpp
+//
+// The recovery-policy classification vocabulary (FW-66): the pure `EvaluateRecoveryPolicy`
+// kernel plus the reason classifiers (`RestartStateForStartReason`, `FailureCauseForReason`,
+// `IsRecoveryReason`), the retryability predicate (`IsRetryableStatus`), the enums,
+// context/decision structs and ToString overloads they depend on. Extracted from
+// DiceDuplexRestartCoordinator.cpp so classification is a standalone, directly-testable unit
+// with no dependency on the session store or logging (per FW-66). Classification returns
+// facts; recording/logging them stays in the coordinator (FW-69 journal).
+//
+// The definitions are copied verbatim from the coordinator's anonymous namespace (only the
+// linkage changes: anonymous-namespace to a named `ASFW::Audio::Backends` namespace so the
+// header is includable). Behaviour is intentionally unchanged — this is a mechanical move.
+// The names keep their `Dice*` prefix for now; the DICE->neutral rename is FW-71's job.
+
+#pragma once
+
+#include "../DICE/Core/DICERestartSession.hpp"
+
+#include <DriverKit/IOLib.h>
+
+#include <cstdint>
+
+namespace ASFW::Audio::Backends {
+
+// The recovery policy is expressed over the DICE restart-session vocabulary; bring those
+// types into scope so the moved bodies stay byte-identical (they referenced them unqualified
+// inside the coordinator via the same using-declarations).
+using ASFW::Audio::DICE::DiceRestartFailureCause;
+using ASFW::Audio::DICE::DiceRestartPhase;
+using ASFW::Audio::DICE::DiceRestartReason;
+using ASFW::Audio::DICE::DiceRestartState;
+
+enum class DiceRecoveryDisposition : uint8_t {
+    kIgnore,
+    kRestart,
+    kFailSession,
+};
+
+enum class DiceRecoveryPolicyReason : uint8_t {
+    kRunningWithFootprint,
+    kRetryableFailure,
+    kIdleWithoutFootprint,
+    kSuppressedByStop,
+    kIdleApplyInvalidated,
+    kMissingDependency,
+    kNonRetryableFailure,
+};
+
+struct DiceRecoveryContext {
+    DiceRestartReason triggerReason{DiceRestartReason::kManualReconfigure};
+    DiceRestartState state{DiceRestartState::kIdle};
+    DiceRestartPhase phase{DiceRestartPhase::kIdle};
+    bool stopRequested{false};
+    bool hasRestartIntent{false};
+    bool hasHostFootprint{false};
+    bool hasDeviceFootprint{false};
+    bool hasDiceRecord{false};
+    bool hasProtocol{false};
+    bool lastFailureRetryable{false};
+};
+
+struct DiceRecoveryDecision {
+    DiceRecoveryDisposition disposition{DiceRecoveryDisposition::kIgnore};
+    DiceRecoveryPolicyReason reason{DiceRecoveryPolicyReason::kIdleWithoutFootprint};
+};
+
+[[nodiscard]] constexpr const char* ToString(DiceRecoveryDisposition disposition) noexcept {
+    switch (disposition) {
+        case DiceRecoveryDisposition::kIgnore: return "Ignore";
+        case DiceRecoveryDisposition::kRestart: return "Restart";
+        case DiceRecoveryDisposition::kFailSession: return "FailSession";
+    }
+    return "Unknown";
+}
+
+[[nodiscard]] constexpr const char* ToString(DiceRecoveryPolicyReason reason) noexcept {
+    switch (reason) {
+        case DiceRecoveryPolicyReason::kRunningWithFootprint: return "running_with_footprint";
+        case DiceRecoveryPolicyReason::kRetryableFailure: return "retryable_failure";
+        case DiceRecoveryPolicyReason::kIdleWithoutFootprint: return "idle_without_footprint";
+        case DiceRecoveryPolicyReason::kSuppressedByStop: return "suppressed_by_stop";
+        case DiceRecoveryPolicyReason::kIdleApplyInvalidated: return "idle_apply_invalidated";
+        case DiceRecoveryPolicyReason::kMissingDependency: return "missing_dependency";
+        case DiceRecoveryPolicyReason::kNonRetryableFailure: return "non_retryable_failure";
+    }
+    return "unknown";
+}
+
+[[nodiscard]] constexpr bool IsRetryableStatus(IOReturn status) noexcept {
+    return status == kIOReturnTimeout ||
+           status == kIOReturnAborted ||
+           status == kIOReturnNotReady ||
+           status == kIOReturnNoDevice;
+}
+
+[[nodiscard]] constexpr DiceRestartFailureCause FailureCauseForReason(
+    DiceRestartReason reason) noexcept {
+    switch (reason) {
+        case DiceRestartReason::kBusResetRebind: return DiceRestartFailureCause::kBusResetRebind;
+        case DiceRestartReason::kRecoverAfterTimingLoss: return DiceRestartFailureCause::kTimingLoss;
+        case DiceRestartReason::kRecoverAfterCycleInconsistent:
+            return DiceRestartFailureCause::kCycleInconsistent;
+        case DiceRestartReason::kRecoverAfterLockLoss: return DiceRestartFailureCause::kLockLoss;
+        case DiceRestartReason::kRecoverAfterTxFault: return DiceRestartFailureCause::kTxFault;
+        case DiceRestartReason::kInitialStart:
+        case DiceRestartReason::kSampleRateChange:
+        case DiceRestartReason::kClockSourceChange:
+        case DiceRestartReason::kManualReconfigure:
+            return DiceRestartFailureCause::kNone;
+    }
+    return DiceRestartFailureCause::kNone;
+}
+
+[[nodiscard]] constexpr bool IsRecoveryReason(DiceRestartReason reason) noexcept {
+    return FailureCauseForReason(reason) != DiceRestartFailureCause::kNone;
+}
+
+[[nodiscard]] constexpr DiceRestartState RestartStateForStartReason(
+    DiceRestartReason reason) noexcept {
+    switch (reason) {
+        case DiceRestartReason::kBusResetRebind:
+        case DiceRestartReason::kRecoverAfterTimingLoss:
+        case DiceRestartReason::kRecoverAfterCycleInconsistent:
+        case DiceRestartReason::kRecoverAfterLockLoss:
+        case DiceRestartReason::kRecoverAfterTxFault:
+            return DiceRestartState::kRecovering;
+        case DiceRestartReason::kInitialStart:
+        case DiceRestartReason::kSampleRateChange:
+        case DiceRestartReason::kClockSourceChange:
+        case DiceRestartReason::kManualReconfigure:
+            return DiceRestartState::kStarting;
+    }
+
+    return DiceRestartState::kStarting;
+}
+
+[[nodiscard]] constexpr DiceRecoveryDecision EvaluateRecoveryPolicy(
+    const DiceRecoveryContext& context) noexcept {
+    if (context.stopRequested || context.state == DiceRestartState::kStopping) {
+        return {
+            .disposition = DiceRecoveryDisposition::kIgnore,
+            .reason = DiceRecoveryPolicyReason::kSuppressedByStop,
+        };
+    }
+
+    if (context.state == DiceRestartState::kApplyingIdleClock) {
+        return {
+            .disposition = DiceRecoveryDisposition::kIgnore,
+            .reason = DiceRecoveryPolicyReason::kIdleApplyInvalidated,
+        };
+    }
+
+    const bool hasRestartFootprint =
+        context.hasRestartIntent || context.hasHostFootprint || context.hasDeviceFootprint;
+
+    if (!context.hasDiceRecord || !context.hasProtocol) {
+        const bool activeSession =
+            context.state == DiceRestartState::kStarting ||
+            context.state == DiceRestartState::kRunning ||
+            context.state == DiceRestartState::kRecovering ||
+            context.state == DiceRestartState::kFailed ||
+            hasRestartFootprint;
+        return {
+            .disposition = activeSession ? DiceRecoveryDisposition::kFailSession
+                                         : DiceRecoveryDisposition::kIgnore,
+            .reason = activeSession ? DiceRecoveryPolicyReason::kMissingDependency
+                                    : DiceRecoveryPolicyReason::kIdleWithoutFootprint,
+        };
+    }
+
+    if (context.state == DiceRestartState::kFailed) {
+        return {
+            .disposition = context.lastFailureRetryable
+                ? DiceRecoveryDisposition::kRestart
+                : DiceRecoveryDisposition::kFailSession,
+            .reason = context.lastFailureRetryable
+                ? DiceRecoveryPolicyReason::kRetryableFailure
+                : DiceRecoveryPolicyReason::kNonRetryableFailure,
+        };
+    }
+
+    if (context.state == DiceRestartState::kStarting ||
+        context.state == DiceRestartState::kRunning ||
+        context.state == DiceRestartState::kRecovering ||
+        hasRestartFootprint) {
+        return {
+            .disposition = DiceRecoveryDisposition::kRestart,
+            .reason = DiceRecoveryPolicyReason::kRunningWithFootprint,
+        };
+    }
+
+    return {
+        .disposition = DiceRecoveryDisposition::kIgnore,
+        .reason = DiceRecoveryPolicyReason::kIdleWithoutFootprint,
+    };
+}
+
+} // namespace ASFW::Audio::Backends

--- a/tests/devices/CMakeLists.txt
+++ b/tests/devices/CMakeLists.txt
@@ -55,6 +55,11 @@ add_device_test(DiceDuplexRestartCoordinatorTests
     "${ASFW_DRIVER_DIR}/Bus/IRM/IRMClient.cpp"
 )
 
+# DICE recovery-policy classification kernel tests (FW-66, header-only policy)
+add_device_test(DiceRecoveryPolicyTests
+    DiceRecoveryPolicyTests.cpp
+)
+
 # Apogee protocol boolean control mapping tests
 add_device_test(ApogeeBooleanControlMappingTests
     ApogeeBooleanControlMappingTests.cpp

--- a/tests/devices/DiceRecoveryPolicyTests.cpp
+++ b/tests/devices/DiceRecoveryPolicyTests.cpp
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2026 ASFireWire Project
+//
+// FW-66 characterization tests for the recovery-policy decision kernel extracted from
+// DiceDuplexRestartCoordinator.cpp into DiceRecoveryPolicy.hpp.
+//
+// The kernel was previously trapped in an anonymous namespace with no direct coverage (only
+// transitive coverage via the coordinator's RecoverStreaming integration tests). These tests
+// lock the exact current decision table, so the extraction is provably behaviour-preserving
+// and the policy is guarded going forward. The functions are constexpr, so the core
+// invariants are also asserted at compile time.
+
+#include <gtest/gtest.h>
+
+#include "Audio/Protocols/Backends/DiceRecoveryPolicy.hpp"
+
+namespace {
+
+using namespace ASFW::Audio::Backends;
+
+// A context with dependencies satisfied (record + protocol present) and neither stop nor
+// idle-apply, so the state/footprint branches are reached. Individual tests tweak fields.
+constexpr DiceRecoveryContext WithDeps(DiceRestartState state) noexcept {
+    DiceRecoveryContext c{};
+    c.state = state;
+    c.hasDiceRecord = true;
+    c.hasProtocol = true;
+    return c;
+}
+
+// ---- IsRetryableStatus: exactly four codes retry ----
+static_assert(IsRetryableStatus(kIOReturnTimeout));
+static_assert(IsRetryableStatus(kIOReturnAborted));
+static_assert(IsRetryableStatus(kIOReturnNotReady));
+static_assert(IsRetryableStatus(kIOReturnNoDevice));
+static_assert(!IsRetryableStatus(kIOReturnSuccess));
+static_assert(!IsRetryableStatus(kIOReturnError));
+
+// ---- FailureCauseForReason / IsRecoveryReason ----
+static_assert(FailureCauseForReason(DiceRestartReason::kBusResetRebind) ==
+              DiceRestartFailureCause::kBusResetRebind);
+static_assert(FailureCauseForReason(DiceRestartReason::kRecoverAfterTimingLoss) ==
+              DiceRestartFailureCause::kTimingLoss);
+static_assert(FailureCauseForReason(DiceRestartReason::kRecoverAfterCycleInconsistent) ==
+              DiceRestartFailureCause::kCycleInconsistent);
+static_assert(FailureCauseForReason(DiceRestartReason::kRecoverAfterLockLoss) ==
+              DiceRestartFailureCause::kLockLoss);
+static_assert(FailureCauseForReason(DiceRestartReason::kRecoverAfterTxFault) ==
+              DiceRestartFailureCause::kTxFault);
+static_assert(FailureCauseForReason(DiceRestartReason::kInitialStart) ==
+              DiceRestartFailureCause::kNone);
+static_assert(FailureCauseForReason(DiceRestartReason::kManualReconfigure) ==
+              DiceRestartFailureCause::kNone);
+static_assert(FailureCauseForReason(DiceRestartReason::kSampleRateChange) ==
+              DiceRestartFailureCause::kNone);
+static_assert(FailureCauseForReason(DiceRestartReason::kClockSourceChange) ==
+              DiceRestartFailureCause::kNone);
+static_assert(IsRecoveryReason(DiceRestartReason::kBusResetRebind));
+static_assert(!IsRecoveryReason(DiceRestartReason::kInitialStart));
+static_assert(!IsRecoveryReason(DiceRestartReason::kSampleRateChange));
+static_assert(!IsRecoveryReason(DiceRestartReason::kClockSourceChange));
+static_assert(!IsRecoveryReason(DiceRestartReason::kManualReconfigure));
+
+// ---- RestartStateForStartReason: reason -> restart state ----
+static_assert(RestartStateForStartReason(DiceRestartReason::kBusResetRebind) ==
+              DiceRestartState::kRecovering);
+static_assert(RestartStateForStartReason(DiceRestartReason::kRecoverAfterTimingLoss) ==
+              DiceRestartState::kRecovering);
+static_assert(RestartStateForStartReason(DiceRestartReason::kRecoverAfterCycleInconsistent) ==
+              DiceRestartState::kRecovering);
+static_assert(RestartStateForStartReason(DiceRestartReason::kRecoverAfterLockLoss) ==
+              DiceRestartState::kRecovering);
+static_assert(RestartStateForStartReason(DiceRestartReason::kRecoverAfterTxFault) ==
+              DiceRestartState::kRecovering);
+static_assert(RestartStateForStartReason(DiceRestartReason::kInitialStart) ==
+              DiceRestartState::kStarting);
+static_assert(RestartStateForStartReason(DiceRestartReason::kSampleRateChange) ==
+              DiceRestartState::kStarting);
+static_assert(RestartStateForStartReason(DiceRestartReason::kClockSourceChange) ==
+              DiceRestartState::kStarting);
+static_assert(RestartStateForStartReason(DiceRestartReason::kManualReconfigure) ==
+              DiceRestartState::kStarting);
+// Cross-invariant: a reason enters kRecovering exactly when it has a failure cause.
+static_assert(RestartStateForStartReason(DiceRestartReason::kRecoverAfterLockLoss) ==
+                  DiceRestartState::kRecovering &&
+              IsRecoveryReason(DiceRestartReason::kRecoverAfterLockLoss));
+static_assert(RestartStateForStartReason(DiceRestartReason::kManualReconfigure) ==
+                  DiceRestartState::kStarting &&
+              !IsRecoveryReason(DiceRestartReason::kManualReconfigure));
+
+// ---- EvaluateRecoveryPolicy: compile-time locks on the branch precedence ----
+static_assert(EvaluateRecoveryPolicy(WithDeps(DiceRestartState::kIdle)).disposition ==
+              DiceRecoveryDisposition::kIgnore);
+static_assert(EvaluateRecoveryPolicy(WithDeps(DiceRestartState::kRunning)).disposition ==
+              DiceRecoveryDisposition::kRestart);
+static_assert(EvaluateRecoveryPolicy(WithDeps(DiceRestartState::kStopping)).reason ==
+              DiceRecoveryPolicyReason::kSuppressedByStop);
+
+TEST(DiceRecoveryPolicyTests, RetryableStatusSet) {
+    EXPECT_TRUE(IsRetryableStatus(kIOReturnTimeout));
+    EXPECT_TRUE(IsRetryableStatus(kIOReturnNoDevice));
+    EXPECT_FALSE(IsRetryableStatus(kIOReturnSuccess));
+    EXPECT_FALSE(IsRetryableStatus(kIOReturnError));
+}
+
+TEST(DiceRecoveryPolicyTests, RecoveryReasonMapping) {
+    EXPECT_TRUE(IsRecoveryReason(DiceRestartReason::kRecoverAfterLockLoss));
+    EXPECT_FALSE(IsRecoveryReason(DiceRestartReason::kSampleRateChange));
+    EXPECT_EQ(FailureCauseForReason(DiceRestartReason::kRecoverAfterTxFault),
+              DiceRestartFailureCause::kTxFault);
+}
+
+TEST(DiceRecoveryPolicyTests, RestartStateForStartReasonMapping) {
+    // Recovery reasons enter kRecovering; deliberate (re)starts enter kStarting.
+    EXPECT_EQ(RestartStateForStartReason(DiceRestartReason::kBusResetRebind),
+              DiceRestartState::kRecovering);
+    EXPECT_EQ(RestartStateForStartReason(DiceRestartReason::kRecoverAfterTxFault),
+              DiceRestartState::kRecovering);
+    EXPECT_EQ(RestartStateForStartReason(DiceRestartReason::kInitialStart),
+              DiceRestartState::kStarting);
+    EXPECT_EQ(RestartStateForStartReason(DiceRestartReason::kManualReconfigure),
+              DiceRestartState::kStarting);
+}
+
+// stop wins over everything, including an otherwise-restartable running session.
+TEST(DiceRecoveryPolicyTests, StopRequestedIsSuppressed) {
+    DiceRecoveryContext c = WithDeps(DiceRestartState::kRunning);
+    c.stopRequested = true;
+    const auto d = EvaluateRecoveryPolicy(c);
+    EXPECT_EQ(d.disposition, DiceRecoveryDisposition::kIgnore);
+    EXPECT_EQ(d.reason, DiceRecoveryPolicyReason::kSuppressedByStop);
+}
+
+TEST(DiceRecoveryPolicyTests, StoppingStateIsSuppressed) {
+    const auto d = EvaluateRecoveryPolicy(WithDeps(DiceRestartState::kStopping));
+    EXPECT_EQ(d.disposition, DiceRecoveryDisposition::kIgnore);
+    EXPECT_EQ(d.reason, DiceRecoveryPolicyReason::kSuppressedByStop);
+}
+
+TEST(DiceRecoveryPolicyTests, ApplyingIdleClockIsInvalidated) {
+    const auto d = EvaluateRecoveryPolicy(WithDeps(DiceRestartState::kApplyingIdleClock));
+    EXPECT_EQ(d.disposition, DiceRecoveryDisposition::kIgnore);
+    EXPECT_EQ(d.reason, DiceRecoveryPolicyReason::kIdleApplyInvalidated);
+}
+
+// Missing record/protocol + an active session (or footprint) -> fail the session.
+TEST(DiceRecoveryPolicyTests, MissingDependencyWithActiveSessionFails) {
+    DiceRecoveryContext c{};
+    c.state = DiceRestartState::kRunning;
+    c.hasDiceRecord = false;
+    c.hasProtocol = true;
+    const auto d = EvaluateRecoveryPolicy(c);
+    EXPECT_EQ(d.disposition, DiceRecoveryDisposition::kFailSession);
+    EXPECT_EQ(d.reason, DiceRecoveryPolicyReason::kMissingDependency);
+}
+
+// Missing dependency but idle with no footprint -> nothing to recover, ignore.
+TEST(DiceRecoveryPolicyTests, MissingDependencyWhileIdleIsIgnored) {
+    DiceRecoveryContext c{};
+    c.state = DiceRestartState::kIdle;
+    c.hasDiceRecord = true;
+    c.hasProtocol = false;
+    const auto d = EvaluateRecoveryPolicy(c);
+    EXPECT_EQ(d.disposition, DiceRecoveryDisposition::kIgnore);
+    EXPECT_EQ(d.reason, DiceRecoveryPolicyReason::kIdleWithoutFootprint);
+}
+
+TEST(DiceRecoveryPolicyTests, FailedRetryableRestarts) {
+    DiceRecoveryContext c = WithDeps(DiceRestartState::kFailed);
+    c.lastFailureRetryable = true;
+    const auto d = EvaluateRecoveryPolicy(c);
+    EXPECT_EQ(d.disposition, DiceRecoveryDisposition::kRestart);
+    EXPECT_EQ(d.reason, DiceRecoveryPolicyReason::kRetryableFailure);
+}
+
+TEST(DiceRecoveryPolicyTests, FailedNonRetryableFailsSession) {
+    DiceRecoveryContext c = WithDeps(DiceRestartState::kFailed);
+    c.lastFailureRetryable = false;
+    const auto d = EvaluateRecoveryPolicy(c);
+    EXPECT_EQ(d.disposition, DiceRecoveryDisposition::kFailSession);
+    EXPECT_EQ(d.reason, DiceRecoveryPolicyReason::kNonRetryableFailure);
+}
+
+TEST(DiceRecoveryPolicyTests, RunningRestarts) {
+    const auto d = EvaluateRecoveryPolicy(WithDeps(DiceRestartState::kRunning));
+    EXPECT_EQ(d.disposition, DiceRecoveryDisposition::kRestart);
+    EXPECT_EQ(d.reason, DiceRecoveryPolicyReason::kRunningWithFootprint);
+}
+
+// An idle state but with a footprint still restarts (footprint outlives the state). Each of
+// the three OR-branches of hasRestartFootprint independently forces the restart.
+TEST(DiceRecoveryPolicyTests, IdleWithHostFootprintRestarts) {
+    DiceRecoveryContext c = WithDeps(DiceRestartState::kIdle);
+    c.hasHostFootprint = true;
+    const auto d = EvaluateRecoveryPolicy(c);
+    EXPECT_EQ(d.disposition, DiceRecoveryDisposition::kRestart);
+    EXPECT_EQ(d.reason, DiceRecoveryPolicyReason::kRunningWithFootprint);
+}
+
+TEST(DiceRecoveryPolicyTests, IdleWithRestartIntentRestarts) {
+    DiceRecoveryContext c = WithDeps(DiceRestartState::kIdle);
+    c.hasRestartIntent = true;
+    const auto d = EvaluateRecoveryPolicy(c);
+    EXPECT_EQ(d.disposition, DiceRecoveryDisposition::kRestart);
+    EXPECT_EQ(d.reason, DiceRecoveryPolicyReason::kRunningWithFootprint);
+}
+
+TEST(DiceRecoveryPolicyTests, IdleWithDeviceFootprintRestarts) {
+    DiceRecoveryContext c = WithDeps(DiceRestartState::kIdle);
+    c.hasDeviceFootprint = true;
+    const auto d = EvaluateRecoveryPolicy(c);
+    EXPECT_EQ(d.disposition, DiceRecoveryDisposition::kRestart);
+    EXPECT_EQ(d.reason, DiceRecoveryPolicyReason::kRunningWithFootprint);
+}
+
+TEST(DiceRecoveryPolicyTests, IdleWithoutFootprintIsIgnored) {
+    const auto d = EvaluateRecoveryPolicy(WithDeps(DiceRestartState::kIdle));
+    EXPECT_EQ(d.disposition, DiceRecoveryDisposition::kIgnore);
+    EXPECT_EQ(d.reason, DiceRecoveryPolicyReason::kIdleWithoutFootprint);
+}
+
+TEST(DiceRecoveryPolicyTests, ToStringCoversAllValues) {
+    EXPECT_STREQ(ToString(DiceRecoveryDisposition::kIgnore), "Ignore");
+    EXPECT_STREQ(ToString(DiceRecoveryDisposition::kRestart), "Restart");
+    EXPECT_STREQ(ToString(DiceRecoveryDisposition::kFailSession), "FailSession");
+
+    EXPECT_STREQ(ToString(DiceRecoveryPolicyReason::kRunningWithFootprint),
+                 "running_with_footprint");
+    EXPECT_STREQ(ToString(DiceRecoveryPolicyReason::kRetryableFailure), "retryable_failure");
+    EXPECT_STREQ(ToString(DiceRecoveryPolicyReason::kIdleWithoutFootprint),
+                 "idle_without_footprint");
+    EXPECT_STREQ(ToString(DiceRecoveryPolicyReason::kSuppressedByStop), "suppressed_by_stop");
+    EXPECT_STREQ(ToString(DiceRecoveryPolicyReason::kIdleApplyInvalidated),
+                 "idle_apply_invalidated");
+    EXPECT_STREQ(ToString(DiceRecoveryPolicyReason::kMissingDependency), "missing_dependency");
+    EXPECT_STREQ(ToString(DiceRecoveryPolicyReason::kNonRetryableFailure),
+                 "non_retryable_failure");
+}
+
+} // namespace


### PR DESCRIPTION
# FW-66: extract recovery-policy classification into DiceRecoveryPolicy.hpp

Step 2 of FW-64. Behaviour-preserving mechanical move — no wire/timing/semantic change.

## What

Lifts the recovery-policy *classification vocabulary* out of `DiceDuplexRestartCoordinator.cpp`'s
anonymous namespace into a standalone header,
`Audio/Protocols/Backends/DiceRecoveryPolicy.hpp` (namespace `ASFW::Audio::Backends`) — the
pure classification the ticket calls for (facts in, facts out; no recording, no logging):

- reason → restart state: `RestartStateForStartReason`,
- reason → failure cause: `FailureCauseForReason` (+ `IsRecoveryReason`),
- `IOReturn` → retryable: `IsRetryableStatus`,
- recovery context → disposition: the `EvaluateRecoveryPolicy(context)` kernel,
- their inputs/outputs: `DiceRecoveryContext`, `DiceRecoveryDecision`, the enums
  `DiceRecoveryDisposition` / `DiceRecoveryPolicyReason`, and their two `ToString` overloads.

The unit has **no dependency on the session store or logging** (per the ticket). Names keep
their `Dice*` prefix — the DICE→neutral rename is FW-73.

**Note on `ClassifyRestartReason`:** the ticket lists it under classification, but the existing
`DICE::ClassifyRestartReason(&session, …)` takes a *session* — it's session-coupled and already
lives in `DICE::`, outside the coordinator. Since RecoveryPolicy must not depend on the session
store, it stays where it is; the pure reason→cause half is `FailureCauseForReason` here.

## Behaviour-preserving

- Every moved definition is copied **byte-identical** (verified against `git diff` — the
  deleted lines match the header line-for-line). Same branch precedence in the kernel, same
  enum order (underlying values unchanged), same retryable-status set, same reason→cause map.
- The coordinator's diff is **+3 / −146**: one `#include`, one file-scope
  `using namespace ASFW::Audio::Backends;`, and the three deleted blocks. Its ~40 in-file
  references and call sites (recovery FSM, clock loop, logging) are **textually unchanged** and
  resolve through the using-directive. `GenerationValue`, `RestartStateForStartReason`, and the
  other `ToString` overloads that live *between* the moved blocks stay put.
- Only linkage changes: anon-namespace `constexpr` → header `constexpr` (implicitly inline).

## Tests

New `tests/devices/DiceRecoveryPolicyTests.cpp` — the kernel had **zero direct coverage**
before (trapped in an anonymous namespace), only transitive coverage via the coordinator's
recovery integration tests. This adds 16 tests + `static_assert`s locking, at compile time and
runtime: every branch of the decision table (stop > applying-idle-clock > missing-dependency >
failed-retryable/non-retryable > running/footprint > idle-default), all three footprint
OR-branches, the exact `IsRetryableStatus` set, the full `FailureCauseForReason` and
`RestartStateForStartReason` mappings (including the cross-invariant that a reason enters
`kRecovering` exactly when it has a failure cause), and every `ToString` value. Host tests, no
hardware.

## Verification

- `DiceRecoveryPolicyTests`: 16/16 (+ static_asserts compiled)
- `DiceDuplexRestartCoordinatorTests`: still 20/20 (unchanged)
- Full host suite: **1159/1159** (was 1143 + 16 new)

## One thing worth a glance (non-blocking)

**Namespace choice.** The vocabulary went into a `Backends` sub-namespace, which contains the
four `DICE::DiceRestart*` using-declarations the moved bodies need without leaking them into
`ASFW::Audio`, at the cost of one file-scope `using namespace` in the coordinator to keep call
sites unchanged. The alternative — `ASFW::Audio` like FW-65's `SyncAsyncBridge` — drops the
using-directive but spills those DICE usings into the broader namespace for every includer.
Happy to switch if you'd prefer the FW-65-consistent placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
