### PR TITLE
FW-68: extract the duplex operation gate (per-GUID active/stop-intent)

### DIFF
--- a/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
@@ -588,13 +588,13 @@ IOReturn DiceDuplexRestartCoordinator::RequestClockConfig(
     }
 
     IOLockLock(lock_);
-    if (stopRequestedGuids_.find(guid) != stopRequestedGuids_.end()) {
+    if (gate_.IsStopRequestedLocked(guid)) {
         IOLockUnlock(lock_);
         return kIOReturnAborted;
     }
 
     request.token = nextClockToken_++;
-    if (activeGuids_.find(guid) != activeGuids_.end()) {
+    if (gate_.IsActiveLocked(guid)) {
         const auto existingIt = pendingClockRequests_.find(guid);
         if (existingIt != pendingClockRequests_.end()) {
             supersededRequest = existingIt->second;
@@ -607,7 +607,7 @@ IOReturn DiceDuplexRestartCoordinator::RequestClockConfig(
             sessionIt->second.hasPendingClockRequest = true;
         }
     } else {
-        activeGuids_.insert(guid);
+        gate_.AcquireLocked(guid);
         shouldLaunchLoop = true;
     }
     IOLockUnlock(lock_);
@@ -713,8 +713,8 @@ void DiceDuplexRestartCoordinator::ClearSession(uint64_t guid) noexcept {
     sessions_.erase(guid);
     pendingClockRequests_.erase(guid);
     completedClockRequests_.erase(guid);
-    activeGuids_.erase(guid);
-    stopRequestedGuids_.erase(guid);
+    gate_.ReleaseLocked(guid);
+    gate_.ClearStopLocked(guid);
     IOLockUnlock(lock_);
 }
 
@@ -1876,56 +1876,27 @@ ASFW::Audio::Runtime::IDirectAudioBindingSource* DiceDuplexRestartCoordinator::G
     return bindingSourceProvider_(guid);
 }
 
+// FW-68: the per-GUID gating state + logic now lives in DuplexOperationGate (gate_). These
+// entry points are thin forwarders to its self-locking API; behaviour is byte-for-byte the
+// former inline bodies (gate_ borrows the same lock_).
 bool DiceDuplexRestartCoordinator::TryAcquireGuid(uint64_t guid) noexcept {
-    if (!lock_) {
-        return false;
-    }
-
-    IOLockLock(lock_);
-    const auto [_, inserted] = activeGuids_.insert(guid);
-    IOLockUnlock(lock_);
-    return inserted;
+    return gate_.Acquire(guid);
 }
 
 void DiceDuplexRestartCoordinator::ReleaseGuid(uint64_t guid) noexcept {
-    if (!lock_) {
-        return;
-    }
-
-    IOLockLock(lock_);
-    activeGuids_.erase(guid);
-    IOLockUnlock(lock_);
+    gate_.Release(guid);
 }
 
 void DiceDuplexRestartCoordinator::RequestStopIntent(uint64_t guid) noexcept {
-    if (!lock_ || guid == 0) {
-        return;
-    }
-
-    IOLockLock(lock_);
-    stopRequestedGuids_.insert(guid);
-    IOLockUnlock(lock_);
+    gate_.RequestStop(guid);
 }
 
 void DiceDuplexRestartCoordinator::ClearStopIntent(uint64_t guid) noexcept {
-    if (!lock_ || guid == 0) {
-        return;
-    }
-
-    IOLockLock(lock_);
-    stopRequestedGuids_.erase(guid);
-    IOLockUnlock(lock_);
+    gate_.ClearStop(guid);
 }
 
 bool DiceDuplexRestartCoordinator::IsStopRequested(uint64_t guid) const noexcept {
-    if (!lock_ || guid == 0) {
-        return false;
-    }
-
-    IOLockLock(lock_);
-    const bool requested = stopRequestedGuids_.find(guid) != stopRequestedGuids_.end();
-    IOLockUnlock(lock_);
-    return requested;
+    return gate_.IsStopRequested(guid);
 }
 
 uint64_t DiceDuplexRestartCoordinator::AllocateRestartId() noexcept {

--- a/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "DiceHostTransport.hpp"
+#include "DuplexOperationGate.hpp"
 
 #include "../../../Discovery/DeviceRegistry.hpp"
 #include "../../../Hardware/HardwareInterface.hpp"
@@ -133,7 +134,7 @@ private:
     void StoreSession(const DICE::DiceRestartSession& session) noexcept;
 
     // FW-61: global teardown cancel token. Distinct from the per-guid stop intent
-    // (stopRequestedGuids_) - that aborts one stream; this aborts everything for
+    // (gate_, see DuplexOperationGate) - that aborts one stream; this aborts everything for
     // service teardown. Owned by DiceAudioBackend and read on the dice queue.
     [[nodiscard]] bool TeardownRequested() const noexcept {
         return cancel_ != nullptr && cancel_->load(std::memory_order_acquire);
@@ -147,8 +148,9 @@ private:
     DirectAudioBindingSourceProvider bindingSourceProvider_;
 
     IOLock* lock_{nullptr};
-    std::unordered_set<uint64_t> activeGuids_{};
-    std::unordered_set<uint64_t> stopRequestedGuids_{};
+    // FW-68: per-GUID active-session + stop-intent gating. Borrows &lock_ (see
+    // DuplexOperationGate) so its critical sections share the coordinator's single lock.
+    Backends::DuplexOperationGate gate_{&lock_};
     std::unordered_map<uint64_t, DICE::DiceRestartSession> sessions_{};
     std::unordered_map<uint64_t, PendingClockRequest> pendingClockRequests_{};
     std::unordered_map<uint64_t, ClockCompletionStore> completedClockRequests_{};

--- a/ASFWDriver/Audio/Protocols/Backends/DuplexOperationGate.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DuplexOperationGate.hpp
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2026 ASFireWire Project
+//
+// DuplexOperationGate.hpp
+//
+// FW-68 (Step 4 of FW-64): per-GUID duplex operation gating extracted from
+// DiceDuplexRestartCoordinator. Owns the two per-GUID sets that gate concurrent duplex
+// operations:
+//   * activeGuids_        - a GUID currently owns the duplex run body (claim/release).
+//   * stopRequestedGuids_ - a GUID has a pending per-stream stop intent.
+//
+// Behaviour-preserving extraction: the gate BORROWS the coordinator's existing IOLock* rather
+// than owning its own. That is deliberate — those sets are read/mutated inside multi-domain
+// single-lock critical sections in the coordinator (RequestClockConfig and ClearSession, which
+// also touch the clock-request maps and the session store under one hold). Owning a separate
+// lock would split those atomic sections; borrowing the coordinator's lock keeps every
+// IOLockLock/IOLockUnlock pairing exactly as it was. The gate therefore exposes two tiers:
+//   * self-locking methods (Acquire/Release/RequestStop/ClearStop/IsStopRequested) that
+//     reproduce the former coordinator members byte-for-byte, for callers that do not already
+//     hold the lock (StartStreaming/StopStreaming/RecoverStreaming and their reads); and
+//   * *Locked variants that assume the caller already holds the lock, for the two multi-domain
+//     critical sections that must stay a single uninterrupted hold.
+//
+// This per-GUID stop intent is distinct from the global FW-60/61 teardown cancel token
+// (cancel_/TeardownRequested()), which aborts everything for service teardown and stays on the
+// coordinator.
+
+#pragma once
+
+#include <DriverKit/IOLib.h>
+
+#include <cstdint>
+#include <unordered_set>
+
+namespace ASFW::Audio::Backends {
+
+class DuplexOperationGate {
+public:
+    // `lock` points at the coordinator's IOLock* member. The pointee is allocated in the
+    // coordinator's constructor body (after this gate is constructed) and stays stable for the
+    // coordinator's lifetime, so the gate reads it fresh on every call.
+    explicit DuplexOperationGate(IOLock** lock) noexcept : lockRef_(lock) {}
+
+    // --- self-locking API: byte-for-byte reproductions of the former coordinator members
+    //     TryAcquireGuid / ReleaseGuid / RequestStopIntent / ClearStopIntent / IsStopRequested.
+
+    [[nodiscard]] bool Acquire(uint64_t guid) noexcept {
+        IOLock* const lock = *lockRef_;
+        if (!lock) {
+            return false;
+        }
+        IOLockLock(lock);
+        const auto [_, inserted] = activeGuids_.insert(guid);
+        IOLockUnlock(lock);
+        return inserted;
+    }
+
+    void Release(uint64_t guid) noexcept {
+        IOLock* const lock = *lockRef_;
+        if (!lock) {
+            return;
+        }
+        IOLockLock(lock);
+        activeGuids_.erase(guid);
+        IOLockUnlock(lock);
+    }
+
+    void RequestStop(uint64_t guid) noexcept {
+        IOLock* const lock = *lockRef_;
+        if (!lock || guid == 0) {
+            return;
+        }
+        IOLockLock(lock);
+        stopRequestedGuids_.insert(guid);
+        IOLockUnlock(lock);
+    }
+
+    void ClearStop(uint64_t guid) noexcept {
+        IOLock* const lock = *lockRef_;
+        if (!lock || guid == 0) {
+            return;
+        }
+        IOLockLock(lock);
+        stopRequestedGuids_.erase(guid);
+        IOLockUnlock(lock);
+    }
+
+    [[nodiscard]] bool IsStopRequested(uint64_t guid) const noexcept {
+        IOLock* const lock = *lockRef_;
+        if (!lock || guid == 0) {
+            return false;
+        }
+        IOLockLock(lock);
+        const bool requested = stopRequestedGuids_.find(guid) != stopRequestedGuids_.end();
+        IOLockUnlock(lock);
+        return requested;
+    }
+
+    // --- lock-held variants: the caller already holds *lockRef_. Do only the set operation, so
+    //     the coordinator's multi-domain critical sections stay one uninterrupted hold. These
+    //     match the former inline accesses in RequestClockConfig / ClearSession exactly.
+
+    [[nodiscard]] bool IsActiveLocked(uint64_t guid) const noexcept {
+        return activeGuids_.find(guid) != activeGuids_.end();
+    }
+
+    [[nodiscard]] bool IsStopRequestedLocked(uint64_t guid) const noexcept {
+        return stopRequestedGuids_.find(guid) != stopRequestedGuids_.end();
+    }
+
+    void AcquireLocked(uint64_t guid) noexcept {
+        activeGuids_.insert(guid);
+    }
+
+    void ReleaseLocked(uint64_t guid) noexcept {
+        activeGuids_.erase(guid);
+    }
+
+    void ClearStopLocked(uint64_t guid) noexcept {
+        stopRequestedGuids_.erase(guid);
+    }
+
+private:
+    IOLock** lockRef_;  // borrowed: &coordinator.lock_ (not owned; never allocated/freed here)
+    std::unordered_set<uint64_t> activeGuids_{};
+    std::unordered_set<uint64_t> stopRequestedGuids_{};
+};
+
+} // namespace ASFW::Audio::Backends

--- a/tests/devices/CMakeLists.txt
+++ b/tests/devices/CMakeLists.txt
@@ -65,6 +65,11 @@ add_device_test(DiceRecoveryPolicyTests
     DiceRecoveryPolicyTests.cpp
 )
 
+# DICE duplex operation gate (active/stop-intent) tests (FW-68, header-only gate)
+add_device_test(DuplexOperationGateTests
+    DuplexOperationGateTests.cpp
+)
+
 # Apogee protocol boolean control mapping tests
 add_device_test(ApogeeBooleanControlMappingTests
     ApogeeBooleanControlMappingTests.cpp

--- a/tests/devices/DuplexOperationGateTests.cpp
+++ b/tests/devices/DuplexOperationGateTests.cpp
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2026 ASFireWire Project
+//
+// FW-68 characterization tests for DuplexOperationGate, the per-GUID duplex operation gate
+// extracted from DiceDuplexRestartCoordinator. These pin the observable behaviour of the former
+// coordinator members (TryAcquireGuid/ReleaseGuid/RequestStopIntent/ClearStopIntent/
+// IsStopRequested) and the lock-held variants used inside the coordinator's multi-domain
+// critical sections, so the extraction is provably behaviour-preserving. Host tests, no hardware.
+
+#include <gtest/gtest.h>
+
+#include <DriverKit/IOLib.h>
+
+#include "Audio/Protocols/Backends/DuplexOperationGate.hpp"
+
+namespace {
+
+using ASFW::Audio::Backends::DuplexOperationGate;
+
+class DuplexOperationGateTest : public ::testing::Test {
+protected:
+    void SetUp() override { ASSERT_NE(lock_, nullptr); }
+    void TearDown() override {
+        if (lock_) {
+            IOLockFree(lock_);
+        }
+    }
+
+    IOLock* lock_ = IOLockAlloc();
+    DuplexOperationGate gate_{&lock_};
+};
+
+// Acquire is a test-and-set on the active set: first claim wins, a second claim of the same GUID
+// fails until Release. (Matches the former TryAcquireGuid returning `inserted`.)
+TEST_F(DuplexOperationGateTest, AcquireIsTestAndSet) {
+    EXPECT_TRUE(gate_.Acquire(0x11));
+    EXPECT_FALSE(gate_.Acquire(0x11));
+    gate_.Release(0x11);
+    EXPECT_TRUE(gate_.Acquire(0x11));
+}
+
+TEST_F(DuplexOperationGateTest, DistinctGuidsAcquireIndependently) {
+    EXPECT_TRUE(gate_.Acquire(0x11));
+    EXPECT_TRUE(gate_.Acquire(0x22));
+    EXPECT_FALSE(gate_.Acquire(0x11));
+    EXPECT_FALSE(gate_.Acquire(0x22));
+}
+
+TEST_F(DuplexOperationGateTest, StopIntentSetAndClear) {
+    EXPECT_FALSE(gate_.IsStopRequested(0x11));
+    gate_.RequestStop(0x11);
+    EXPECT_TRUE(gate_.IsStopRequested(0x11));
+    gate_.ClearStop(0x11);
+    EXPECT_FALSE(gate_.IsStopRequested(0x11));
+
+    // Clearing a GUID with no stop-intent is a safe no-op (erase of an absent key) and does
+    // not disturb another GUID's intent.
+    gate_.RequestStop(0x22);
+    gate_.ClearStop(0x11);  // 0x11 not present
+    EXPECT_TRUE(gate_.IsStopRequested(0x22));
+}
+
+// The two sets are orthogonal: claiming a GUID does not set stop-intent, stop-intent does not
+// release the claim, and intent on one GUID does not affect another.
+TEST_F(DuplexOperationGateTest, ActiveAndStopIntentAreIndependent) {
+    gate_.Acquire(0x11);
+    EXPECT_FALSE(gate_.IsStopRequested(0x11));  // acquiring does not set stop
+    gate_.RequestStop(0x11);
+    EXPECT_TRUE(gate_.IsStopRequested(0x11));   // stop is set
+    EXPECT_TRUE(gate_.IsActiveLocked(0x11));    // and the claim still stands
+
+    gate_.Acquire(0x22);
+    gate_.RequestStop(0x22);
+    EXPECT_TRUE(gate_.IsActiveLocked(0x11));    // 0x22's activity/intent leaves 0x11 alone
+    EXPECT_TRUE(gate_.IsStopRequested(0x11));
+}
+
+// guid==0: RequestStop/ClearStop/IsStopRequested short-circuit (former members guarded guid==0);
+// Acquire/Release have NO zero guard (former TryAcquireGuid/ReleaseGuid did not either).
+TEST_F(DuplexOperationGateTest, ZeroGuidGuardsMatchOriginals) {
+    gate_.RequestStop(0);
+    EXPECT_FALSE(gate_.IsStopRequested(0));
+    EXPECT_FALSE(gate_.IsStopRequestedLocked(0));  // guarded: nothing was inserted
+    gate_.ClearStop(0);                            // guarded no-op
+    EXPECT_FALSE(gate_.IsStopRequestedLocked(0));
+
+    EXPECT_TRUE(gate_.Acquire(0));                  // no zero guard on Acquire -> inserts 0
+    EXPECT_TRUE(gate_.IsActiveLocked(0));
+    gate_.Release(0);                               // no zero guard on Release -> erases 0
+    EXPECT_FALSE(gate_.IsActiveLocked(0));
+}
+
+// The gate borrows &lock_ and reads it fresh each call: a null lock short-circuits every
+// self-locking method exactly as the former members did, and the gate starts working the moment
+// the borrowed lock is allocated.
+TEST(DuplexOperationGateNullLock, NoLockShortCircuitsSelfLockingApi) {
+    IOLock* lock = nullptr;
+    DuplexOperationGate gate{&lock};
+    EXPECT_FALSE(gate.Acquire(0x11));
+    gate.Release(0x11);       // no-op, must not deref a null lock
+    gate.RequestStop(0x11);   // no-op
+    EXPECT_FALSE(gate.IsStopRequested(0x11));
+
+    lock = IOLockAlloc();
+    ASSERT_NE(lock, nullptr);
+    EXPECT_TRUE(gate.Acquire(0x11));
+    IOLockFree(lock);
+}
+
+// Lock-held variants do only the set op (no internal locking) — used inside RequestClockConfig /
+// ClearSession's single critical section.
+TEST_F(DuplexOperationGateTest, LockedVariantsMutateWithoutLocking) {
+    EXPECT_FALSE(gate_.IsActiveLocked(0x11));
+    gate_.AcquireLocked(0x11);
+    EXPECT_TRUE(gate_.IsActiveLocked(0x11));
+    gate_.ReleaseLocked(0x11);
+    EXPECT_FALSE(gate_.IsActiveLocked(0x11));
+
+    gate_.RequestStop(0x22);
+    EXPECT_TRUE(gate_.IsStopRequestedLocked(0x22));
+    gate_.ClearStopLocked(0x22);
+    EXPECT_FALSE(gate_.IsStopRequestedLocked(0x22));
+}
+
+// The self-locking public API and the lock-held variants operate on the same underlying sets.
+TEST_F(DuplexOperationGateTest, SelfLockingAndLockedVariantsShareState) {
+    gate_.Acquire(0x33);                       // self-locking claim
+    EXPECT_TRUE(gate_.IsActiveLocked(0x33));   // visible to the locked read
+    gate_.ReleaseLocked(0x33);                 // locked release
+    EXPECT_TRUE(gate_.Acquire(0x33));          // claimable again via self-locking path
+}
+
+// The read-only methods are const and callable on a const gate (matches the former const
+// IsStopRequested member; the const IsStopRequested still locks the borrowed lock_).
+TEST_F(DuplexOperationGateTest, ConstReadMethodsCallableOnConstInstance) {
+    gate_.Acquire(0x11);
+    gate_.RequestStop(0x22);
+    const DuplexOperationGate& c = gate_;
+    EXPECT_TRUE(c.IsStopRequested(0x22));
+    EXPECT_TRUE(c.IsActiveLocked(0x11));
+    EXPECT_TRUE(c.IsStopRequestedLocked(0x22));
+    EXPECT_FALSE(c.IsStopRequestedLocked(0x11));
+}
+
+} // namespace


### PR DESCRIPTION
# FW-68: extract the duplex operation gate (per-GUID active/stop-intent)

Step 4 of FW-64. Behaviour-preserving — no wire/timing/atomicity/ordering change.

## What

Moves the per-GUID duplex-operation gating out of `DiceDuplexRestartCoordinator` into a
`DuplexOperationGate` (`Audio/Protocols/Backends/DuplexOperationGate.hpp`): the two sets
`activeGuids_` / `stopRequestedGuids_` and the five members
`TryAcquireGuid`/`ReleaseGuid`/`RequestStopIntent`/`ClearStopIntent`/`IsStopRequested`. Those
entry points become thin forwarders to the gate. Kept distinct from the global FW-60/61 teardown
cancel token (`cancel_`/`TeardownRequested()`), which stays on the coordinator.

## The one design call worth your eyes (this sets the pattern for FW-67/69)

The naive extraction — a gate owning its own lock — is **not** behaviour-preserving here.
`activeGuids_`/`stopRequestedGuids_` are read/mutated *directly* inside two multi-domain
critical sections that hold `lock_` **once** across the gate sets **and** the clock-request maps
**and** the session store: `RequestClockConfig` (the `stopRequested?` → `active?` → claim
check-then-act) and `ClearSession` (erases all five maps together). And the lock guards real
cross-thread concurrency — `RecoverStreaming` runs on the dice work queue while
`StartStreaming`/`RequestClockConfig` run on the caller thread — so splitting a hold would be a
genuine race, not a no-op.

So the gate **borrows** the coordinator's existing `lock_` (via `IOLock** = &lock_`) rather than
owning one, and exposes two tiers:

- **self-locking** `Acquire`/`Release`/`RequestStop`/`ClearStop`/`IsStopRequested` — byte-for-byte
  the former members, for callers that don't hold the lock (Start/Stop/Recover paths);
- **lock-held** `IsActiveLocked`/`IsStopRequestedLocked`/`AcquireLocked`/`ReleaseLocked`/
  `ClearStopLocked` — no internal locking, called by `RequestClockConfig`/`ClearSession` *inside*
  their existing single `IOLockLock`/`IOLockUnlock` span, so those holds stay one uninterrupted
  critical section.

Net: every lock acquire/release pairing is unchanged in count and placement; no section split.

**Two things this implies, flagged for your call:**
1. It necessarily edits `RequestClockConfig` and `ClearSession` (the ticket's move-list doesn't
   mention them, but they touch the sets directly, so they're unavoidable).
2. This lock-borrowing + `*Locked` pattern is what **FW-67 (clock broker) and FW-69 (session
   store/journal) will also need** — they share the same `lock_` and the same two critical
   sections. If you'd rather each component own its own lock, this cluster needs a different
   decomposition and I'd stop before building more. **FW-67 is intentionally not started yet**:
   its own move-list functions (`TryConsumePendingClockRequest`/`CompleteClockRequest`/
   `FailPendingClockRequest`) also write `sessions_[guid]` and emit the `[FSM]` log — i.e. they're
   entangled with FW-69's store + journal — so FW-67 wants FW-69 sequenced first (or a split).
   Happy to write that up separately; this PR is just the clean, independent Step 4.

## Tests

New `DuplexOperationGateTests` — 9 tests pinning the observable contract: test-and-set claim
semantics, stop-intent set/clear, active/stop independence + cross-GUID isolation, the exact
`guid==0` guard asymmetry (`Acquire`/`Release` unguarded, the rest guarded — matching the former
members), null-lock short-circuit + fresh-read-each-call of the borrowed lock, and the lock-held
variants. Host tests, no hardware.

## Verification

- `DuplexOperationGateTests`: 9/9
- `DiceDuplexRestartCoordinatorTests`: still 20/20 (unchanged)
- Full host suite: **1188/1188**

## One non-blocking choice

The five entry points are kept as **thin forwarders** to the gate (so all existing call sites are
untouched — lowest-risk) rather than inlining `gate_.*` into Start/Stop/Recover. Trivially
inlinable if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
