### PR TITLE
(DICE-1) Midas Venice F32  / Dual Stream Implementation

### DIFF
--- a/ASFWDriver/Audio/DriverKit/ASFWAudioDevice.cpp
+++ b/ASFWDriver/Audio/DriverKit/ASFWAudioDevice.cpp
@@ -82,6 +82,20 @@ kern_return_t ASFWAudioDevice::StartIO(IOUserAudioStartStopFlags in_flags) {
             ivars.runtime.txSlotProvider.controlBlock = nullptr;
             ivars.runtime.txSlotProvider.numSlots = 0;
             ivars.runtime.txExecutionTimeline.controlBlock = nullptr;
+
+            // Secondary playback stream resources.
+            ivars.txPayloadMapSecondary = nullptr;
+            ivars.txMetadataMapSecondary = nullptr;
+            ivars.txControlMapSecondary = nullptr;
+            ivars.txPayloadBufferSecondary = nullptr;
+            ivars.txMetadataBufferSecondary = nullptr;
+            ivars.txControlBufferSecondary = nullptr;
+            ivars.runtime.txSlotProviderSecondary.payloadBase = nullptr;
+            ivars.runtime.txSlotProviderSecondary.metadataRing = nullptr;
+            ivars.runtime.txSlotProviderSecondary.controlBlock = nullptr;
+            ivars.runtime.txSlotProviderSecondary.numSlots = 0;
+            ivars.runtime.txSecondaryActive = false;
+
             if (txResourcesAllocated && ivars.device.audioNub) {
                 ivars.device.audioNub->FreeTxIsochResources();
             }
@@ -164,7 +178,7 @@ kern_return_t ASFWAudioDevice::StartIO(IOUserAudioStartStopFlags in_flags) {
             IOMemoryDescriptor* rawControl = nullptr;
 
             kern_return_t allocKr = ivars.device.audioNub->AllocateTxIsochResources(
-                numSlots, maxPacketBytes, interruptInterval,
+                0, numSlots, maxPacketBytes, interruptInterval,
                 &rawPayload, &rawMetadata, &rawControl
             );
             if (allocKr != kIOReturnSuccess) {
@@ -233,6 +247,74 @@ kern_return_t ASFWAudioDevice::StartIO(IOUserAudioStartStopFlags in_flags) {
                      control->rxTransferDelayTicks.load(std::memory_order_relaxed),
                      control->txTransferDelayTicks.load(std::memory_order_relaxed),
                      timingRateHz);
+
+        // --- Secondary playback stream (multi-stream DICE, e.g. Venice F32 = 2×16) ---
+        // Allocate/map/configure the second host IT pipeline. It shadows the
+        // master's per-packet timing in lockstep and encodes host output channels
+        // [pcmChannels, 2×pcmChannels). The matching secondary IT hardware context
+        // is created + wired to this slab by the duplex bringup
+        // (PrepareTransmitStream), which runs after this allocation.
+        if (profile->TxStreamCount() > 1) {
+            ASFW::Isoch::Audio::DICE::DiceStreamConfig txConfig2{};
+            if (!profile->BuildDefaultTxStreamConfig(txConfig2)) {
+                kr = failStart(kIOReturnError, "BuildDefaultTxStreamConfig2");
+                return;
+            }
+            txConfig2.sourceChannelOffset = txConfig2.pcmChannels;
+
+            const uint32_t numSlots2 =
+                ASFW::IsochTransport::AudioTimingGeometry::kTxSharedSlotPackets;
+            const uint32_t maxPacketBytes2 =
+                8u + static_cast<uint32_t>(txConfig2.framesPerDataPacket) * txConfig2.dbs * 4u;
+            const uint32_t interruptInterval2 =
+                ASFW::IsochTransport::AudioTimingGeometry::kTimingGroupPackets;
+
+            IOMemoryDescriptor* rawPayload2 = nullptr;
+            IOMemoryDescriptor* rawMetadata2 = nullptr;
+            IOMemoryDescriptor* rawControl2 = nullptr;
+            kern_return_t allocKr2 = ivars.device.audioNub->AllocateTxIsochResources(
+                1, numSlots2, maxPacketBytes2, interruptInterval2,
+                &rawPayload2, &rawMetadata2, &rawControl2);
+            if (allocKr2 != kIOReturnSuccess) {
+                kr = failStart(allocKr2, "AllocateTxIsochResources2");
+                return;
+            }
+            ivars.txPayloadBufferSecondary = ASFW::Common::AdoptRetained(rawPayload2);
+            ivars.txMetadataBufferSecondary = ASFW::Common::AdoptRetained(rawMetadata2);
+            ivars.txControlBufferSecondary = ASFW::Common::AdoptRetained(rawControl2);
+
+            allocKr2 = ASFW::Common::CreateSharedMapping(ivars.txPayloadBufferSecondary, ivars.txPayloadMapSecondary);
+            if (allocKr2 != kIOReturnSuccess) { kr = failStart(allocKr2, "MapTxPayload2"); return; }
+            allocKr2 = ASFW::Common::CreateSharedMapping(ivars.txMetadataBufferSecondary, ivars.txMetadataMapSecondary);
+            if (allocKr2 != kIOReturnSuccess) { kr = failStart(allocKr2, "MapTxMetadata2"); return; }
+            allocKr2 = ASFW::Common::CreateSharedMapping(ivars.txControlBufferSecondary, ivars.txControlMapSecondary);
+            if (allocKr2 != kIOReturnSuccess) { kr = failStart(allocKr2, "MapTxControl2"); return; }
+
+            uint8_t* payloadBase2 = reinterpret_cast<uint8_t*>(ivars.txPayloadMapSecondary->GetAddress());
+            auto* metadataRing2 = reinterpret_cast<ASFW::IsochTransport::TxPacketMeta*>(ivars.txMetadataMapSecondary->GetAddress());
+            auto* controlBlock2 = reinterpret_cast<ASFW::IsochTransport::TxStreamControl*>(ivars.txControlMapSecondary->GetAddress());
+
+            ivars.runtime.txSlotProviderSecondary.payloadBase = payloadBase2;
+            ivars.runtime.txSlotProviderSecondary.metadataRing = metadataRing2;
+            ivars.runtime.txSlotProviderSecondary.controlBlock = controlBlock2;
+            ivars.runtime.txSlotProviderSecondary.numSlots = numSlots2;
+            ivars.runtime.txSlotProviderSecondary.slotStrideBytes = maxPacketBytes2;
+            // isoChannel here is only a fallback; the host IT ring stamps the real
+            // transmit channel (PlaybackChannel(1)) from its Configure() value.
+            ivars.runtime.txSlotProviderSecondary.isoChannel = txConfig2.sid;
+
+            if (!ivars.runtime.txStreamEngineSecondary.Configure(*profile, txConfig2)) {
+                kr = failStart(kIOReturnError, "ConfigureTxStreamEngine2");
+                return;
+            }
+            ivars.runtime.txStreamEngineSecondary.BindSlotProvider(&ivars.runtime.txSlotProviderSecondary);
+            ivars.runtime.txStreamEngineSecondary.ResetForStart(0, 0);
+            ivars.runtime.txSecondaryActive = true;
+
+            ASFW_LOG(Audio,
+                     "ASFWAudioDevice: Allocated & configured SECONDARY TX stream offset=%u dbs=%u slots=%u slotSize=%u",
+                     txConfig2.sourceChannelOffset, txConfig2.dbs, numSlots2, maxPacketBytes2);
+        }
         }
 
         // --- Prefill TX ring ---
@@ -486,6 +568,22 @@ kern_return_t ASFWAudioDevice::StopIO(IOUserAudioStartStopFlags in_flags) {
         ivars.runtime.txSlotProvider.controlBlock = nullptr;
         ivars.runtime.txSlotProvider.numSlots = 0;
         ivars.runtime.txExecutionTimeline.controlBlock = nullptr;
+
+        // Secondary playback stream teardown. Drop txSecondaryActive first so the
+        // RT pump/IO paths stop touching the secondary engine before its mapped
+        // slab is released.
+        ivars.runtime.txSecondaryActive = false;
+        ivars.txPayloadMapSecondary = nullptr;
+        ivars.txMetadataMapSecondary = nullptr;
+        ivars.txControlMapSecondary = nullptr;
+        ivars.txPayloadBufferSecondary = nullptr;
+        ivars.txMetadataBufferSecondary = nullptr;
+        ivars.txControlBufferSecondary = nullptr;
+        ivars.runtime.txSlotProviderSecondary.payloadBase = nullptr;
+        ivars.runtime.txSlotProviderSecondary.metadataRing = nullptr;
+        ivars.runtime.txSlotProviderSecondary.controlBlock = nullptr;
+        ivars.runtime.txSlotProviderSecondary.numSlots = 0;
+
         if (ivars.device.audioNub) {
             ivars.device.audioNub->FreeTxIsochResources();
         }

--- a/ASFWDriver/Audio/DriverKit/ASFWAudioDriverIO.cpp
+++ b/ASFWDriver/Audio/DriverKit/ASFWAudioDriverIO.cpp
@@ -210,6 +210,19 @@ kern_return_t InstallIOOperationHandler(IOUserAudioDevice& audioDevice,
                         hostBuffer,
                         completionCursor);
 
+                    // Fan out the same host buffer to the secondary stream; its
+                    // payload writer reads channels [16, 32) via sourceChannelOffset.
+                    if (driverIvars->runtime.txSecondaryActive) {
+                        const uint64_t secondaryCompletion =
+                            driverIvars->runtime.txSlotProviderSecondary.controlBlock
+                                ? driverIvars->runtime.txSlotProviderSecondary.controlBlock
+                                      ->completionCursor.load(std::memory_order_acquire)
+                                : 0;
+                        driverIvars->runtime.txStreamEngineSecondary.WriteHostOutputFloat32(
+                            hostBuffer,
+                            secondaryCompletion);
+                    }
+
                     const auto& cw = driverIvars->runtime.txStreamEngine.PayloadWriterCounters();
                     ASFW::Audio::Runtime::PayloadWriterTelemetryRecord rec{};
                     rec.sampleTime = sampleTime;

--- a/ASFWDriver/Audio/DriverKit/ASFWAudioDriverLifecycle.cpp
+++ b/ASFWDriver/Audio/DriverKit/ASFWAudioDriverLifecycle.cpp
@@ -256,6 +256,20 @@ void PerformLoudTeardown(ASFWAudioDriver_IVars& ivars, const char* reason) noexc
         ivars.runtime.txSlotProvider.controlBlock = nullptr;
         ivars.runtime.txSlotProvider.numSlots = 0;
         ivars.runtime.txExecutionTimeline.controlBlock = nullptr;
+
+        // Secondary playback stream teardown (mirrors the master above).
+        ivars.runtime.txSecondaryActive = false;
+        ivars.txPayloadMapSecondary = nullptr;
+        ivars.txMetadataMapSecondary = nullptr;
+        ivars.txControlMapSecondary = nullptr;
+        ivars.txPayloadBufferSecondary = nullptr;
+        ivars.txMetadataBufferSecondary = nullptr;
+        ivars.txControlBufferSecondary = nullptr;
+        ivars.runtime.txSlotProviderSecondary.payloadBase = nullptr;
+        ivars.runtime.txSlotProviderSecondary.metadataRing = nullptr;
+        ivars.runtime.txSlotProviderSecondary.controlBlock = nullptr;
+        ivars.runtime.txSlotProviderSecondary.numSlots = 0;
+
         ivars.device.audioNub->FreeTxIsochResources();
     }
 

--- a/ASFWDriver/Audio/DriverKit/ASFWAudioDriverPrivate.hpp
+++ b/ASFWDriver/Audio/DriverKit/ASFWAudioDriverPrivate.hpp
@@ -190,6 +190,15 @@ struct AudioDriverRuntimeState {
     ASFW::Audio::Runtime::RxSequenceReplayReader txReplayReader;
     DextTxSlotProvider txSlotProvider;
     DextTxExecutionTimeline txExecutionTimeline;
+
+    // Secondary playback stream (multi-stream DICE, e.g. Venice F32 = 2×16). It
+    // shadows the master's per-packet timing in lockstep (same packetIndex/SYT/
+    // disposition) and differs only in payload: it encodes host output channels
+    // [pcmChannels, 2×pcmChannels). Inactive (txSecondaryActive == false) for
+    // single-stream devices, leaving the master path untouched.
+    ASFW::Protocols::Audio::DICE::DiceTxStreamEngine txStreamEngineSecondary;
+    DextTxSlotProvider txSlotProviderSecondary;
+    bool txSecondaryActive{false};
 };
 
 struct ASFWAudioDriver_IVars {
@@ -210,6 +219,15 @@ struct ASFWAudioDriver_IVars {
     OSSharedPtr<IOMemoryMap> txPayloadMap;
     OSSharedPtr<IOMemoryMap> txMetadataMap;
     OSSharedPtr<IOMemoryMap> txControlMap;
+
+    // Secondary playback stream shared resources (Venice F32 = 2×16). Mirrors the
+    // master set above; unused for single-stream devices.
+    OSSharedPtr<IOMemoryDescriptor> txPayloadBufferSecondary;
+    OSSharedPtr<IOMemoryDescriptor> txMetadataBufferSecondary;
+    OSSharedPtr<IOMemoryDescriptor> txControlBufferSecondary;
+    OSSharedPtr<IOMemoryMap> txPayloadMapSecondary;
+    OSSharedPtr<IOMemoryMap> txMetadataMapSecondary;
+    OSSharedPtr<IOMemoryMap> txControlMapSecondary;
     OSSharedPtr<OSAction> txPreparationAction;
     OSSharedPtr<IODispatchQueue> txPreparationQueue;
     OSSharedPtr<OSAction> ztsAnchorAction;

--- a/ASFWDriver/Audio/DriverKit/ASFWAudioDriverZts.cpp
+++ b/ASFWDriver/Audio/DriverKit/ASFWAudioDriverZts.cpp
@@ -358,6 +358,10 @@ uint32_t PrepareTransmitSlots(ASFWAudioDriver_IVars& ivars,
                         kFramesPerPacket;
                     (void)ivars.runtime.txStreamEngine
                         .AlignFrameCursorOnce(alignedFrame);
+                    if (ivars.runtime.txSecondaryActive) {
+                        (void)ivars.runtime.txStreamEngineSecondary
+                            .AlignFrameCursorOnce(alignedFrame);
+                    }
                 }
             }
         }
@@ -419,6 +423,15 @@ uint32_t PrepareTransmitSlots(ASFWAudioDriver_IVars& ivars,
             break;
         }
 
+        // Shadow the master's per-packet timing on the secondary stream so both
+        // device RX streams advance in lockstep (same packetIndex/DBC/SYT/
+        // disposition), differing only in payload (channels 17–32). Best-effort:
+        // a secondary hiccup must never stall the master (channels 1–16).
+        if (ivars.runtime.txSecondaryActive) {
+            (void)ivars.runtime.txStreamEngineSecondary.PrepareNextTransmitSlot(
+                static_cast<uint32_t>(nextPacketToPrepare), timing);
+        }
+
         const uint32_t slotIdx =
             static_cast<uint32_t>(
                 nextPacketToPrepare % numSlots);
@@ -472,6 +485,11 @@ void PrefillTxRingBeforeStart(ASFWAudioDriver_IVars& ivars) noexcept {
             ASFW::Protocols::Audio::DICE::TxSlotPrepareResult::
                 kPrepared) {
             break;
+        }
+        // Seed the secondary ring in lockstep with the same NO-DATA packets.
+        if (ivars.runtime.txSecondaryActive) {
+            (void)ivars.runtime.txStreamEngineSecondary.PrepareNextTransmitSlot(
+                static_cast<uint32_t>(packetIndex), timing);
         }
         ++prepared;
     }

--- a/ASFWDriver/Audio/DriverKit/ASFWAudioNub.cpp
+++ b/ASFWDriver/Audio/DriverKit/ASFWAudioNub.cpp
@@ -543,7 +543,7 @@ kern_return_t IMPL(ASFWAudioNub, AllocateTxIsochResources)
 
     // Delegate allocation to the core IsochService
     return ctx->isoch.AllocateTxIsochResources(
-        numSlots, maxPacketBytes, interruptInterval,
+        streamIndex, numSlots, maxPacketBytes, interruptInterval,
         outPayloadSlab, outMetadataRing, outControlBlock);
 }
 

--- a/ASFWDriver/Audio/DriverKit/ASFWAudioNub.iig
+++ b/ASFWDriver/Audio/DriverKit/ASFWAudioNub.iig
@@ -63,6 +63,7 @@ public:
      * @param outControlBlock Shared memory descriptor containing stream control states.
      */
     virtual kern_return_t AllocateTxIsochResources(
+        uint32_t streamIndex,
         uint32_t numSlots,
         uint32_t maxPacketBytes,
         uint32_t interruptInterval,

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/DiceDeviceProfile.hpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/DiceDeviceProfile.hpp
@@ -36,6 +36,13 @@ public:
     /// Builds the default receive (device-to-host) stream configuration.
     [[nodiscard]] virtual bool BuildDefaultRxStreamConfig(DiceStreamConfig& outConfig) const noexcept = 0;
 
+    /// Number of isochronous streams per direction (DICE TX_NUMBER/RX_NUMBER).
+    /// BuildDefault*StreamConfig describes ONE wire stream; the HAL aggregate
+    /// channel count is per-stream PCM × stream count. A multi-stream device
+    /// (Venice F32 = 2×16) overrides these; single-stream devices keep 1.
+    [[nodiscard]] virtual uint32_t TxStreamCount() const noexcept { return 1; }
+    [[nodiscard]] virtual uint32_t RxStreamCount() const noexcept { return 1; }
+
     // Default implementations mapping DICE structures to the unified IAudioDeviceProfile:
     [[nodiscard]] Encoding::AudioWireFormat TxWireFormat() const noexcept override {
         return Quirks().tx.hostToDevicePcmEncoding;
@@ -45,10 +52,12 @@ public:
         return Quirks().rx.deviceToHostPcmEncoding;
     }
 
+    // HAL aggregate = per-stream PCM × stream count. Single-stream profiles
+    // (TxStreamCount/RxStreamCount == 1) are unchanged.
     [[nodiscard]] uint32_t TxChannelCount() const noexcept override {
         DiceStreamConfig config{};
         if (BuildDefaultTxStreamConfig(config)) {
-            return config.pcmChannels;
+            return config.pcmChannels * TxStreamCount();
         }
         return 0;
     }
@@ -56,7 +65,7 @@ public:
     [[nodiscard]] uint32_t RxChannelCount() const noexcept override {
         DiceStreamConfig config{};
         if (BuildDefaultRxStreamConfig(config)) {
-            return config.pcmChannels;
+            return config.pcmChannels * RxStreamCount();
         }
         return 0;
     }

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/DiceStreamConfig.hpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/DiceStreamConfig.hpp
@@ -30,6 +30,11 @@ struct DiceStreamConfig final {
     uint8_t framesPerDataPacket{8};
     uint8_t fdf{0x02};
     uint8_t fmt{0x10};
+
+    // First host buffer channel this stream encodes (de-interleave). Stream 0
+    // reads from 0; for a multi-stream device the Nth stream reads from
+    // N × pcmChannels. Single-stream devices keep 0.
+    uint8_t sourceChannelOffset{0};
 };
 
 } // namespace ASFW::Isoch::Audio::DICE

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/MidasVeniceProfile.cpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/MidasVeniceProfile.cpp
@@ -22,20 +22,17 @@ constexpr uint32_t kMidasVeniceModelId = 0x000001;
 // carrying 16 PCM channels, 0 MIDI (DBS = 16) — 32×32 total (RX_NUMBER/TX_NUMBER
 // = 2, per-stream number_audio = 16).
 //
-// TX (host->device playback): BuildDefaultTxStreamConfig describes ONE wire
-// stream (16ch / DBS=16); TxStreamCount() == 2 makes the HAL aggregate 32. The
-// host transmit engine must match the device's per-stream DBS=16, not the
-// aggregate 32, or the device's 16-slot RX rejects the CIP.
-//
-// RX (device->host capture): kept as the aggregate (32 / DBS=32) here because the
-// capture path derives its real per-stream geometry from the device's runtime
-// caps (deviceToHostStreams), not this profile — only the HAL input channel count
-// is taken from RxChannelCount(). Input is already 2×16 on the wire.
-constexpr uint32_t kRxPcmChannels  = 32;
-constexpr uint32_t kTxPcmChannels  = 16;  // per wire stream (×2 = 32 HAL out)
-constexpr uint32_t kMidiSlots      = 0;
-constexpr uint32_t kRxDbs          = kRxPcmChannels + kMidiSlots;  // 32
-constexpr uint32_t kTxDbs          = kTxPcmChannels + kMidiSlots;  // 16
+// Both configs below describe ONE wire stream; Tx/RxStreamCount() == 2 makes the
+// HAL aggregate 32 per side. The host transmit engine must match the device's
+// per-stream DBS=16, not the aggregate 32, or the device's 16-slot RX rejects
+// the CIP. The capture path derives its real per-stream geometry from the
+// device's runtime caps (deviceToHostStreams), not this profile — only the HAL
+// input channel count is taken from RxChannelCount().
+constexpr uint32_t kRxPcmChannels = 16; // per wire stream (×2 = 32 HAL in)
+constexpr uint32_t kTxPcmChannels = 16; // per wire stream (×2 = 32 HAL out)
+constexpr uint32_t kMidiSlots = 0;
+constexpr uint32_t kRxDbs = kRxPcmChannels + kMidiSlots; // 16
+constexpr uint32_t kTxDbs = kTxPcmChannels + kMidiSlots; // 16
 
 void FillStreamConfig(DiceStreamConfig& out, DiceStreamDirection direction) noexcept {
     out = DiceStreamConfig{};

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/MidasVeniceProfile.cpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/MidasVeniceProfile.cpp
@@ -18,18 +18,24 @@ constexpr uint32_t kMidasVendorId      = 0x10c73f;
 constexpr uint32_t kMidasVeniceModelId = 0x000001;
 
 // Venice F32 stream geometry verified at runtime from the TCAT TX/RX STREAM
-// FORMAT registers at 48 kHz: a SINGLE isochronous stream per direction carrying
-// 32 PCM channels, 0 MIDI (DBS = 32). The device reports RX_NUMBER/TX_NUMBER = 1
-// with am824Slots = 32 (DICE DUPLEX START: inCh=32 inSlots=32, streams=1). Earlier
-// values (33 = +MIDI, 16 = half) did not match the device's RX format, so the
-// host CIP never locked the device and no hardware ZTS was produced.
-// (At 2x sample rates DICE may split into multiple streams; that path is handled
-// generically by the per-stream bringup/transport but is untested on this device.)
+// FORMAT registers at 48 kHz: TWO isochronous streams per direction, each
+// carrying 16 PCM channels, 0 MIDI (DBS = 16) — 32×32 total (RX_NUMBER/TX_NUMBER
+// = 2, per-stream number_audio = 16).
+//
+// TX (host->device playback): BuildDefaultTxStreamConfig describes ONE wire
+// stream (16ch / DBS=16); TxStreamCount() == 2 makes the HAL aggregate 32. The
+// host transmit engine must match the device's per-stream DBS=16, not the
+// aggregate 32, or the device's 16-slot RX rejects the CIP.
+//
+// RX (device->host capture): kept as the aggregate (32 / DBS=32) here because the
+// capture path derives its real per-stream geometry from the device's runtime
+// caps (deviceToHostStreams), not this profile — only the HAL input channel count
+// is taken from RxChannelCount(). Input is already 2×16 on the wire.
 constexpr uint32_t kRxPcmChannels  = 32;
-constexpr uint32_t kTxPcmChannels  = 32;
+constexpr uint32_t kTxPcmChannels  = 16;  // per wire stream (×2 = 32 HAL out)
 constexpr uint32_t kMidiSlots      = 0;
-constexpr uint32_t kRxDbs          = kRxPcmChannels + kMidiSlots;
-constexpr uint32_t kTxDbs          = kTxPcmChannels + kMidiSlots;
+constexpr uint32_t kRxDbs          = kRxPcmChannels + kMidiSlots;  // 32
+constexpr uint32_t kTxDbs          = kTxPcmChannels + kMidiSlots;  // 16
 
 void FillStreamConfig(DiceStreamConfig& out, DiceStreamDirection direction) noexcept {
     out = DiceStreamConfig{};

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/MidasVeniceProfile.hpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/MidasVeniceProfile.hpp
@@ -21,6 +21,10 @@ public:
     [[nodiscard]] bool BuildDefaultTxStreamConfig(DiceStreamConfig& outConfig) const noexcept override;
     [[nodiscard]] bool BuildDefaultRxStreamConfig(DiceStreamConfig& outConfig) const noexcept override;
 
+    // Venice F32 splits playback across 2 isoch streams of 16ch each; the wire
+    // config above is per-stream, so the HAL aggregate is 16 × 2 = 32 out.
+    [[nodiscard]] uint32_t TxStreamCount() const noexcept override { return 2; }
+
     [[nodiscard]] uint32_t TxSafetyOffsetFrames(double sampleRate) const noexcept override;
     [[nodiscard]] uint32_t RxSafetyOffsetFrames(double sampleRate) const noexcept override;
 

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/MidasVeniceProfile.hpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/MidasVeniceProfile.hpp
@@ -21,9 +21,10 @@ public:
     [[nodiscard]] bool BuildDefaultTxStreamConfig(DiceStreamConfig& outConfig) const noexcept override;
     [[nodiscard]] bool BuildDefaultRxStreamConfig(DiceStreamConfig& outConfig) const noexcept override;
 
-    // Venice F32 splits playback across 2 isoch streams of 16ch each; the wire
-    // config above is per-stream, so the HAL aggregate is 16 × 2 = 32 out.
+    // Venice F32 runs 2 isoch streams of 16ch in each direction; the wire
+    // configs above are per-stream, so the HAL aggregate is 16 × 2 = 32 per side.
     [[nodiscard]] uint32_t TxStreamCount() const noexcept override { return 2; }
+    [[nodiscard]] uint32_t RxStreamCount() const noexcept override { return 2; }
 
     [[nodiscard]] uint32_t TxSafetyOffsetFrames(double sampleRate) const noexcept override;
     [[nodiscard]] uint32_t RxSafetyOffsetFrames(double sampleRate) const noexcept override;

--- a/ASFWDriver/Audio/Engine/Direct/Tx/DiceTxStreamEngine.cpp
+++ b/ASFWDriver/Audio/Engine/Direct/Tx/DiceTxStreamEngine.cpp
@@ -16,6 +16,7 @@ AMDTP::AmdtpStreamConfig DiceStreamConfigMapper::ToAmdtpConfig(
     config.fmt = diceConfig.fmt;
     config.fdf = diceConfig.fdf;
     config.framesPerDataPacket = diceConfig.framesPerDataPacket;
+    config.sourceChannelOffset = diceConfig.sourceChannelOffset;
     // Compute the true max packet size: CIP headers (8 bytes) + frames × DBS × 4 bytes/slot.
     // Do not use the AmdtpStreamConfig default (512) — it is too small for high-channel
     // devices (e.g. a 24-channel device with DBS=24 needs 776 bytes at 8 fpd).

--- a/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
@@ -1181,6 +1181,32 @@ IOReturn DiceDuplexRestartCoordinator::RunDuplexStart(
                                       DiceRestartFailureCause::kStartTransmit);
     }
 
+    // Prepare each secondary playback stream on its own host IT context. It
+    // transmits on the iso channel that feeds the device's matching RX stream
+    // (PlaybackChannel(i)); the host IT ring stamps that channel into every
+    // packet header. The audio engine maps the secondary's shared slab (already
+    // allocated by StartIO) and writes its 16-ch slice.
+    for (uint32_t i = 1; i < channels.playbackStreamCount; ++i) {
+        if (abortIfTeardown("PreparingHostTransmitStream")) {
+            return kIOReturnAborted;
+        }
+        const kern_return_t status = hostTransport_.PrepareTransmitStream(
+            i,
+            channels.PlaybackChannel(i),
+            hardware_,
+            ReadLocalSid(hardware_));
+        if (status != kIOReturnSuccess) {
+            return rollbackToFailure(status,
+                                     DiceRestartPhase::kStartingHostTransmit,
+                                     DiceRestartFailureCause::kStartTransmit);
+        }
+        if (!IsRestartEpochCurrent(guid, restartId, topologyGeneration)) {
+            return rollbackToInvalidation(kIOReturnAborted,
+                                          DiceRestartPhase::kStartingHostTransmit,
+                                          DiceRestartFailureCause::kStartTransmit);
+        }
+    }
+
     SetSessionPhase(session, DiceRestartPhase::kWaitingGlobalClock);
     StoreSession(session);
     if (abortIfTeardown("WaitingGlobalClock")) {

--- a/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.cpp
@@ -34,43 +34,31 @@ kern_return_t DiceIsochHostTransport::ReserveCaptureResources(uint64_t guid,
 }
 
 kern_return_t DiceIsochHostTransport::PrepareReceive(
-    uint8_t channel,
-    Driver::HardwareInterface& hardware,
+    uint8_t channel, Driver::HardwareInterface& hardware,
     ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
-    Encoding::AudioWireFormat wireFormat,
-    uint32_t am824Slots,
-    uint32_t streamChannels) noexcept {
-    return isoch_.PrepareReceive(
-        channel, hardware, bindingSource, wireFormat, am824Slots,
-        /*packetCallback=*/nullptr, streamChannels);
+    Encoding::AudioWireFormat wireFormat, uint32_t am824Slots, uint32_t streamChannels) noexcept {
+    return isoch_.PrepareReceive(channel, hardware, bindingSource, wireFormat, am824Slots,
+                                 /*packetCallback=*/nullptr, streamChannels);
 }
 
-kern_return_t DiceIsochHostTransport::PrepareTransmit(
-    uint8_t channel,
-    Driver::HardwareInterface& hardware,
-    uint8_t sourceId) noexcept {
+kern_return_t DiceIsochHostTransport::PrepareTransmit(uint8_t channel,
+                                                      Driver::HardwareInterface& hardware,
+                                                      uint8_t sourceId) noexcept {
     return isoch_.PrepareTransmit(channel, hardware, sourceId);
 }
 
-kern_return_t DiceIsochHostTransport::PrepareReceiveStream(
-    uint32_t streamIndex,
-    uint8_t channel,
-    Driver::HardwareInterface& hardware,
-    ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
-    uint32_t channelOffset,
-    uint32_t streamChannels,
-    Encoding::AudioWireFormat wireFormat,
-    uint32_t am824Slots) noexcept {
-    return isoch_.PrepareReceiveStream(
-        streamIndex, channel, hardware, bindingSource, channelOffset,
-        streamChannels, wireFormat, am824Slots);
+kern_return_t DiceIsochHostTransport::PrepareReceiveStream(uint32_t streamIndex, uint8_t channel,
+                                                           Driver::HardwareInterface& hardware,
+                                                           uint32_t channelOffset,
+                                                           Encoding::AudioWireFormat wireFormat,
+                                                           uint32_t am824Slots) noexcept {
+    return isoch_.PrepareReceiveStream(streamIndex, channel, hardware, channelOffset, wireFormat,
+                                       am824Slots);
 }
 
-kern_return_t DiceIsochHostTransport::PrepareTransmitStream(
-    uint32_t streamIndex,
-    uint8_t channel,
-    Driver::HardwareInterface& hardware,
-    uint8_t sourceId) noexcept {
+kern_return_t DiceIsochHostTransport::PrepareTransmitStream(uint32_t streamIndex, uint8_t channel,
+                                                            Driver::HardwareInterface& hardware,
+                                                            uint8_t sourceId) noexcept {
     return isoch_.PrepareTransmitStream(streamIndex, channel, hardware, sourceId);
 }
 

--- a/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.cpp
@@ -47,13 +47,12 @@ kern_return_t DiceIsochHostTransport::PrepareTransmit(uint8_t channel,
     return isoch_.PrepareTransmit(channel, hardware, sourceId);
 }
 
-kern_return_t DiceIsochHostTransport::PrepareReceiveStream(uint32_t streamIndex, uint8_t channel,
-                                                           Driver::HardwareInterface& hardware,
-                                                           uint32_t channelOffset,
-                                                           Encoding::AudioWireFormat wireFormat,
-                                                           uint32_t am824Slots) noexcept {
-    return isoch_.PrepareReceiveStream(streamIndex, channel, hardware, channelOffset, wireFormat,
-                                       am824Slots);
+kern_return_t DiceIsochHostTransport::PrepareReceiveStream(
+    uint32_t streamIndex, uint8_t channel, Driver::HardwareInterface& hardware,
+    ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource, uint32_t channelOffset,
+    uint32_t streamChannels, Encoding::AudioWireFormat wireFormat, uint32_t am824Slots) noexcept {
+    return isoch_.PrepareReceiveStream(streamIndex, channel, hardware, bindingSource, channelOffset,
+                                       streamChannels, wireFormat, am824Slots);
 }
 
 kern_return_t DiceIsochHostTransport::PrepareTransmitStream(uint32_t streamIndex, uint8_t channel,

--- a/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.hpp
@@ -22,54 +22,42 @@ class ASFWAudioNub;
 namespace ASFW::Audio {
 
 class IDiceHostTransport {
-public:
+  public:
     virtual ~IDiceHostTransport() = default;
 
     [[nodiscard]] virtual kern_return_t BeginSplitDuplex(uint64_t guid) noexcept = 0;
-    [[nodiscard]] virtual kern_return_t ReservePlaybackResources(uint64_t guid,
-                                                                 ::ASFW::IRM::IRMClient& irmClient,
-                                                                 uint8_t channel,
-                                                                 uint32_t bandwidthUnits) noexcept = 0;
-    [[nodiscard]] virtual kern_return_t ReserveCaptureResources(uint64_t guid,
-                                                                ::ASFW::IRM::IRMClient& irmClient,
-                                                                uint8_t channel,
-                                                                uint32_t bandwidthUnits) noexcept = 0;
-    [[nodiscard]] virtual kern_return_t PrepareReceive(
-        uint8_t channel,
-        Driver::HardwareInterface& hardware,
-        ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
-        Encoding::AudioWireFormat wireFormat = Encoding::AudioWireFormat::kAM824,
-        uint32_t am824Slots = 0,
-        uint32_t streamChannels = 0) noexcept = 0;
-    [[nodiscard]] virtual kern_return_t PrepareTransmit(
-        uint8_t channel,
-        Driver::HardwareInterface& hardware,
-        uint8_t sourceId) noexcept = 0;
+    [[nodiscard]] virtual kern_return_t
+    ReservePlaybackResources(uint64_t guid, ::ASFW::IRM::IRMClient& irmClient, uint8_t channel,
+                             uint32_t bandwidthUnits) noexcept = 0;
+    [[nodiscard]] virtual kern_return_t
+    ReserveCaptureResources(uint64_t guid, ::ASFW::IRM::IRMClient& irmClient, uint8_t channel,
+                            uint32_t bandwidthUnits) noexcept = 0;
+    [[nodiscard]] virtual kern_return_t
+    PrepareReceive(uint8_t channel, Driver::HardwareInterface& hardware,
+                   ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
+                   Encoding::AudioWireFormat wireFormat = Encoding::AudioWireFormat::kAM824,
+                   uint32_t am824Slots = 0, uint32_t streamChannels = 0) noexcept = 0;
+    [[nodiscard]] virtual kern_return_t PrepareTransmit(uint8_t channel,
+                                                        Driver::HardwareInterface& hardware,
+                                                        uint8_t sourceId) noexcept = 0;
     // Secondary streams (streamIndex >= 1) for multi-stream DICE devices; the
     // master stream uses PrepareReceive/PrepareTransmit above.
-    [[nodiscard]] virtual kern_return_t PrepareReceiveStream(
-        uint32_t streamIndex,
-        uint8_t channel,
-        Driver::HardwareInterface& hardware,
-        ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
-        uint32_t channelOffset,
-        uint32_t streamChannels,
-        Encoding::AudioWireFormat wireFormat = Encoding::AudioWireFormat::kAM824,
-        uint32_t am824Slots = 0) noexcept = 0;
-    [[nodiscard]] virtual kern_return_t PrepareTransmitStream(
-        uint32_t streamIndex,
-        uint8_t channel,
-        Driver::HardwareInterface& hardware,
-        uint8_t sourceId) noexcept = 0;
+    [[nodiscard]] virtual kern_return_t
+    PrepareReceiveStream(uint32_t streamIndex, uint8_t channel, Driver::HardwareInterface& hardware,
+                         uint32_t channelOffset,
+                         Encoding::AudioWireFormat wireFormat = Encoding::AudioWireFormat::kAM824,
+                         uint32_t am824Slots = 0) noexcept = 0;
+    [[nodiscard]] virtual kern_return_t PrepareTransmitStream(uint32_t streamIndex, uint8_t channel,
+                                                              Driver::HardwareInterface& hardware,
+                                                              uint8_t sourceId) noexcept = 0;
     [[nodiscard]] virtual kern_return_t StartPreparedReceive() noexcept = 0;
     [[nodiscard]] virtual kern_return_t StartPreparedTransmit() noexcept = 0;
     [[nodiscard]] virtual kern_return_t StopAll() noexcept = 0;
 };
 
 class DiceIsochHostTransport final : public IDiceHostTransport {
-public:
-    explicit DiceIsochHostTransport(Driver::IsochService& isoch) noexcept
-        : isoch_(isoch) {}
+  public:
+    explicit DiceIsochHostTransport(Driver::IsochService& isoch) noexcept : isoch_(isoch) {}
 
     void SetTimingLossCallback(Driver::IsochService::TimingLossCallback callback) noexcept;
 
@@ -82,36 +70,27 @@ public:
                                                         ::ASFW::IRM::IRMClient& irmClient,
                                                         uint8_t channel,
                                                         uint32_t bandwidthUnits) noexcept override;
-    [[nodiscard]] kern_return_t PrepareReceive(
-        uint8_t channel,
-        Driver::HardwareInterface& hardware,
-        ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
-        Encoding::AudioWireFormat wireFormat = Encoding::AudioWireFormat::kAM824,
-        uint32_t am824Slots = 0,
-        uint32_t streamChannels = 0) noexcept override;
-    [[nodiscard]] kern_return_t PrepareTransmit(
-        uint8_t channel,
-        Driver::HardwareInterface& hardware,
-        uint8_t sourceId) noexcept override;
-    [[nodiscard]] kern_return_t PrepareReceiveStream(
-        uint32_t streamIndex,
-        uint8_t channel,
-        Driver::HardwareInterface& hardware,
-        ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
-        uint32_t channelOffset,
-        uint32_t streamChannels,
-        Encoding::AudioWireFormat wireFormat = Encoding::AudioWireFormat::kAM824,
-        uint32_t am824Slots = 0) noexcept override;
-    [[nodiscard]] kern_return_t PrepareTransmitStream(
-        uint32_t streamIndex,
-        uint8_t channel,
-        Driver::HardwareInterface& hardware,
-        uint8_t sourceId) noexcept override;
+    [[nodiscard]] kern_return_t
+    PrepareReceive(uint8_t channel, Driver::HardwareInterface& hardware,
+                   ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
+                   Encoding::AudioWireFormat wireFormat = Encoding::AudioWireFormat::kAM824,
+                   uint32_t am824Slots = 0, uint32_t streamChannels = 0) noexcept override;
+    [[nodiscard]] kern_return_t PrepareTransmit(uint8_t channel,
+                                                Driver::HardwareInterface& hardware,
+                                                uint8_t sourceId) noexcept override;
+    [[nodiscard]] kern_return_t
+    PrepareReceiveStream(uint32_t streamIndex, uint8_t channel, Driver::HardwareInterface& hardware,
+                         uint32_t channelOffset,
+                         Encoding::AudioWireFormat wireFormat = Encoding::AudioWireFormat::kAM824,
+                         uint32_t am824Slots = 0) noexcept override;
+    [[nodiscard]] kern_return_t PrepareTransmitStream(uint32_t streamIndex, uint8_t channel,
+                                                      Driver::HardwareInterface& hardware,
+                                                      uint8_t sourceId) noexcept override;
     [[nodiscard]] kern_return_t StartPreparedReceive() noexcept override;
     [[nodiscard]] kern_return_t StartPreparedTransmit() noexcept override;
     [[nodiscard]] kern_return_t StopAll() noexcept override;
 
-private:
+  private:
     Driver::IsochService& isoch_;
 };
 

--- a/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.hpp
@@ -44,7 +44,8 @@ class IDiceHostTransport {
     // master stream uses PrepareReceive/PrepareTransmit above.
     [[nodiscard]] virtual kern_return_t
     PrepareReceiveStream(uint32_t streamIndex, uint8_t channel, Driver::HardwareInterface& hardware,
-                         uint32_t channelOffset,
+                         ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
+                         uint32_t channelOffset, uint32_t streamChannels,
                          Encoding::AudioWireFormat wireFormat = Encoding::AudioWireFormat::kAM824,
                          uint32_t am824Slots = 0) noexcept = 0;
     [[nodiscard]] virtual kern_return_t PrepareTransmitStream(uint32_t streamIndex, uint8_t channel,
@@ -80,7 +81,8 @@ class DiceIsochHostTransport final : public IDiceHostTransport {
                                                 uint8_t sourceId) noexcept override;
     [[nodiscard]] kern_return_t
     PrepareReceiveStream(uint32_t streamIndex, uint8_t channel, Driver::HardwareInterface& hardware,
-                         uint32_t channelOffset,
+                         ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
+                         uint32_t channelOffset, uint32_t streamChannels,
                          Encoding::AudioWireFormat wireFormat = Encoding::AudioWireFormat::kAM824,
                          uint32_t am824Slots = 0) noexcept override;
     [[nodiscard]] kern_return_t PrepareTransmitStream(uint32_t streamIndex, uint8_t channel,

--- a/ASFWDriver/Audio/Wire/AMDTP/AmdtpPayloadWriter.cpp
+++ b/ASFWDriver/Audio/Wire/AMDTP/AmdtpPayloadWriter.cpp
@@ -129,10 +129,16 @@ void AmdtpPayloadWriter::WriteFloat32Interleaved(
         const uint32_t pcmSlots = (streamConfig_.pcmChannels < snap.dbs)
                                       ? streamConfig_.pcmChannels
                                       : snap.dbs;
+        // This stream encodes the host channels [sourceChannelOffset,
+        // sourceChannelOffset + pcmChannels) of the shared interleaved buffer —
+        // the de-interleave that mirrors the RX side's channelOffset. Host
+        // channels outside the buffer encode PCM zero.
+        const uint32_t srcOffset = streamConfig_.sourceChannelOffset;
         bool frameNonZero = false;
         for (uint32_t ch = 0; ch < pcmSlots; ++ch) {
+            const uint32_t srcCh = srcOffset + ch;
             const float sample =
-                (ch < hostBuffer.channels) ? source[ch] : 0.0f;
+                (srcCh < hostBuffer.channels) ? source[srcCh] : 0.0f;
             WriteBE32(dest + ch * kBytesPerSlot,
                       PcmSlotCodec::EncodeFloat32(
                           sample, txPolicy_.hostToDevicePcmEncoding));

--- a/ASFWDriver/Audio/Wire/AMDTP/AmdtpTypes.hpp
+++ b/ASFWDriver/Audio/Wire/AMDTP/AmdtpTypes.hpp
@@ -34,6 +34,12 @@ struct AmdtpStreamConfig final {
 
     uint8_t framesPerDataPacket{8};
     uint32_t maxPacketBytes{512};
+
+    // First host buffer channel this stream encodes. For a multi-stream device
+    // (Venice F32 = 2×16) the 32-ch host output buffer is split across streams:
+    // stream 0 reads channels [0, pcmChannels), stream 1 reads [16, 16+pcmChannels),
+    // etc. Single-stream devices keep 0.
+    uint8_t sourceChannelOffset{0};
 };
 
 struct AmdtpTxPolicy final {

--- a/ASFWDriver/Hardware/InterruptDispatcher.cpp
+++ b/ASFWDriver/Hardware/InterruptDispatcher.cpp
@@ -24,15 +24,25 @@ void InterruptDispatcher::HandleSnapshot(const InterruptSnapshot& snap, Controll
         // Clear the per-context event bits to acknowledge
         hardware.Write(Register32::kIsoRecvIntEventClear, snap.isoRecvEvent);
 
-        // Context 0 is our single IR context for now
-        if ((snap.isoRecvEvent & 0x01) && isoch.ReceiveContext()) {
-            // Dispatch descriptor processing to workqueue (deferred from ISR)
-            workQueue.DispatchAsync(^{
-              if (isoch.ReceiveContext()) {
-                  isoch.ReceiveContext()->Poll();
+        // One OHCI IR context backs each capture stream (contextIndex ==
+        // streamIndex). A multi-stream DICE device (Venice F32 = 2×16) runs a
+        // master (context 0) plus secondary contexts whose event bits are
+        // (1 << contextIndex). Drain every signalled context, not just context 0;
+        // the secondary's ring would otherwise fill without ever being polled and
+        // its channel slice (e.g. 17–32) would never reach the input buffer.
+        // Poll the master first so the producer timeline is published before the
+        // secondary slices anchor to it.
+        const uint32_t recvEvent = snap.isoRecvEvent;
+        workQueue.DispatchAsync(^{
+          for (uint32_t ctxIdx = 0; ctxIdx < IsochService::kMaxStreamsPerDirection; ++ctxIdx) {
+              if ((recvEvent & (1u << ctxIdx)) == 0) {
+                  continue;
               }
-            });
-        }
+              if (auto* rx = isoch.ReceiveContext(ctxIdx)) {
+                  rx->Poll();
+              }
+          }
+        });
     }
 
     // ===== ISOCHRONOUS TRANSMIT INTERRUPT =====

--- a/ASFWDriver/Hardware/InterruptDispatcher.cpp
+++ b/ASFWDriver/Hardware/InterruptDispatcher.cpp
@@ -59,12 +59,18 @@ void InterruptDispatcher::HandleSnapshot(const InterruptSnapshot& snap, Controll
         // Clear event bits to acknowledge
         hardware.Write(Register32::kIsoXmitIntEventClear, snap.isoXmitEvent);
 
-        // Context 0 is our single IT context
-        if ((snap.isoXmitEvent & 0x01) && isoch.TransmitContext()) {
-            // Process IT directly in ISR context for lowest latency.
-            // IT RefillRing is fast (atomic assemble + mem writes).
-            // DispatchAsync adds latency which might cause underruns if buffers are small.
-            isoch.TransmitContext()->HandleInterrupt();
+        // One OHCI IT context backs each playback stream (contextIndex ==
+        // streamIndex). A multi-stream DICE device (Venice F32 = 2×16) runs a
+        // master (context 0) plus secondary contexts (event bit 1 << contextIndex).
+        // Process every signalled context directly in ISR for lowest latency
+        // (IT RefillRing is fast; DispatchAsync would add underrun-prone latency).
+        for (uint32_t ctxIdx = 0; ctxIdx < IsochService::kMaxStreamsPerDirection; ++ctxIdx) {
+            if ((snap.isoXmitEvent & (1u << ctxIdx)) == 0) {
+                continue;
+            }
+            if (auto* tx = isoch.TransmitContext(ctxIdx)) {
+                tx->HandleInterrupt();
+            }
         }
     }
 

--- a/ASFWDriver/Isoch/IsochService.cpp
+++ b/ASFWDriver/Isoch/IsochService.cpp
@@ -7,40 +7,32 @@
 #include <DriverKit/IOBufferMemoryDescriptor.h>
 #include <DriverKit/IOMemoryMap.h>
 #endif
-#include "Memory/IsochDMAMemoryManager.hpp"
 #include "../Shared/Isoch/IsochAudioTransport.hpp"
+#include "Memory/IsochDMAMemoryManager.hpp"
 
 namespace ASFW::Driver {
 
 using namespace ASFW::Isoch;
 
-kern_return_t IsochService::StartReceive(uint8_t channel,
-                                         HardwareInterface& hardware,
-                                         ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
-                                         ASFW::Encoding::AudioWireFormat wireFormat,
-                                         uint32_t am824Slots,
-                                         ASFW::Isoch::IsochReceiveCallback packetCallback) {
-    const kern_return_t prepareKr =
-        PrepareReceive(channel,
-                       hardware,
-                       bindingSource,
-                       wireFormat,
-                       am824Slots,
-                       std::move(packetCallback));
+kern_return_t
+IsochService::StartReceive(uint8_t channel, HardwareInterface& hardware,
+                           ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
+                           ASFW::Encoding::AudioWireFormat wireFormat, uint32_t am824Slots,
+                           ASFW::Isoch::IsochReceiveCallback packetCallback) {
+    const kern_return_t prepareKr = PrepareReceive(channel, hardware, bindingSource, wireFormat,
+                                                   am824Slots, std::move(packetCallback));
     if (prepareKr != kIOReturnSuccess) {
         return prepareKr;
     }
     return StartPreparedReceive();
 }
 
-kern_return_t IsochService::PrepareReceive(
-    uint8_t channel,
-    HardwareInterface& hardware,
-    ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
-    ASFW::Encoding::AudioWireFormat wireFormat,
-    uint32_t am824Slots,
-    ASFW::Isoch::IsochReceiveCallback packetCallback,
-    uint32_t streamChannels) {
+kern_return_t
+IsochService::PrepareReceive(uint8_t channel, HardwareInterface& hardware,
+                             ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
+                             ASFW::Encoding::AudioWireFormat wireFormat, uint32_t am824Slots,
+                             ASFW::Isoch::IsochReceiveCallback packetCallback,
+                             uint32_t streamChannels) {
     if (!isochReceiveContext_) {
         ASFW::Isoch::Memory::IsochMemoryConfig config;
         config.numDescriptors = ASFW::Isoch::IsochReceiveContext::kNumDescriptors;
@@ -65,11 +57,8 @@ kern_return_t IsochService::PrepareReceive(
             return kIOReturnNoMemory;
         }
         RefreshReceiveTimingLossCallback();
-        isochReceiveContext_->SetZtsAnchorReadyCallback(
-            ztsAnchorReadyCallback_);
-        isochReceiveContext_->SetReplayReadyCallback([this]() {
-            StartDeferredTransmitIfReady();
-        });
+        isochReceiveContext_->SetZtsAnchorReadyCallback(ztsAnchorReadyCallback_);
+        isochReceiveContext_->SetReplayReadyCallback([this]() { StartDeferredTransmitIfReady(); });
     }
 
     isochReceiveContext_->SetDirectAudioBindingSource(bindingSource);
@@ -77,9 +66,9 @@ kern_return_t IsochService::PrepareReceive(
     // Master stream: contextIndex 0, channelOffset 0, isSecondary false.
     // streamChannels 0 == full binding width (single-stream back-compat);
     // multi-stream devices pass their first slice's PCM count.
-    const kern_return_t kr = isochReceiveContext_->Configure(
-        channel, 0, wireFormat, am824Slots,
-        /*channelOffset=*/0, streamChannels, /*isSecondary=*/false);
+    const kern_return_t kr =
+        isochReceiveContext_->Configure(channel, 0, wireFormat, am824Slots,
+                                        /*channelOffset=*/0, streamChannels, /*isSecondary=*/false);
     if (kr != kIOReturnSuccess) {
         ASFW_LOG(Isoch, "IsochService: IR Configure failed: 0x%08x", kr);
         return kr;
@@ -93,15 +82,11 @@ kern_return_t IsochService::PrepareReceive(
     return kIOReturnSuccess;
 }
 
-kern_return_t IsochService::PrepareReceiveStream(
-    uint32_t streamIndex,
-    uint8_t channel,
-    HardwareInterface& hardware,
-    ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
-    uint32_t channelOffset,
-    uint32_t streamChannels,
-    ASFW::Encoding::AudioWireFormat wireFormat,
-    uint32_t am824Slots) {
+kern_return_t IsochService::PrepareReceiveStream(uint32_t streamIndex, uint8_t channel,
+                                                 HardwareInterface& hardware,
+                                                 uint32_t channelOffset,
+                                                 ASFW::Encoding::AudioWireFormat wireFormat,
+                                                 uint32_t am824Slots) {
     // Stream 0 is the master; callers use PrepareReceive() for it.
     if (streamIndex == 0 || streamIndex >= kMaxStreamsPerDirection) {
         return kIOReturnBadArgument;
@@ -117,16 +102,14 @@ kern_return_t IsochService::PrepareReceiveStream(
 
         auto isochMem = ASFW::Isoch::Memory::IsochDMAMemoryManager::Create(config);
         if (!isochMem || !isochMem->Initialize(hardware)) {
-            ASFW_LOG(Isoch,
-                     "IsochService: secondary RX DMA memory init failed (stream %u)",
+            ASFW_LOG(Isoch, "IsochService: secondary RX DMA memory init failed (stream %u)",
                      streamIndex);
             return kIOReturnNoMemory;
         }
 
         slot = IsochReceiveContext::Create(&hardware, isochMem);
         if (!slot) {
-            ASFW_LOG(Isoch,
-                     "IsochService: Failed to create secondary IR context (stream %u)",
+            ASFW_LOG(Isoch, "IsochService: Failed to create secondary IR context (stream %u)",
                      streamIndex);
             return kIOReturnNoMemory;
         }
@@ -134,26 +117,18 @@ kern_return_t IsochService::PrepareReceiveStream(
         // the master context, so no ZTS/replay/timing-loss callbacks here.
     }
 
-    // Bind to the SAME shared input buffer as the master so this stream can
-    // write its de-interleaved slice; the context itself applies channelOffset.
-    slot->SetDirectAudioBindingSource(bindingSource);
-
     // contextIndex == streamIndex routes this stream to its own OHCI IR context.
-    // isSecondary=true makes it write PCM only (no clock/replay/ZTS).
-    const kern_return_t kr = slot->Configure(
-        channel, static_cast<uint8_t>(streamIndex), wireFormat, am824Slots,
-        channelOffset, streamChannels, /*isSecondary=*/true);
+    const kern_return_t kr =
+        slot->Configure(channel, static_cast<uint8_t>(streamIndex), wireFormat, am824Slots);
     if (kr != kIOReturnSuccess) {
-        ASFW_LOG(Isoch,
-                 "IsochService: secondary IR Configure failed (stream %u): 0x%08x",
+        ASFW_LOG(Isoch, "IsochService: secondary IR Configure failed (stream %u): 0x%08x",
                  streamIndex, kr);
         return kr;
     }
 
     captureChannelOffset_[streamIndex] = channelOffset;
-    ASFW_LOG(Isoch,
-             "IsochService: Prepared secondary IR stream %u on channel %u (offset %u, %u ch)",
-             streamIndex, channel, channelOffset, streamChannels);
+    ASFW_LOG(Isoch, "IsochService: Prepared secondary IR stream %u on channel %u (offset %u)",
+             streamIndex, channel, channelOffset);
     return kIOReturnSuccess;
 }
 
@@ -170,8 +145,7 @@ kern_return_t IsochService::StartPreparedReceive() {
         if (ctx) {
             const kern_return_t skr = ctx->Start();
             if (skr != kIOReturnSuccess) {
-                ASFW_LOG(Isoch,
-                         "IsochService: secondary IR start failed: 0x%08x", skr);
+                ASFW_LOG(Isoch, "IsochService: secondary IR start failed: 0x%08x", skr);
                 return skr;
             }
         }
@@ -216,7 +190,8 @@ kern_return_t IsochService::StartDVCapture(uint8_t channel, HardwareInterface& h
 
     if (isochReceiveContext_ &&
         isochReceiveContext_->GetState() == ASFW::Isoch::IRPolicy::State::Running) {
-        ASFW_LOG(Isoch, "IsochService: StartDVCapture blocked: IR context busy (audio receive running)");
+        ASFW_LOG(Isoch,
+                 "IsochService: StartDVCapture blocked: IR context busy (audio receive running)");
         return kIOReturnBusy;
     }
 
@@ -225,8 +200,8 @@ kern_return_t IsochService::StartDVCapture(uint8_t channel, HardwareInterface& h
     const uint64_t ringBytes = ASFW::Isoch::Rx::DVCaptureSink::RequiredBytes(kDVRingRecords);
 
     IOBufferMemoryDescriptor* memRaw = nullptr;
-    kern_return_t kr = IOBufferMemoryDescriptor::Create(kIOMemoryDirectionOutIn,
-                                                        ringBytes, 64, &memRaw);
+    kern_return_t kr =
+        IOBufferMemoryDescriptor::Create(kIOMemoryDirectionOutIn, ringBytes, 64, &memRaw);
     if (kr != kIOReturnSuccess || !memRaw) {
         ASFW_LOG(Isoch, "IsochService: StartDVCapture ring allocation failed: 0x%x", kr);
         return kr ? kr : kIOReturnNoMemory;
@@ -254,12 +229,12 @@ kern_return_t IsochService::StartDVCapture(uint8_t channel, HardwareInterface& h
     }
 
     auto* sink = &dvSink_;
-    kr = StartReceive(channel, hardware, /*bindingSource=*/nullptr,
-                      ASFW::Encoding::AudioWireFormat::kAM824, /*am824Slots=*/0,
-                      [sink](std::span<const uint8_t> data, uint32_t status,
-                             uint64_t /*timestamp*/) {
-                          sink->OnPacket(data.data(), data.size(), status);
-                      });
+    kr = StartReceive(
+        channel, hardware, /*bindingSource=*/nullptr, ASFW::Encoding::AudioWireFormat::kAM824,
+        /*am824Slots=*/0,
+        [sink](std::span<const uint8_t> data, uint32_t status, uint64_t /*timestamp*/) {
+            sink->OnPacket(data.data(), data.size(), status);
+        });
     if (kr != kIOReturnSuccess) {
         dvSink_.Detach();
         dvRing_.Reset();
@@ -267,8 +242,8 @@ kern_return_t IsochService::StartDVCapture(uint8_t channel, HardwareInterface& h
     }
 
     dvCaptureActive_ = true;
-    ASFW_LOG(Isoch, "IsochService: DV capture started on channel %u (ring=%llu bytes)",
-             channel, ringBytes);
+    ASFW_LOG(Isoch, "IsochService: DV capture started on channel %u (ring=%llu bytes)", channel,
+             ringBytes);
     return kIOReturnSuccess;
 }
 
@@ -279,7 +254,8 @@ kern_return_t IsochService::StopDVCapture() {
     return StopReceive();
 }
 
-kern_return_t IsochService::CopyDVCaptureMemory(uint64_t* options, IOMemoryDescriptor** memory) const {
+kern_return_t IsochService::CopyDVCaptureMemory(uint64_t* options,
+                                                IOMemoryDescriptor** memory) const {
     if (!memory) {
         return kIOReturnBadArgument;
     }
@@ -294,8 +270,7 @@ kern_return_t IsochService::CopyDVCaptureMemory(uint64_t* options, IOMemoryDescr
     return kIOReturnSuccess;
 }
 
-kern_return_t IsochService::StartTransmit(uint8_t channel,
-                                          HardwareInterface& hardware,
+kern_return_t IsochService::StartTransmit(uint8_t channel, HardwareInterface& hardware,
                                           uint8_t sid) {
     const kern_return_t prepareKr = PrepareTransmit(channel, hardware, sid);
     if (prepareKr != kIOReturnSuccess) {
@@ -304,8 +279,7 @@ kern_return_t IsochService::StartTransmit(uint8_t channel,
     return StartPreparedTransmit();
 }
 
-kern_return_t IsochService::PrepareTransmit(uint8_t channel,
-                                            HardwareInterface& hardware,
+kern_return_t IsochService::PrepareTransmit(uint8_t channel, HardwareInterface& hardware,
                                             uint8_t sid) {
     if (!isochTransmitContext_) {
         ASFW::Isoch::Memory::IsochMemoryConfig config;
@@ -331,8 +305,7 @@ kern_return_t IsochService::PrepareTransmit(uint8_t channel,
             ASFW_LOG(Isoch, "IsochService: Failed to create IT context");
             return kIOReturnNoMemory;
         }
-        isochTransmitContext_->SetTxPreparationCallback(
-            txPreparationCallback_);
+        isochTransmitContext_->SetTxPreparationCallback(txPreparationCallback_);
     }
 
     const kern_return_t kr = isochTransmitContext_->Configure(channel, sid);
@@ -343,15 +316,10 @@ kern_return_t IsochService::PrepareTransmit(uint8_t channel,
 
     if (txPayloadSlab_ && txMetadataRing_ && txControlBlock_) {
         const kern_return_t memKr = isochTransmitContext_->SetSharedMemoryDescriptors(
-            txPayloadSlab_.get(),
-            txMetadataRing_.get(),
-            txControlBlock_.get(),
-            interruptInterval_,
+            txPayloadSlab_.get(), txMetadataRing_.get(), txControlBlock_.get(), interruptInterval_,
             ASFW::IsochTransport::AudioTimingGeometry::kHalZeroTimestampPeriodFrames);
         if (memKr != kIOReturnSuccess) {
-            ASFW_LOG(Isoch,
-                     "IsochService: IT shared-memory setup failed: 0x%08x",
-                     memKr);
+            ASFW_LOG(Isoch, "IsochService: IT shared-memory setup failed: 0x%08x", memKr);
             return memKr;
         }
     }
@@ -360,10 +328,8 @@ kern_return_t IsochService::PrepareTransmit(uint8_t channel,
     return kIOReturnSuccess;
 }
 
-kern_return_t IsochService::PrepareTransmitStream(uint32_t streamIndex,
-                                                  uint8_t channel,
-                                                  HardwareInterface& hardware,
-                                                  uint8_t sid) {
+kern_return_t IsochService::PrepareTransmitStream(uint32_t streamIndex, uint8_t channel,
+                                                  HardwareInterface& hardware, uint8_t sid) {
     // Stream 0 is the master; callers use PrepareTransmit() for it.
     if (streamIndex == 0 || streamIndex >= kMaxStreamsPerDirection) {
         return kIOReturnBadArgument;
@@ -380,16 +346,14 @@ kern_return_t IsochService::PrepareTransmitStream(uint32_t streamIndex,
 
         auto isochMem = ASFW::Isoch::Memory::IsochDMAMemoryManager::Create(config);
         if (!isochMem || !isochMem->Initialize(hardware)) {
-            ASFW_LOG(Isoch,
-                     "IsochService: secondary TX DMA memory init failed (stream %u)",
+            ASFW_LOG(Isoch, "IsochService: secondary TX DMA memory init failed (stream %u)",
                      streamIndex);
             return kIOReturnNoMemory;
         }
 
         slot = IsochTransmitContext::Create(&hardware, isochMem);
         if (!slot) {
-            ASFW_LOG(Isoch,
-                     "IsochService: Failed to create secondary IT context (stream %u)",
+            ASFW_LOG(Isoch, "IsochService: Failed to create secondary IT context (stream %u)",
                      streamIndex);
             return kIOReturnNoMemory;
         }
@@ -398,16 +362,14 @@ kern_return_t IsochService::PrepareTransmitStream(uint32_t streamIndex,
 
     const kern_return_t kr = slot->Configure(channel, sid);
     if (kr != kIOReturnSuccess) {
-        ASFW_LOG(Isoch,
-                 "IsochService: secondary IT Configure failed (stream %u): 0x%08x",
+        ASFW_LOG(Isoch, "IsochService: secondary IT Configure failed (stream %u): 0x%08x",
                  streamIndex, kr);
         return kr;
     }
     // The secondary stream's shared payload slab is wired by the audio-engine
     // pass; without it the context is configured but not yet startable.
-    ASFW_LOG(Isoch,
-             "IsochService: Prepared secondary IT stream %u on channel %u",
-             streamIndex, channel);
+    ASFW_LOG(Isoch, "IsochService: Prepared secondary IT stream %u on channel %u", streamIndex,
+             channel);
     return kIOReturnSuccess;
 }
 
@@ -438,8 +400,7 @@ kern_return_t IsochService::StartPreparedTransmit() {
         if (ctx) {
             const kern_return_t skr = ctx->Start();
             if (skr != kIOReturnSuccess) {
-                ASFW_LOG(Isoch,
-                         "IsochService: secondary IT start failed: 0x%08x", skr);
+                ASFW_LOG(Isoch, "IsochService: secondary IT start failed: 0x%08x", skr);
                 return skr;
             }
         }
@@ -462,30 +423,29 @@ kern_return_t IsochService::StopTransmit() {
 
 kern_return_t IsochService::BeginSplitDuplex(uint64_t guid) {
     const kern_return_t kr = ClaimDuplexGuid(guid);
-    if (kr != kIOReturnSuccess) return kr;
-    
+    if (kr != kIOReturnSuccess)
+        return kr;
+
     reserved_.Reset();
     return kIOReturnSuccess;
 }
 
-kern_return_t IsochService::ReservePlaybackResources(uint64_t guid,
-                                                     IRM::IRMClient& irmClient,
-                                                     uint8_t channel,
-                                                     uint32_t bandwidthUnits) {
-    if (activeGuid_ != guid) return kIOReturnNotPrivileged;
-    
+kern_return_t IsochService::ReservePlaybackResources(uint64_t guid, IRM::IRMClient& irmClient,
+                                                     uint8_t channel, uint32_t bandwidthUnits) {
+    if (activeGuid_ != guid)
+        return kIOReturnNotPrivileged;
+
     reserved_.playbackActive = true;
     reserved_.playbackChannel = channel;
     reserved_.playbackBandwidthUnits = bandwidthUnits;
     return kIOReturnSuccess;
 }
 
-kern_return_t IsochService::ReserveCaptureResources(uint64_t guid,
-                                                    IRM::IRMClient& irmClient,
-                                                    uint8_t channel,
-                                                    uint32_t bandwidthUnits) {
-    if (activeGuid_ != guid) return kIOReturnNotPrivileged;
-    
+kern_return_t IsochService::ReserveCaptureResources(uint64_t guid, IRM::IRMClient& irmClient,
+                                                    uint8_t channel, uint32_t bandwidthUnits) {
+    if (activeGuid_ != guid)
+        return kIOReturnNotPrivileged;
+
     reserved_.captureActive = true;
     reserved_.captureChannel = channel;
     reserved_.captureBandwidthUnits = bandwidthUnits;
@@ -503,28 +463,23 @@ void IsochService::SetTimingLossCallback(TimingLossCallback callback) noexcept {
     timingLossCallback_ = std::move(callback);
 }
 
-void IsochService::SetTxPreparationCallback(
-    TxPreparationCallback callback) noexcept {
+void IsochService::SetTxPreparationCallback(TxPreparationCallback callback) noexcept {
     txPreparationCallback_ = std::move(callback);
     if (isochTransmitContext_) {
-        isochTransmitContext_->SetTxPreparationCallback(
-            txPreparationCallback_);
+        isochTransmitContext_->SetTxPreparationCallback(txPreparationCallback_);
     }
 }
 
-void IsochService::SetZtsAnchorReadyCallback(
-    ZtsAnchorReadyCallback callback) noexcept {
+void IsochService::SetZtsAnchorReadyCallback(ZtsAnchorReadyCallback callback) noexcept {
     ztsAnchorReadyCallback_ = std::move(callback);
     if (isochReceiveContext_) {
-        isochReceiveContext_->SetZtsAnchorReadyCallback(
-            ztsAnchorReadyCallback_);
+        isochReceiveContext_->SetZtsAnchorReadyCallback(ztsAnchorReadyCallback_);
     }
 }
 
 kern_return_t IsochService::ClaimDuplexGuid(uint64_t guid) {
     if (activeGuid_ != 0 && activeGuid_ != guid) {
-        ASFW_LOG(Isoch, "IsochService: GUID conflict 0x%llx (active: 0x%llx)",
-                 guid, activeGuid_);
+        ASFW_LOG(Isoch, "IsochService: GUID conflict 0x%llx (active: 0x%llx)", guid, activeGuid_);
         return kIOReturnBusy;
     }
     activeGuid_ = guid;
@@ -533,9 +488,7 @@ kern_return_t IsochService::ClaimDuplexGuid(uint64_t guid) {
 
 void IsochService::RefreshReceiveTimingLossCallback() noexcept {
     if (isochReceiveContext_) {
-        isochReceiveContext_->SetTimingLossCallback([this]() {
-            OnReceiveTimingLossDetected();
-        });
+        isochReceiveContext_->SetTimingLossCallback([this]() { OnReceiveTimingLossDetected(); });
     }
 }
 
@@ -546,34 +499,25 @@ void IsochService::OnReceiveTimingLossDetected() noexcept {
 }
 
 void IsochService::StartDeferredTransmitIfReady() noexcept {
-    if (!txStartPending_ || !isochTransmitContext_ ||
-        !isochReceiveContext_ ||
+    if (!txStartPending_ || !isochTransmitContext_ || !isochReceiveContext_ ||
         !isochReceiveContext_->IsReplayEstablished()) {
         return;
     }
 
     txStartPending_ = false;
-    ASFW_LOG(
-        Isoch,
-        "IsochService: IR replay established; starting deferred IT");
+    ASFW_LOG(Isoch, "IsochService: IR replay established; starting deferred IT");
     const kern_return_t status = isochTransmitContext_->Start();
     if (status != kIOReturnSuccess) {
-        ASFW_LOG(
-            Isoch,
-            "IsochService: deferred IT start failed: 0x%08x",
-            status);
+        ASFW_LOG(Isoch, "IsochService: deferred IT start failed: 0x%08x", status);
         OnReceiveTimingLossDetected();
     }
 }
 
-kern_return_t IsochService::AllocateTxIsochResources(
-    uint32_t numSlots,
-    uint32_t maxPacketBytes,
-    uint32_t interruptInterval,
-    IOMemoryDescriptor** outPayloadSlab,
-    IOMemoryDescriptor** outMetadataRing,
-    IOMemoryDescriptor** outControlBlock)
-{
+kern_return_t IsochService::AllocateTxIsochResources(uint32_t numSlots, uint32_t maxPacketBytes,
+                                                     uint32_t interruptInterval,
+                                                     IOMemoryDescriptor** outPayloadSlab,
+                                                     IOMemoryDescriptor** outMetadataRing,
+                                                     IOMemoryDescriptor** outControlBlock) {
     if (!outPayloadSlab || !outMetadataRing || !outControlBlock) {
         return kIOReturnBadArgument;
     }
@@ -586,11 +530,8 @@ kern_return_t IsochService::AllocateTxIsochResources(
     // 1. Allocate payload slab (page-aligned)
     const size_t payloadSlabBytes = static_cast<size_t>(numSlots) * maxPacketBytes;
     IOBufferMemoryDescriptor* payloadDescriptor = nullptr;
-    kern_return_t kr = IOBufferMemoryDescriptor::Create(
-        kIOMemoryDirectionInOut,
-        payloadSlabBytes,
-        4096,
-        &payloadDescriptor);
+    kern_return_t kr = IOBufferMemoryDescriptor::Create(kIOMemoryDirectionInOut, payloadSlabBytes,
+                                                        4096, &payloadDescriptor);
     if (kr != kIOReturnSuccess || !payloadDescriptor) {
         ASFW_LOG(Isoch, "IsochService: Failed to allocate payload slab: 0x%08x", kr);
         FreeTxIsochResources();
@@ -599,13 +540,11 @@ kern_return_t IsochService::AllocateTxIsochResources(
     txPayloadSlab_ = OSSharedPtr<IOBufferMemoryDescriptor>(payloadDescriptor, OSNoRetain);
 
     // 2. Allocate metadata ring (cacheline aligned)
-    const size_t metadataRingBytes = static_cast<size_t>(numSlots) * sizeof(ASFW::IsochTransport::TxPacketMeta);
+    const size_t metadataRingBytes =
+        static_cast<size_t>(numSlots) * sizeof(ASFW::IsochTransport::TxPacketMeta);
     IOBufferMemoryDescriptor* metadataDescriptor = nullptr;
-    kr = IOBufferMemoryDescriptor::Create(
-        kIOMemoryDirectionInOut,
-        metadataRingBytes,
-        64,
-        &metadataDescriptor);
+    kr = IOBufferMemoryDescriptor::Create(kIOMemoryDirectionInOut, metadataRingBytes, 64,
+                                          &metadataDescriptor);
     if (kr != kIOReturnSuccess || !metadataDescriptor) {
         ASFW_LOG(Isoch, "IsochService: Failed to allocate metadata ring: 0x%08x", kr);
         FreeTxIsochResources();
@@ -616,11 +555,8 @@ kern_return_t IsochService::AllocateTxIsochResources(
     // 3. Allocate control block (cacheline aligned)
     const size_t controlBlockBytes = sizeof(ASFW::IsochTransport::TxStreamControl);
     IOBufferMemoryDescriptor* controlDescriptor = nullptr;
-    kr = IOBufferMemoryDescriptor::Create(
-        kIOMemoryDirectionInOut,
-        controlBlockBytes,
-        64,
-        &controlDescriptor);
+    kr = IOBufferMemoryDescriptor::Create(kIOMemoryDirectionInOut, controlBlockBytes, 64,
+                                          &controlDescriptor);
     if (kr != kIOReturnSuccess || !controlDescriptor) {
         ASFW_LOG(Isoch, "IsochService: Failed to allocate control block: 0x%08x", kr);
         FreeTxIsochResources();
@@ -640,12 +576,12 @@ kern_return_t IsochService::AllocateTxIsochResources(
 
     interruptInterval_ = interruptInterval;
 
-    ASFW_LOG(Isoch, "IsochService: Allocated Tx isoch resources. numSlots=%u slotSize=%u", numSlots, maxPacketBytes);
+    ASFW_LOG(Isoch, "IsochService: Allocated Tx isoch resources. numSlots=%u slotSize=%u", numSlots,
+             maxPacketBytes);
     return kIOReturnSuccess;
 }
 
-kern_return_t IsochService::FreeTxIsochResources()
-{
+kern_return_t IsochService::FreeTxIsochResources() {
     txPayloadSlab_ = nullptr;
     txMetadataRing_ = nullptr;
     txControlBlock_ = nullptr;
@@ -653,7 +589,8 @@ kern_return_t IsochService::FreeTxIsochResources()
     return kIOReturnSuccess;
 }
 
-kern_return_t IsochService::GetCycleTimePair(uint64_t* outHostTimeMid, uint32_t* outCycleTimer, HardwareInterface& hardware) {
+kern_return_t IsochService::GetCycleTimePair(uint64_t* outHostTimeMid, uint32_t* outCycleTimer,
+                                             HardwareInterface& hardware) {
     if (!outHostTimeMid || !outCycleTimer) {
         return kIOReturnBadArgument;
     }

--- a/ASFWDriver/Isoch/IsochService.cpp
+++ b/ASFWDriver/Isoch/IsochService.cpp
@@ -82,11 +82,10 @@ IsochService::PrepareReceive(uint8_t channel, HardwareInterface& hardware,
     return kIOReturnSuccess;
 }
 
-kern_return_t IsochService::PrepareReceiveStream(uint32_t streamIndex, uint8_t channel,
-                                                 HardwareInterface& hardware,
-                                                 uint32_t channelOffset,
-                                                 ASFW::Encoding::AudioWireFormat wireFormat,
-                                                 uint32_t am824Slots) {
+kern_return_t IsochService::PrepareReceiveStream(
+    uint32_t streamIndex, uint8_t channel, HardwareInterface& hardware,
+    ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource, uint32_t channelOffset,
+    uint32_t streamChannels, ASFW::Encoding::AudioWireFormat wireFormat, uint32_t am824Slots) {
     // Stream 0 is the master; callers use PrepareReceive() for it.
     if (streamIndex == 0 || streamIndex >= kMaxStreamsPerDirection) {
         return kIOReturnBadArgument;
@@ -117,9 +116,15 @@ kern_return_t IsochService::PrepareReceiveStream(uint32_t streamIndex, uint8_t c
         // the master context, so no ZTS/replay/timing-loss callbacks here.
     }
 
+    // Bind to the SAME shared input buffer as the master so this stream can
+    // write its de-interleaved slice; the context itself applies channelOffset.
+    slot->SetDirectAudioBindingSource(bindingSource);
+
     // contextIndex == streamIndex routes this stream to its own OHCI IR context.
+    // isSecondary=true makes it write PCM only (no clock/replay/ZTS).
     const kern_return_t kr =
-        slot->Configure(channel, static_cast<uint8_t>(streamIndex), wireFormat, am824Slots);
+        slot->Configure(channel, static_cast<uint8_t>(streamIndex), wireFormat, am824Slots,
+                        channelOffset, streamChannels, /*isSecondary=*/true);
     if (kr != kIOReturnSuccess) {
         ASFW_LOG(Isoch, "IsochService: secondary IR Configure failed (stream %u): 0x%08x",
                  streamIndex, kr);
@@ -127,8 +132,9 @@ kern_return_t IsochService::PrepareReceiveStream(uint32_t streamIndex, uint8_t c
     }
 
     captureChannelOffset_[streamIndex] = channelOffset;
-    ASFW_LOG(Isoch, "IsochService: Prepared secondary IR stream %u on channel %u (offset %u)",
-             streamIndex, channel, channelOffset);
+    ASFW_LOG(Isoch,
+             "IsochService: Prepared secondary IR stream %u on channel %u (offset %u, %u ch)",
+             streamIndex, channel, channelOffset, streamChannels);
     return kIOReturnSuccess;
 }
 

--- a/ASFWDriver/Isoch/IsochService.cpp
+++ b/ASFWDriver/Isoch/IsochService.cpp
@@ -320,9 +320,10 @@ kern_return_t IsochService::PrepareTransmit(uint8_t channel, HardwareInterface& 
         return kr;
     }
 
-    if (txPayloadSlab_ && txMetadataRing_ && txControlBlock_) {
+    if (txPayloadSlab_[0] && txMetadataRing_[0] && txControlBlock_[0]) {
         const kern_return_t memKr = isochTransmitContext_->SetSharedMemoryDescriptors(
-            txPayloadSlab_.get(), txMetadataRing_.get(), txControlBlock_.get(), interruptInterval_,
+            txPayloadSlab_[0].get(), txMetadataRing_[0].get(), txControlBlock_[0].get(),
+            interruptInterval_,
             ASFW::IsochTransport::AudioTimingGeometry::kHalZeroTimestampPeriodFrames);
         if (memKr != kIOReturnSuccess) {
             ASFW_LOG(Isoch, "IsochService: IT shared-memory setup failed: 0x%08x", memKr);
@@ -372,8 +373,31 @@ kern_return_t IsochService::PrepareTransmitStream(uint32_t streamIndex, uint8_t 
                  streamIndex, kr);
         return kr;
     }
-    // The secondary stream's shared payload slab is wired by the audio-engine
-    // pass; without it the context is configured but not yet startable.
+    // The audio-side slot provider encodes a placeholder channel; have the ring
+    // stamp this context's real transmit channel (from Configure above) instead.
+    slot->EnableChannelStamping();
+
+    // Wire this stream's own shared payload slab (allocated via
+    // AllocateTxIsochResources(streamIndex)) so the context can DMA it. The
+    // audio engine maps the same descriptors and writes the de-interleaved slice.
+    if (txPayloadSlab_[streamIndex] && txMetadataRing_[streamIndex] &&
+        txControlBlock_[streamIndex]) {
+        const kern_return_t memKr = slot->SetSharedMemoryDescriptors(
+            txPayloadSlab_[streamIndex].get(), txMetadataRing_[streamIndex].get(),
+            txControlBlock_[streamIndex].get(), interruptInterval_,
+            ASFW::IsochTransport::AudioTimingGeometry::kHalZeroTimestampPeriodFrames);
+        if (memKr != kIOReturnSuccess) {
+            ASFW_LOG(Isoch,
+                     "IsochService: secondary IT shared-memory setup failed (stream %u): 0x%08x",
+                     streamIndex, memKr);
+            return memKr;
+        }
+    } else {
+        ASFW_LOG(Isoch, "IsochService: secondary IT stream %u has no shared slab — not startable",
+                 streamIndex);
+        return kIOReturnNotReady;
+    }
+
     ASFW_LOG(Isoch, "IsochService: Prepared secondary IT stream %u on channel %u", streamIndex,
              channel);
     return kIOReturnSuccess;
@@ -519,7 +543,8 @@ void IsochService::StartDeferredTransmitIfReady() noexcept {
     }
 }
 
-kern_return_t IsochService::AllocateTxIsochResources(uint32_t numSlots, uint32_t maxPacketBytes,
+kern_return_t IsochService::AllocateTxIsochResources(uint32_t streamIndex, uint32_t numSlots,
+                                                     uint32_t maxPacketBytes,
                                                      uint32_t interruptInterval,
                                                      IOMemoryDescriptor** outPayloadSlab,
                                                      IOMemoryDescriptor** outMetadataRing,
@@ -527,11 +552,17 @@ kern_return_t IsochService::AllocateTxIsochResources(uint32_t numSlots, uint32_t
     if (!outPayloadSlab || !outMetadataRing || !outControlBlock) {
         return kIOReturnBadArgument;
     }
+    if (streamIndex >= kMaxStreamsPerDirection) {
+        return kIOReturnBadArgument;
+    }
     *outPayloadSlab = nullptr;
     *outMetadataRing = nullptr;
     *outControlBlock = nullptr;
 
-    FreeTxIsochResources();
+    // Free only this stream's prior resources; other streams keep theirs.
+    txPayloadSlab_[streamIndex] = nullptr;
+    txMetadataRing_[streamIndex] = nullptr;
+    txControlBlock_[streamIndex] = nullptr;
 
     // 1. Allocate payload slab (page-aligned)
     const size_t payloadSlabBytes = static_cast<size_t>(numSlots) * maxPacketBytes;
@@ -540,10 +571,10 @@ kern_return_t IsochService::AllocateTxIsochResources(uint32_t numSlots, uint32_t
                                                         4096, &payloadDescriptor);
     if (kr != kIOReturnSuccess || !payloadDescriptor) {
         ASFW_LOG(Isoch, "IsochService: Failed to allocate payload slab: 0x%08x", kr);
-        FreeTxIsochResources();
         return (kr == kIOReturnSuccess) ? kIOReturnNoMemory : kr;
     }
-    txPayloadSlab_ = OSSharedPtr<IOBufferMemoryDescriptor>(payloadDescriptor, OSNoRetain);
+    txPayloadSlab_[streamIndex] =
+        OSSharedPtr<IOBufferMemoryDescriptor>(payloadDescriptor, OSNoRetain);
 
     // 2. Allocate metadata ring (cacheline aligned)
     const size_t metadataRingBytes =
@@ -553,10 +584,11 @@ kern_return_t IsochService::AllocateTxIsochResources(uint32_t numSlots, uint32_t
                                           &metadataDescriptor);
     if (kr != kIOReturnSuccess || !metadataDescriptor) {
         ASFW_LOG(Isoch, "IsochService: Failed to allocate metadata ring: 0x%08x", kr);
-        FreeTxIsochResources();
+        txPayloadSlab_[streamIndex] = nullptr;
         return (kr == kIOReturnSuccess) ? kIOReturnNoMemory : kr;
     }
-    txMetadataRing_ = OSSharedPtr<IOBufferMemoryDescriptor>(metadataDescriptor, OSNoRetain);
+    txMetadataRing_[streamIndex] =
+        OSSharedPtr<IOBufferMemoryDescriptor>(metadataDescriptor, OSNoRetain);
 
     // 3. Allocate control block (cacheline aligned)
     const size_t controlBlockBytes = sizeof(ASFW::IsochTransport::TxStreamControl);
@@ -565,32 +597,36 @@ kern_return_t IsochService::AllocateTxIsochResources(uint32_t numSlots, uint32_t
                                           &controlDescriptor);
     if (kr != kIOReturnSuccess || !controlDescriptor) {
         ASFW_LOG(Isoch, "IsochService: Failed to allocate control block: 0x%08x", kr);
-        FreeTxIsochResources();
+        txPayloadSlab_[streamIndex] = nullptr;
+        txMetadataRing_[streamIndex] = nullptr;
         return (kr == kIOReturnSuccess) ? kIOReturnNoMemory : kr;
     }
-    txControlBlock_ = OSSharedPtr<IOBufferMemoryDescriptor>(controlDescriptor, OSNoRetain);
+    txControlBlock_[streamIndex] =
+        OSSharedPtr<IOBufferMemoryDescriptor>(controlDescriptor, OSNoRetain);
 
     // Return the descriptors to the caller with retained references
-    *outPayloadSlab = txPayloadSlab_.get();
+    *outPayloadSlab = txPayloadSlab_[streamIndex].get();
     (*outPayloadSlab)->retain();
 
-    *outMetadataRing = txMetadataRing_.get();
+    *outMetadataRing = txMetadataRing_[streamIndex].get();
     (*outMetadataRing)->retain();
 
-    *outControlBlock = txControlBlock_.get();
+    *outControlBlock = txControlBlock_[streamIndex].get();
     (*outControlBlock)->retain();
 
     interruptInterval_ = interruptInterval;
 
-    ASFW_LOG(Isoch, "IsochService: Allocated Tx isoch resources. numSlots=%u slotSize=%u", numSlots,
-             maxPacketBytes);
+    ASFW_LOG(Isoch, "IsochService: Allocated Tx isoch resources stream %u. numSlots=%u slotSize=%u",
+             streamIndex, numSlots, maxPacketBytes);
     return kIOReturnSuccess;
 }
 
 kern_return_t IsochService::FreeTxIsochResources() {
-    txPayloadSlab_ = nullptr;
-    txMetadataRing_ = nullptr;
-    txControlBlock_ = nullptr;
+    for (uint32_t i = 0; i < kMaxStreamsPerDirection; ++i) {
+        txPayloadSlab_[i] = nullptr;
+        txMetadataRing_[i] = nullptr;
+        txControlBlock_[i] = nullptr;
+    }
     ASFW_LOG(Isoch, "IsochService: Freed Tx isoch resources");
     return kIOReturnSuccess;
 }

--- a/ASFWDriver/Isoch/IsochService.cpp
+++ b/ASFWDriver/Isoch/IsochService.cpp
@@ -367,6 +367,10 @@ kern_return_t IsochService::PrepareTransmitStream(uint32_t streamIndex, uint8_t 
         // No TX-preparation callback on secondaries; the master drives refill.
     }
 
+    // Each secondary stream runs on its own OHCI IT context (== streamIndex) so
+    // it does not collide with the master (context 0) on the hardware registers.
+    slot->SetContextIndex(static_cast<uint8_t>(streamIndex));
+
     const kern_return_t kr = slot->Configure(channel, sid);
     if (kr != kIOReturnSuccess) {
         ASFW_LOG(Isoch, "IsochService: secondary IT Configure failed (stream %u): 0x%08x",

--- a/ASFWDriver/Isoch/IsochService.hpp
+++ b/ASFWDriver/Isoch/IsochService.hpp
@@ -53,13 +53,16 @@ class IsochService {
         uint8_t channel, HardwareInterface& hardware,
         ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
         ASFW::Encoding::AudioWireFormat wireFormat = ASFW::Encoding::AudioWireFormat::kAM824,
-        uint32_t am824Slots = 0, ASFW::Isoch::IsochReceiveCallback packetCallback = nullptr);
+        uint32_t am824Slots = 0, ASFW::Isoch::IsochReceiveCallback packetCallback = nullptr,
+        uint32_t streamChannels = 0);
     // Prepare a secondary capture stream (streamIndex >= 1) on its own OHCI IR
     // context. channelOffset is the first host input channel this stream writes
     // (e.g. 16 for the second 16-ch slice of a 32-ch device); it is recorded for
     // the audio-engine de-interleave pass and not yet applied to the decoder.
     kern_return_t PrepareReceiveStream(
-        uint32_t streamIndex, uint8_t channel, HardwareInterface& hardware, uint32_t channelOffset,
+        uint32_t streamIndex, uint8_t channel, HardwareInterface& hardware,
+        ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource, uint32_t channelOffset,
+        uint32_t streamChannels,
         ASFW::Encoding::AudioWireFormat wireFormat = ASFW::Encoding::AudioWireFormat::kAM824,
         uint32_t am824Slots = 0);
     kern_return_t StartPreparedReceive();

--- a/ASFWDriver/Isoch/IsochService.hpp
+++ b/ASFWDriver/Isoch/IsochService.hpp
@@ -112,14 +112,14 @@ class IsochService {
      * @param outMetadataRing Shared memory descriptor containing packet metadata.
      * @param outControlBlock Shared memory descriptor containing stream control states.
      */
-    kern_return_t AllocateTxIsochResources(uint32_t numSlots, uint32_t maxPacketBytes,
-                                           uint32_t interruptInterval,
+    kern_return_t AllocateTxIsochResources(uint32_t streamIndex, uint32_t numSlots,
+                                           uint32_t maxPacketBytes, uint32_t interruptInterval,
                                            IOMemoryDescriptor** outPayloadSlab,
                                            IOMemoryDescriptor** outMetadataRing,
                                            IOMemoryDescriptor** outControlBlock);
 
     /**
-     * @brief Releases all allocated shared transmit resources.
+     * @brief Releases all allocated shared transmit resources (every stream).
      */
     kern_return_t FreeTxIsochResources();
 
@@ -198,9 +198,13 @@ class IsochService {
     ASFW::Isoch::Rx::DVCaptureSink dvSink_{};
     bool dvCaptureActive_{false};
 
-    OSSharedPtr<IOBufferMemoryDescriptor> txPayloadSlab_{nullptr};
-    OSSharedPtr<IOBufferMemoryDescriptor> txMetadataRing_{nullptr};
-    OSSharedPtr<IOBufferMemoryDescriptor> txControlBlock_{nullptr};
+    // Per-stream TX shared resources. Index 0 == master; 1.. are secondary
+    // playback streams (multi-stream DICE, e.g. Venice F32 = 2×16). Each IT
+    // context DMAs its own slab; the audio engine maps each and writes its
+    // de-interleaved 16-ch slice into it.
+    OSSharedPtr<IOBufferMemoryDescriptor> txPayloadSlab_[kMaxStreamsPerDirection]{};
+    OSSharedPtr<IOBufferMemoryDescriptor> txMetadataRing_[kMaxStreamsPerDirection]{};
+    OSSharedPtr<IOBufferMemoryDescriptor> txControlBlock_[kMaxStreamsPerDirection]{};
 
     uint64_t activeGuid_{0};
     TimingLossCallback timingLossCallback_{};

--- a/ASFWDriver/Isoch/IsochService.hpp
+++ b/ASFWDriver/Isoch/IsochService.hpp
@@ -12,10 +12,10 @@
 #include <DriverKit/OSSharedPtr.h>
 #endif
 
+#include "../Common/DriverKitOwnership.hpp"
 #include "IsochReceiveContext.hpp"
 #include "Receive/DVCaptureSink.hpp"
 #include "Transmit/IsochTransmitContext.hpp"
-#include "../Common/DriverKitOwnership.hpp"
 
 namespace ASFW::Audio::Runtime {
 class IDirectAudioBindingSource;
@@ -30,7 +30,7 @@ namespace ASFW::Driver {
 class HardwareInterface;
 
 class IsochService {
-public:
+  public:
     using TimingLossCallback = std::function<void(uint64_t guid)>;
     using TxPreparationCallback = std::function<void(uint64_t generation)>;
     using ZtsAnchorReadyCallback = std::function<void(uint64_t generation)>;
@@ -44,39 +44,30 @@ public:
     // IR/IT hardware context backs each stream (contextIndex == streamIndex).
     static constexpr uint32_t kMaxStreamsPerDirection = 4;
 
-    kern_return_t StartReceive(uint8_t channel,
-                               HardwareInterface& hardware,
-                               ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
-                               ASFW::Encoding::AudioWireFormat wireFormat = ASFW::Encoding::AudioWireFormat::kAM824,
-                               uint32_t am824Slots = 0,
-                               ASFW::Isoch::IsochReceiveCallback packetCallback = nullptr);
-    kern_return_t PrepareReceive(uint8_t channel,
-                                 HardwareInterface& hardware,
-                                 ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
-                                 ASFW::Encoding::AudioWireFormat wireFormat = ASFW::Encoding::AudioWireFormat::kAM824,
-                                 uint32_t am824Slots = 0,
-                                 ASFW::Isoch::IsochReceiveCallback packetCallback = nullptr,
-                                 uint32_t streamChannels = 0);
+    kern_return_t StartReceive(
+        uint8_t channel, HardwareInterface& hardware,
+        ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
+        ASFW::Encoding::AudioWireFormat wireFormat = ASFW::Encoding::AudioWireFormat::kAM824,
+        uint32_t am824Slots = 0, ASFW::Isoch::IsochReceiveCallback packetCallback = nullptr);
+    kern_return_t PrepareReceive(
+        uint8_t channel, HardwareInterface& hardware,
+        ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
+        ASFW::Encoding::AudioWireFormat wireFormat = ASFW::Encoding::AudioWireFormat::kAM824,
+        uint32_t am824Slots = 0, ASFW::Isoch::IsochReceiveCallback packetCallback = nullptr);
     // Prepare a secondary capture stream (streamIndex >= 1) on its own OHCI IR
     // context. channelOffset is the first host input channel this stream writes
     // (e.g. 16 for the second 16-ch slice of a 32-ch device); it is recorded for
     // the audio-engine de-interleave pass and not yet applied to the decoder.
-    kern_return_t PrepareReceiveStream(uint32_t streamIndex,
-                                       uint8_t channel,
-                                       HardwareInterface& hardware,
-                                       ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
-                                       uint32_t channelOffset,
-                                       uint32_t streamChannels,
-                                       ASFW::Encoding::AudioWireFormat wireFormat = ASFW::Encoding::AudioWireFormat::kAM824,
-                                       uint32_t am824Slots = 0);
+    kern_return_t PrepareReceiveStream(
+        uint32_t streamIndex, uint8_t channel, HardwareInterface& hardware, uint32_t channelOffset,
+        ASFW::Encoding::AudioWireFormat wireFormat = ASFW::Encoding::AudioWireFormat::kAM824,
+        uint32_t am824Slots = 0);
     kern_return_t StartPreparedReceive();
 
     kern_return_t StopReceive();
 
     [[nodiscard]] uint32_t CaptureStreamChannelOffset(uint32_t streamIndex) const noexcept {
-        return (streamIndex < kMaxStreamsPerDirection)
-                   ? captureChannelOffset_[streamIndex]
-                   : 0;
+        return (streamIndex < kMaxStreamsPerDirection) ? captureChannelOffset_[streamIndex] : 0;
     }
 
     // Minimal DV (IEC 61883-2) capture tap: starts IR on the given channel with
@@ -86,32 +77,22 @@ public:
     kern_return_t StopDVCapture();
     kern_return_t CopyDVCaptureMemory(uint64_t* options, IOMemoryDescriptor** memory) const;
 
-    kern_return_t StartTransmit(uint8_t channel,
-                                HardwareInterface& hardware,
-                                uint8_t sid);
-    kern_return_t PrepareTransmit(uint8_t channel,
-                                  HardwareInterface& hardware,
-                                  uint8_t sid);
+    kern_return_t StartTransmit(uint8_t channel, HardwareInterface& hardware, uint8_t sid);
+    kern_return_t PrepareTransmit(uint8_t channel, HardwareInterface& hardware, uint8_t sid);
     // Prepare a secondary playback stream (streamIndex >= 1) on its own OHCI IT
     // context. The shared payload slab for the secondary stream is wired by the
     // audio-engine pass via SetSecondaryTransmitSharedMemory(); this only
     // creates and configures the hardware context.
-    kern_return_t PrepareTransmitStream(uint32_t streamIndex,
-                                        uint8_t channel,
-                                        HardwareInterface& hardware,
-                                        uint8_t sid);
+    kern_return_t PrepareTransmitStream(uint32_t streamIndex, uint8_t channel,
+                                        HardwareInterface& hardware, uint8_t sid);
     kern_return_t StartPreparedTransmit();
 
     kern_return_t StopTransmit();
 
     kern_return_t BeginSplitDuplex(uint64_t guid);
-    kern_return_t ReservePlaybackResources(uint64_t guid,
-                                           IRM::IRMClient& irmClient,
-                                           uint8_t channel,
-                                           uint32_t bandwidthUnits);
-    kern_return_t ReserveCaptureResources(uint64_t guid,
-                                          IRM::IRMClient& irmClient,
-                                          uint8_t channel,
+    kern_return_t ReservePlaybackResources(uint64_t guid, IRM::IRMClient& irmClient,
+                                           uint8_t channel, uint32_t bandwidthUnits);
+    kern_return_t ReserveCaptureResources(uint64_t guid, IRM::IRMClient& irmClient, uint8_t channel,
                                           uint32_t bandwidthUnits);
 
     void StopAll();
@@ -128,13 +109,11 @@ public:
      * @param outMetadataRing Shared memory descriptor containing packet metadata.
      * @param outControlBlock Shared memory descriptor containing stream control states.
      */
-    kern_return_t AllocateTxIsochResources(
-        uint32_t numSlots,
-        uint32_t maxPacketBytes,
-        uint32_t interruptInterval,
-        IOMemoryDescriptor** outPayloadSlab,
-        IOMemoryDescriptor** outMetadataRing,
-        IOMemoryDescriptor** outControlBlock);
+    kern_return_t AllocateTxIsochResources(uint32_t numSlots, uint32_t maxPacketBytes,
+                                           uint32_t interruptInterval,
+                                           IOMemoryDescriptor** outPayloadSlab,
+                                           IOMemoryDescriptor** outMetadataRing,
+                                           IOMemoryDescriptor** outControlBlock);
 
     /**
      * @brief Releases all allocated shared transmit resources.
@@ -147,26 +126,31 @@ public:
      * @param outCycleTimer Raw FireWire cycle timer value from hardware.
      * @param hardware Reference to the hardware interface.
      */
-    kern_return_t GetCycleTimePair(uint64_t* outHostTimeMid, uint32_t* outCycleTimer, HardwareInterface& hardware);
+    kern_return_t GetCycleTimePair(uint64_t* outHostTimeMid, uint32_t* outCycleTimer,
+                                   HardwareInterface& hardware);
 
     ASFW::Isoch::IsochReceiveContext* ReceiveContext() const { return isochReceiveContext_.get(); }
-    ASFW::Isoch::IsochTransmitContext* TransmitContext() const { return isochTransmitContext_.get(); }
+    ASFW::Isoch::IsochTransmitContext* TransmitContext() const {
+        return isochTransmitContext_.get();
+    }
 
     // Per-stream accessors: index 0 == master, index 1+ == secondary streams.
     ASFW::Isoch::IsochReceiveContext* ReceiveContext(uint32_t streamIndex) const {
-        if (streamIndex == 0) return isochReceiveContext_.get();
+        if (streamIndex == 0)
+            return isochReceiveContext_.get();
         if (streamIndex < kMaxStreamsPerDirection)
             return secondaryReceiveContexts_[streamIndex - 1].get();
         return nullptr;
     }
     ASFW::Isoch::IsochTransmitContext* TransmitContext(uint32_t streamIndex) const {
-        if (streamIndex == 0) return isochTransmitContext_.get();
+        if (streamIndex == 0)
+            return isochTransmitContext_.get();
         if (streamIndex < kMaxStreamsPerDirection)
             return secondaryTransmitContexts_[streamIndex - 1].get();
         return nullptr;
     }
 
-private:
+  private:
     kern_return_t ClaimDuplexGuid(uint64_t guid);
     void RefreshReceiveTimingLossCallback() noexcept;
     void OnReceiveTimingLossDetected() noexcept;
@@ -202,7 +186,8 @@ private:
         }
 
         [[nodiscard]] void* BaseAddress() const noexcept {
-            return map ? reinterpret_cast<void*>(static_cast<uintptr_t>(map->GetAddress())) : nullptr;
+            return map ? reinterpret_cast<void*>(static_cast<uintptr_t>(map->GetAddress()))
+                       : nullptr;
         }
     };
 

--- a/ASFWDriver/Isoch/Receive/IsochReceiveContext.hpp
+++ b/ASFWDriver/Isoch/Receive/IsochReceiveContext.hpp
@@ -1,54 +1,54 @@
 #pragma once
 
-#include <DriverKit/OSObject.h>
-#include <new>
-#include <DriverKit/IOLib.h>
 #include <DriverKit/IOBufferMemoryDescriptor.h>
-#include <memory>
-#include <vector>
+#include <DriverKit/IOLib.h>
+#include <DriverKit/OSObject.h>
 #include <atomic>
+#include <memory>
+#include <new>
 #include <span>
+#include <vector>
 
+#include "../../Hardware/HardwareInterface.hpp"
 #include "../../Shared/Contexts/DmaContextManagerBase.hpp"
 #include "../../Shared/Memory/IDMAMemory.hpp"
 #include "../../Shared/Rings/DescriptorRing.hpp"
-#include "../../Hardware/HardwareInterface.hpp"
 #include "../Core/IsochTypes.hpp"
 #include "../Memory/IIsochDMAMemory.hpp"
 
+#include "../../Audio/DriverKit/Runtime/AudioGraphBinding.hpp"
+#include "../../Audio/Engine/Direct/AudioClockPublisher.hpp"
+#include "../../Audio/Engine/Direct/DirectInputWriter.hpp"
+#include "../../Audio/Engine/Direct/Rx/RxAudioPacketProcessor.hpp"
+#include "../../Shared/Isoch/AudioTimingGeometry.hpp"
 #include "IsochRxDmaRing.hpp"
 #include "IsochRxTiming.hpp"
 #include "ZtsTelemetry.hpp"
-#include "../../Shared/Isoch/AudioTimingGeometry.hpp"
-#include "../../Audio/Engine/Direct/DirectInputWriter.hpp"
-#include "../../Audio/Engine/Direct/AudioClockPublisher.hpp"
-#include "../../Audio/Engine/Direct/Rx/RxAudioPacketProcessor.hpp"
-#include "../../Audio/DriverKit/Runtime/AudioGraphBinding.hpp"
 
 namespace ASFW {
 namespace Audio::Runtime {
 class IDirectAudioBindingSource;
 }
-}
+} // namespace ASFW
 
 namespace ASFW::Isoch {
 
 // Policy trait for Isoch Receive Context to satisfy DmaContextManagerBase requirements
 struct IRPolicy {
-    enum class State {
-        Stopped,
-        Running,
-        Stopping
-    };
+    enum class State { Stopped, Running, Stopping };
 
     static constexpr State kInitialState = State::Stopped;
 
     static const char* ToStr(State s) {
         switch (s) {
-            case State::Stopped: return "Stopped";
-            case State::Running: return "Running";
-            case State::Stopping: return "Stopping";
-            default: return "Unknown";
+        case State::Stopped:
+            return "Stopped";
+        case State::Running:
+            return "Running";
+        case State::Stopping:
+            return "Stopping";
+        default:
+            return "Unknown";
         }
     }
 };
@@ -57,15 +57,14 @@ struct IRTag {
     static constexpr const char kContextName[] = "IsochReceiveContext";
 };
 
-class IsochReceiveContext : public OSObject,
-                            public ::ASFW::Shared::DmaContextManagerBase<IsochReceiveContext,
-                                                                         ::ASFW::Shared::DescriptorRing,
-                                                                         IRTag,
-                                                                         IRPolicy> {
-public:
+class IsochReceiveContext
+    : public OSObject,
+      public ::ASFW::Shared::DmaContextManagerBase<
+          IsochReceiveContext, ::ASFW::Shared::DescriptorRing, IRTag, IRPolicy> {
+  public:
     IsochReceiveContext()
-        : ::ASFW::Shared::DmaContextManagerBase<IsochReceiveContext, ::ASFW::Shared::DescriptorRing, IRTag, IRPolicy>(*this, descriptorRing_) {
-    }
+        : ::ASFW::Shared::DmaContextManagerBase<IsochReceiveContext, ::ASFW::Shared::DescriptorRing,
+                                                IRTag, IRPolicy>(*this, descriptorRing_) {}
 
     virtual bool init() override;
     virtual void free() override;
@@ -74,16 +73,16 @@ public:
     void* operator new(size_t size, std::nothrow_t const&) { return IOMallocZero(size); }
     void operator delete(void* ptr, size_t size) { IOFree(ptr, size); }
 
-    static OSSharedPtr<IsochReceiveContext> Create(::ASFW::Driver::HardwareInterface* hw,
-                                                  std::shared_ptr<::ASFW::Isoch::Memory::IIsochDMAMemory> dmaMemory);
+    static OSSharedPtr<IsochReceiveContext>
+    Create(::ASFW::Driver::HardwareInterface* hw,
+           std::shared_ptr<::ASFW::Isoch::Memory::IIsochDMAMemory> dmaMemory);
 
     static constexpr size_t kNumDescriptors =
         ASFW::IsochTransport::AudioTimingGeometry::kRxDescriptorPackets;
     static constexpr size_t kMaxPacketSize = 4096;
     static_assert(kNumDescriptors %
-                      ASFW::IsochTransport::AudioTimingGeometry::
-                          kTimingGroupPackets ==
-                  0,
+                          ASFW::IsochTransport::AudioTimingGeometry::kTimingGroupPackets ==
+                      0,
                   "IR descriptor ring must be an integer number of interrupt "
                   "groups or the interrupt cadence breaks at the ring wrap");
 
@@ -91,21 +90,20 @@ public:
     // de-interleave: this context writes `streamChannels` PCM channels (0 == the
     // binding's full width) into the shared input buffer at `channelOffset`. A
     // secondary context writes PCM only and does not own the clock/ZTS/replay.
-    kern_return_t Configure(uint8_t channel,
-                            uint8_t contextIndex,
-                            Encoding::AudioWireFormat wireFormat = Encoding::AudioWireFormat::kAM824,
-                            uint32_t am824Slots = 0,
-                            uint32_t channelOffset = 0,
-                            uint32_t streamChannels = 0,
-                            bool isSecondary = false);
+    kern_return_t
+    Configure(uint8_t channel, uint8_t contextIndex,
+              Encoding::AudioWireFormat wireFormat = Encoding::AudioWireFormat::kAM824,
+              uint32_t am824Slots = 0, uint32_t channelOffset = 0, uint32_t streamChannels = 0,
+              bool isSecondary = false);
     kern_return_t Start();
     void Stop();
     uint32_t Poll();
 
     void SetCallback(IsochReceiveCallback callback);
 
-    void SetDirectAudioBindingSource(ASFW::Audio::Runtime::IDirectAudioBindingSource* source) noexcept;
-    
+    void
+    SetDirectAudioBindingSource(ASFW::Audio::Runtime::IDirectAudioBindingSource* source) noexcept;
+
     using TimingLossCallback = std::function<void()>;
     void SetTimingLossCallback(TimingLossCallback callback) noexcept;
     using ZtsAnchorReadyCallback = std::function<void(uint64_t)>;
@@ -132,7 +130,7 @@ public:
     // line into the TxSyt log category. Called by the watchdog (~1 s).
     void LogTxSytTrace();
 
-private:
+  private:
     void ResetReplayEpochForDiscontinuity() noexcept;
 
     struct Registers {
@@ -175,15 +173,6 @@ private:
     uint32_t channelOffset_{0};
     uint32_t streamChannels_{0};
     bool isSecondary_{false};
-
-    // Secondary-slice frame anchoring. A secondary context runs on its own OHCI
-    // IR context that arms/starts independently of the master, so its private
-    // cursor (from 0) has no relation to the master's ring position. We anchor it
-    // to the master's published inputProducedEndFrame on the first write of each
-    // replay epoch so both halves of a frame land in the same ring slot; the two
-    // streams are frame-locked by the device clock and stay aligned thereafter.
-    bool secondaryAnchored_{false};
-    uint64_t secondaryAnchorEpoch_{0};
 
     uint64_t absoluteFrameCursor_{0};
     bool cursorInitialized_{false};

--- a/ASFWDriver/Isoch/Receive/IsochReceiveContext.hpp
+++ b/ASFWDriver/Isoch/Receive/IsochReceiveContext.hpp
@@ -174,6 +174,15 @@ class IsochReceiveContext
     uint32_t streamChannels_{0};
     bool isSecondary_{false};
 
+    // Secondary-slice frame anchoring. A secondary context runs on its own OHCI
+    // IR context that arms/starts independently of the master, so its private
+    // cursor (from 0) has no relation to the master's ring position. We anchor it
+    // to the master's published inputProducedEndFrame on the first write of each
+    // replay epoch so both halves of a frame land in the same ring slot; the two
+    // streams are frame-locked by the device clock and stay aligned thereafter.
+    bool secondaryAnchored_{false};
+    uint64_t secondaryAnchorEpoch_{0};
+
     uint64_t absoluteFrameCursor_{0};
     bool cursorInitialized_{false};
     uint64_t rxZtsPublishCount_{0};

--- a/ASFWDriver/Isoch/Transmit/IsochTransmitContext.hpp
+++ b/ASFWDriver/Isoch/Transmit/IsochTransmitContext.hpp
@@ -65,6 +65,11 @@ public:
 
     kern_return_t Configure(uint8_t channel, uint8_t sid) noexcept;
 
+    // Select which OHCI IT hardware context backs this stream. Defaults to 0
+    // (master); secondary streams must use their own context (== streamIndex) or
+    // they collide with the master on context 0's registers. Set before Start().
+    void SetContextIndex(uint8_t index) noexcept { contextIndex_ = index; }
+
     // Secondary streams enable this so the ring stamps the configured transmit
     // channel into every packet header (the audio-side producer encodes a
     // placeholder channel). The master leaves it off (verbatim header copy).

--- a/ASFWDriver/Isoch/Transmit/IsochTransmitContext.hpp
+++ b/ASFWDriver/Isoch/Transmit/IsochTransmitContext.hpp
@@ -65,6 +65,11 @@ public:
 
     kern_return_t Configure(uint8_t channel, uint8_t sid) noexcept;
 
+    // Secondary streams enable this so the ring stamps the configured transmit
+    // channel into every packet header (the audio-side producer encodes a
+    // placeholder channel). The master leaves it off (verbatim header copy).
+    void EnableChannelStamping() noexcept { ring_.SetStampChannel(true); }
+
     /**
      * @brief Map the shared memory regions allocated by the host into the Dext address space.
      * Prepares the payload slab for DMA and resolves its physical IOVA for descriptor priming.

--- a/ASFWDriver/Isoch/Transmit/IsochTxDmaRing.cpp
+++ b/ASFWDriver/Isoch/Transmit/IsochTxDmaRing.cpp
@@ -12,6 +12,24 @@ namespace ASFW::Isoch::Tx {
 using namespace ASFW::Async::HW;
 using namespace ASFW::Driver;
 
+namespace {
+// Replace the channel field [13:8] of a little-endian OHCI isoch transmit header
+// quadlet with `channel`. The producer (slot provider) encodes a channel; this
+// lets the owning ring override it with its configured transmit channel so a
+// secondary stream rides its own iso channel.
+[[nodiscard]] inline uint32_t StampHeaderChannel(uint32_t leHeader, uint8_t channel) noexcept {
+    // An all-zero header is the "no packet" sentinel (e.g. underrun): leave it
+    // untouched so the ring never invents packet state.
+    if (leHeader == 0) {
+        return 0;
+    }
+    uint32_t h = OSSwapLittleToHostInt32(leHeader);
+    h = (h & ~(static_cast<uint32_t>(0x3F) << 8)) |
+        (static_cast<uint32_t>(channel & 0x3F) << 8);
+    return OSSwapHostToLittleInt32(h);
+}
+} // namespace
+
 void IsochTxDmaRing::ResetForStart() noexcept {
     softwareFillAbsIdx_ = 0;
     lastHwPacketIndex_ = 0;
@@ -293,8 +311,13 @@ IsochTxDmaRing::PrimeStats IsochTxDmaRing::Prime(
             .branchBits = OHCIDescriptor::kBranchNever,
         });
 
-        // Set the immediate isochronous headers from metadata.
-        immDesc->immediateData[0] = meta.immediateHeader[0];
+        // Set the immediate isochronous headers from metadata. Secondary streams
+        // opt into restamping the transmit channel ([13:8]) from this ring's
+        // channel_ (set by Configure), so they ride their own iso channel without
+        // the audio-side slot provider knowing it. The master copies verbatim.
+        immDesc->immediateData[0] = stampChannel_
+            ? StampHeaderChannel(meta.immediateHeader[0], channel_)
+            : meta.immediateHeader[0];
         immDesc->immediateData[1] = meta.immediateHeader[1];
 
         // Linux queue_iso_transmit() self-links the skip address so a lost
@@ -691,7 +714,9 @@ IsochTxDmaRing::RefillOutcome IsochTxDmaRing::Refill(
         const uint32_t descBase = hwSlot * Layout::kBlocksPerPacket;
         auto* immDesc = reinterpret_cast<OHCIDescriptorImmediate*>(
             slab_.GetDescriptorPtr(descBase));
-        immDesc->immediateData[0] = meta.immediateHeader[0];
+        immDesc->immediateData[0] = stampChannel_
+            ? StampHeaderChannel(meta.immediateHeader[0], channel_)
+            : meta.immediateHeader[0];
         immDesc->immediateData[1] = meta.immediateHeader[1];
         immDesc->common.branchWord = MakeBranchWordAT(
             slab_.GetDescriptorIOVA(descBase),

--- a/ASFWDriver/Isoch/Transmit/IsochTxDmaRing.hpp
+++ b/ASFWDriver/Isoch/Transmit/IsochTxDmaRing.hpp
@@ -116,6 +116,12 @@ public:
 
     void SetChannel(uint8_t channel) noexcept { channel_ = channel; }
 
+    // When enabled, the refill path overrides the transmit channel ([13:8]) of
+    // each non-empty packet header with channel_. Secondary streams opt in so
+    // they ride their own iso channel without the audio-side producer encoding
+    // it; the master leaves this off (verbatim metadata copy).
+    void SetStampChannel(bool enabled) noexcept { stampChannel_ = enabled; }
+
     [[nodiscard]] bool HasRings() const noexcept { return slab_.IsValid(); }
 
     [[nodiscard]] kern_return_t SetupRings(Memory::IIsochDMAMemory& dmaMemory) noexcept {
@@ -174,6 +180,7 @@ private:
                           uint32_t payloadLength) noexcept;
 
     uint8_t channel_{0};
+    bool stampChannel_{false};
     IsochTxDescriptorSlab slab_{};
     Memory::IIsochDMAMemory* dmaMemory_{nullptr};
 

--- a/tests/audio/DiceProfileTests.cpp
+++ b/tests/audio/DiceProfileTests.cpp
@@ -87,15 +87,19 @@ TEST(DiceProfileTests, ResolvesMidasVeniceProfileByVendorAndModel) {
     EXPECT_EQ(profile->TxWireFormat(), ASFW::Encoding::AudioWireFormat::kRawPcm24In32);
     EXPECT_EQ(profile->RxWireFormat(), ASFW::Encoding::AudioWireFormat::kAM824);
 
-    // Venice F32 at 48 kHz: single 32-ch stream per direction, 0 MIDI, DBS=32.
-    EXPECT_EQ(profile->TxChannelCount(), 32);
+    // Venice F32 at 48 kHz: 2 streams/direction × 16ch. The TX wire config is
+    // per-stream (DBS=16) with TxStreamCount()==2, so the HAL aggregate stays 32
+    // out. RX is kept as the aggregate (capture geometry comes from device caps).
+    EXPECT_EQ(profile->TxChannelCount(), 32);  // 16 × 2 streams
     EXPECT_EQ(profile->RxChannelCount(), 32);
     EXPECT_EQ(profile->TxMidiSlots(), 0);
     EXPECT_EQ(profile->RxMidiSlots(), 0);
-    EXPECT_EQ(profile->TxDbs(), 32);
+    EXPECT_EQ(profile->TxDbs(), 16);           // per wire stream
     EXPECT_EQ(profile->RxDbs(), 32);
 
     const auto* diceProfile = static_cast<const IDiceDeviceProfile*>(profile);
+    EXPECT_EQ(diceProfile->TxStreamCount(), 2u);
+    EXPECT_EQ(diceProfile->RxStreamCount(), 1u);
     EXPECT_TRUE(diceProfile->Quirks().tx.preserveFdfInNoDataPackets);
     EXPECT_EQ(diceProfile->Quirks().tx.hostToDevicePcmEncoding,
               ASFW::Encoding::AudioWireFormat::kRawPcm24In32);

--- a/tests/audio/DiceProfileTests.cpp
+++ b/tests/audio/DiceProfileTests.cpp
@@ -87,19 +87,19 @@ TEST(DiceProfileTests, ResolvesMidasVeniceProfileByVendorAndModel) {
     EXPECT_EQ(profile->TxWireFormat(), ASFW::Encoding::AudioWireFormat::kRawPcm24In32);
     EXPECT_EQ(profile->RxWireFormat(), ASFW::Encoding::AudioWireFormat::kAM824);
 
-    // Venice F32 at 48 kHz: 2 streams/direction × 16ch. The TX wire config is
-    // per-stream (DBS=16) with TxStreamCount()==2, so the HAL aggregate stays 32
-    // out. RX is kept as the aggregate (capture geometry comes from device caps).
-    EXPECT_EQ(profile->TxChannelCount(), 32);  // 16 × 2 streams
-    EXPECT_EQ(profile->RxChannelCount(), 32);
+    // Venice F32 at 48 kHz: 2 streams/direction × 16ch. Both wire configs are
+    // per-stream (DBS=16) with Tx/RxStreamCount()==2, so the HAL aggregate is
+    // 32 per side.
+    EXPECT_EQ(profile->TxChannelCount(), 32); // 16 × 2 streams
+    EXPECT_EQ(profile->RxChannelCount(), 32); // 16 × 2 streams
     EXPECT_EQ(profile->TxMidiSlots(), 0);
     EXPECT_EQ(profile->RxMidiSlots(), 0);
-    EXPECT_EQ(profile->TxDbs(), 16);           // per wire stream
-    EXPECT_EQ(profile->RxDbs(), 32);
+    EXPECT_EQ(profile->TxDbs(), 16); // per wire stream
+    EXPECT_EQ(profile->RxDbs(), 16); // per wire stream
 
     const auto* diceProfile = static_cast<const IDiceDeviceProfile*>(profile);
     EXPECT_EQ(diceProfile->TxStreamCount(), 2u);
-    EXPECT_EQ(diceProfile->RxStreamCount(), 1u);
+    EXPECT_EQ(diceProfile->RxStreamCount(), 2u);
     EXPECT_TRUE(diceProfile->Quirks().tx.preserveFdfInNoDataPackets);
     EXPECT_EQ(diceProfile->Quirks().tx.hostToDevicePcmEncoding,
               ASFW::Encoding::AudioWireFormat::kRawPcm24In32);

--- a/tests/audio/IsochServiceTxPreparationTests.cpp
+++ b/tests/audio/IsochServiceTxPreparationTests.cpp
@@ -97,12 +97,15 @@ TEST(IsochServiceTxPreparation, SecondaryStreamRejectsIndexZeroAndOutOfRange) {
     HardwareInterface hardware;
 
     // Index 0 is the master — must go through PrepareReceive/PrepareTransmit.
-    EXPECT_EQ(service.PrepareReceiveStream(0, /*channel=*/1, hardware, /*offset=*/0),
+    EXPECT_EQ(service.PrepareReceiveStream(0, /*channel=*/1, hardware,
+                                           /*binding=*/nullptr, /*offset=*/0,
+                                           /*streamChannels=*/16),
               kIOReturnBadArgument);
     EXPECT_EQ(service.PrepareTransmitStream(0, /*channel=*/0, hardware, /*sid=*/0x3f),
               kIOReturnBadArgument);
     // Out of range.
-    EXPECT_EQ(service.PrepareReceiveStream(IsochService::kMaxStreamsPerDirection, 2, hardware, 16),
+    EXPECT_EQ(service.PrepareReceiveStream(IsochService::kMaxStreamsPerDirection, 2, hardware,
+                                           nullptr, 16, 16),
               kIOReturnBadArgument);
 }
 
@@ -113,7 +116,9 @@ TEST(IsochServiceTxPreparation, SecondaryReceiveStreamCreatesContextAndRecordsOf
     EXPECT_EQ(service.ReceiveContext(1), nullptr);
 
     ASSERT_EQ(service.PrepareReceiveStream(/*streamIndex=*/1, /*channel=*/2, hardware,
-                                           /*channelOffset=*/16),
+                                           /*bindingSource=*/nullptr,
+                                           /*channelOffset=*/16,
+                                           /*streamChannels=*/16),
               kIOReturnSuccess);
 
     // Master untouched; secondary now exists and its de-interleave offset is recorded.

--- a/tests/audio/IsochServiceTxPreparationTests.cpp
+++ b/tests/audio/IsochServiceTxPreparationTests.cpp
@@ -20,103 +20,71 @@ using ASFW::IsochTransport::ExpectedCommitGen;
 using ASFW::IsochTransport::TxPacketMeta;
 using ASFW::IsochTransport::TxStreamControl;
 
-TEST(IsochServiceTxPreparation,
-     CallbackRegisteredBeforeContextCreationSurvivesStartTransmit) {
+TEST(IsochServiceTxPreparation, CallbackRegisteredBeforeContextCreationSurvivesStartTransmit) {
     IsochService service;
     HardwareInterface hardware;
 
     uint32_t callbackCount = 0;
     uint64_t callbackGeneration = 0;
-    service.SetTxPreparationCallback(
-        [&](uint64_t generation) {
-            ++callbackCount;
-            callbackGeneration = generation;
-        });
+    service.SetTxPreparationCallback([&](uint64_t generation) {
+        ++callbackCount;
+        callbackGeneration = generation;
+    });
 
     IOMemoryDescriptor* payloadDescriptor = nullptr;
     IOMemoryDescriptor* metadataDescriptor = nullptr;
     IOMemoryDescriptor* controlDescriptor = nullptr;
-    ASSERT_EQ(
-        service.AllocateTxIsochResources(
-            AudioTimingGeometry::kTxSharedSlotPackets,
-            512,
-            AudioTimingGeometry::kTxPacketsPerGroup,
-            &payloadDescriptor,
-            &metadataDescriptor,
-            &controlDescriptor),
-        kIOReturnSuccess);
+    ASSERT_EQ(service.AllocateTxIsochResources(AudioTimingGeometry::kTxSharedSlotPackets, 512,
+                                               AudioTimingGeometry::kTxPacketsPerGroup,
+                                               &payloadDescriptor, &metadataDescriptor,
+                                               &controlDescriptor),
+              kIOReturnSuccess);
     ASSERT_NE(payloadDescriptor, nullptr);
     ASSERT_NE(metadataDescriptor, nullptr);
     ASSERT_NE(controlDescriptor, nullptr);
 
     IOAddressSegment metadataRange{};
-    ASSERT_EQ(metadataDescriptor->GetAddressRange(&metadataRange),
-              kIOReturnSuccess);
-    std::memset(reinterpret_cast<void*>(metadataRange.address),
-                0,
-                metadataRange.length);
-    auto* metadata =
-        reinterpret_cast<TxPacketMeta*>(metadataRange.address);
-    for (uint64_t packetIndex = 0;
-         packetIndex < AudioTimingGeometry::kTxSharedSlotPackets;
+    ASSERT_EQ(metadataDescriptor->GetAddressRange(&metadataRange), kIOReturnSuccess);
+    std::memset(reinterpret_cast<void*>(metadataRange.address), 0, metadataRange.length);
+    auto* metadata = reinterpret_cast<TxPacketMeta*>(metadataRange.address);
+    for (uint64_t packetIndex = 0; packetIndex < AudioTimingGeometry::kTxSharedSlotPackets;
          ++packetIndex) {
-        auto& meta =
-            metadata[packetIndex %
-                     AudioTimingGeometry::kTxSharedSlotPackets];
+        auto& meta = metadata[packetIndex % AudioTimingGeometry::kTxSharedSlotPackets];
         meta.packetIndex = packetIndex;
         meta.payloadLength = 8;
         meta.commitGen.store(
-            ExpectedCommitGen(
-                packetIndex,
-                AudioTimingGeometry::kTxSharedSlotPackets),
+            ExpectedCommitGen(packetIndex, AudioTimingGeometry::kTxSharedSlotPackets),
             std::memory_order_release);
     }
 
     IOAddressSegment controlRange{};
-    ASSERT_EQ(controlDescriptor->GetAddressRange(&controlRange),
-              kIOReturnSuccess);
-    std::memset(reinterpret_cast<void*>(controlRange.address),
-                0,
-                controlRange.length);
-    auto* control =
-        reinterpret_cast<TxStreamControl*>(controlRange.address);
-    control->exposeCursor.store(
-        AudioTimingGeometry::kTxPreparationLeadPackets,
-        std::memory_order_release);
+    ASSERT_EQ(controlDescriptor->GetAddressRange(&controlRange), kIOReturnSuccess);
+    std::memset(reinterpret_cast<void*>(controlRange.address), 0, controlRange.length);
+    auto* control = reinterpret_cast<TxStreamControl*>(controlRange.address);
+    control->exposeCursor.store(AudioTimingGeometry::kTxPreparationLeadPackets,
+                                std::memory_order_release);
 
-    ASSERT_EQ(service.StartTransmit(/*channel=*/3,
-                                    hardware,
+    ASSERT_EQ(service.StartTransmit(/*channel=*/3, hardware,
                                     /*sid=*/0x3f),
               kIOReturnSuccess);
     auto* context = service.TransmitContext();
     ASSERT_NE(context, nullptr);
 
     const Register32 commandPtrRegister =
-        static_cast<Register32>(
-            DMAContextHelpers::IsoXmitCommandPtr(0));
-    const uint32_t initialCommandPtr =
-        hardware.GetTestRegister(commandPtrRegister);
+        static_cast<Register32>(DMAContextHelpers::IsoXmitCommandPtr(0));
+    const uint32_t initialCommandPtr = hardware.GetTestRegister(commandPtrRegister);
     EXPECT_EQ(initialCommandPtr & 0xfU, Layout::kBlocksPerPacket);
     const uint32_t descriptorBase = initialCommandPtr & 0xfffffff0U;
-    const uint32_t completedPackets =
-        AudioTimingGeometry::kTxPacketsPerGroup;
+    const uint32_t completedPackets = AudioTimingGeometry::kTxPacketsPerGroup;
     const uint32_t nextCommandPtr =
-        descriptorBase +
-        completedPackets *
-            Layout::kBlocksPerPacket *
-            Layout::kDescriptorStride;
-    hardware.SetTestRegister(
-        commandPtrRegister,
-        nextCommandPtr | Layout::kBlocksPerPacket);
+        descriptorBase + completedPackets * Layout::kBlocksPerPacket * Layout::kDescriptorStride;
+    hardware.SetTestRegister(commandPtrRegister, nextCommandPtr | Layout::kBlocksPerPacket);
 
     context->HandleInterrupt();
 
     EXPECT_EQ(callbackCount, 1U);
     EXPECT_EQ(callbackGeneration, 1U);
-    EXPECT_EQ(
-        control->preparationRequestGeneration.load(
-            std::memory_order_acquire),
-        1U);
+    EXPECT_EQ(control->preparationRequestGeneration.load(std::memory_order_acquire), 1U);
 }
 
 // Secondary-stream container: a multi-stream DICE device (Venice F32 = 2×16)
@@ -129,15 +97,12 @@ TEST(IsochServiceTxPreparation, SecondaryStreamRejectsIndexZeroAndOutOfRange) {
     HardwareInterface hardware;
 
     // Index 0 is the master — must go through PrepareReceive/PrepareTransmit.
-    EXPECT_EQ(service.PrepareReceiveStream(0, /*channel=*/1, hardware,
-                                           /*binding=*/nullptr, /*offset=*/0,
-                                           /*streamChannels=*/16),
+    EXPECT_EQ(service.PrepareReceiveStream(0, /*channel=*/1, hardware, /*offset=*/0),
               kIOReturnBadArgument);
     EXPECT_EQ(service.PrepareTransmitStream(0, /*channel=*/0, hardware, /*sid=*/0x3f),
               kIOReturnBadArgument);
     // Out of range.
-    EXPECT_EQ(service.PrepareReceiveStream(IsochService::kMaxStreamsPerDirection,
-                                           2, hardware, nullptr, 16, 16),
+    EXPECT_EQ(service.PrepareReceiveStream(IsochService::kMaxStreamsPerDirection, 2, hardware, 16),
               kIOReturnBadArgument);
 }
 
@@ -147,12 +112,9 @@ TEST(IsochServiceTxPreparation, SecondaryReceiveStreamCreatesContextAndRecordsOf
 
     EXPECT_EQ(service.ReceiveContext(1), nullptr);
 
-    ASSERT_EQ(
-        service.PrepareReceiveStream(/*streamIndex=*/1, /*channel=*/2, hardware,
-                                     /*bindingSource=*/nullptr,
-                                     /*channelOffset=*/16,
-                                     /*streamChannels=*/16),
-        kIOReturnSuccess);
+    ASSERT_EQ(service.PrepareReceiveStream(/*streamIndex=*/1, /*channel=*/2, hardware,
+                                           /*channelOffset=*/16),
+              kIOReturnSuccess);
 
     // Master untouched; secondary now exists and its de-interleave offset is recorded.
     EXPECT_EQ(service.ReceiveContext(0), nullptr);
@@ -168,13 +130,12 @@ TEST(IsochServiceTxPreparation, SecondaryTransmitStreamCreatesIndependentContext
     IsochService service;
     HardwareInterface hardware;
 
-    ASSERT_EQ(
-        service.PrepareTransmitStream(/*streamIndex=*/1, /*channel=*/4, hardware,
-                                      /*sid=*/0x3f),
-        kIOReturnSuccess);
+    ASSERT_EQ(service.PrepareTransmitStream(/*streamIndex=*/1, /*channel=*/4, hardware,
+                                            /*sid=*/0x3f),
+              kIOReturnSuccess);
 
-    EXPECT_EQ(service.TransmitContext(0), nullptr);  // master not created
-    EXPECT_NE(service.TransmitContext(1), nullptr);  // secondary created
+    EXPECT_EQ(service.TransmitContext(0), nullptr); // master not created
+    EXPECT_NE(service.TransmitContext(1), nullptr); // secondary created
     EXPECT_NE(service.TransmitContext(1), service.TransmitContext(0));
 
     service.StopAll();

--- a/tests/audio/IsochServiceTxPreparationTests.cpp
+++ b/tests/audio/IsochServiceTxPreparationTests.cpp
@@ -34,10 +34,10 @@ TEST(IsochServiceTxPreparation, CallbackRegisteredBeforeContextCreationSurvivesS
     IOMemoryDescriptor* payloadDescriptor = nullptr;
     IOMemoryDescriptor* metadataDescriptor = nullptr;
     IOMemoryDescriptor* controlDescriptor = nullptr;
-    ASSERT_EQ(service.AllocateTxIsochResources(AudioTimingGeometry::kTxSharedSlotPackets, 512,
-                                               AudioTimingGeometry::kTxPacketsPerGroup,
-                                               &payloadDescriptor, &metadataDescriptor,
-                                               &controlDescriptor),
+    ASSERT_EQ(service.AllocateTxIsochResources(
+                  /*streamIndex=*/0, AudioTimingGeometry::kTxSharedSlotPackets, 512,
+                  AudioTimingGeometry::kTxPacketsPerGroup, &payloadDescriptor, &metadataDescriptor,
+                  &controlDescriptor),
               kIOReturnSuccess);
     ASSERT_NE(payloadDescriptor, nullptr);
     ASSERT_NE(metadataDescriptor, nullptr);
@@ -135,6 +135,17 @@ TEST(IsochServiceTxPreparation, SecondaryTransmitStreamCreatesIndependentContext
     IsochService service;
     HardwareInterface hardware;
 
+    // The secondary stream's shared slab must be allocated before its context is
+    // prepared (StartIO allocates, the duplex bringup then wires the context).
+    IOMemoryDescriptor* payloadDescriptor = nullptr;
+    IOMemoryDescriptor* metadataDescriptor = nullptr;
+    IOMemoryDescriptor* controlDescriptor = nullptr;
+    ASSERT_EQ(service.AllocateTxIsochResources(
+                  /*streamIndex=*/1, AudioTimingGeometry::kTxSharedSlotPackets, 512,
+                  AudioTimingGeometry::kTxPacketsPerGroup, &payloadDescriptor, &metadataDescriptor,
+                  &controlDescriptor),
+              kIOReturnSuccess);
+
     ASSERT_EQ(service.PrepareTransmitStream(/*streamIndex=*/1, /*channel=*/4, hardware,
                                             /*sid=*/0x3f),
               kIOReturnSuccess);
@@ -144,6 +155,13 @@ TEST(IsochServiceTxPreparation, SecondaryTransmitStreamCreatesIndependentContext
     EXPECT_NE(service.TransmitContext(1), service.TransmitContext(0));
 
     service.StopAll();
+
+    if (payloadDescriptor)
+        payloadDescriptor->release();
+    if (metadataDescriptor)
+        metadataDescriptor->release();
+    if (controlDescriptor)
+        controlDescriptor->release();
 }
 
 } // namespace

--- a/tests/devices/DiceDuplexRestartCoordinatorTests.cpp
+++ b/tests/devices/DiceDuplexRestartCoordinatorTests.cpp
@@ -1,20 +1,20 @@
 #include <gtest/gtest.h>
 
-#include "Testing/HostDriverKitStubs.hpp"
-#include "Audio/DriverKit/Runtime/DirectAudioBindingSource.hpp"
 #include "Async/Interfaces/IFireWireBus.hpp"
-#include "Audio/Protocols/Backends/DiceDuplexRestartCoordinator.hpp"
 #include "Audio/Core/AudioRuntimeRegistry.hpp"
-#include "Discovery/DeviceRegistry.hpp"
-#include "Hardware/HardwareInterface.hpp"
-#include "Bus/IRM/IRMClient.hpp"
+#include "Audio/DriverKit/Runtime/DirectAudioBindingSource.hpp"
+#include "Audio/Protocols/Backends/DiceDuplexRestartCoordinator.hpp"
+#include "Audio/Protocols/DICE/Core/IDICEDuplexProtocol.hpp"
 #include "Audio/Protocols/DeviceProtocolFactory.hpp"
 #include "Audio/Protocols/IDeviceProtocol.hpp"
-#include "Audio/Protocols/DICE/Core/IDICEDuplexProtocol.hpp"
+#include "Bus/IRM/IRMClient.hpp"
+#include "Discovery/DeviceRegistry.hpp"
+#include "Hardware/HardwareInterface.hpp"
+#include "Testing/HostDriverKitStubs.hpp"
 
 #include <atomic>
-#include <condition_variable>
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <future>
 #include <memory>
@@ -33,7 +33,11 @@ using ASFW::Async::AsyncStatus;
 using ASFW::Async::FWAddress;
 using ASFW::Async::IFireWireBus;
 using ASFW::Audio::AudioDuplexChannels;
+using ASFW::Audio::AudioRuntimeRegistry;
 using ASFW::Audio::AudioStreamRuntimeCaps;
+using ASFW::Audio::DiceDuplexRestartCoordinator;
+using ASFW::Audio::IDeviceProtocol;
+using ASFW::Audio::IDiceHostTransport;
 using ASFW::Audio::DICE::DiceClockApplyResult;
 using ASFW::Audio::DICE::DiceClockRequestOutcome;
 using ASFW::Audio::DICE::DiceDesiredClockConfig;
@@ -45,13 +49,9 @@ using ASFW::Audio::DICE::DiceRestartErrorClass;
 using ASFW::Audio::DICE::DiceRestartFailureCause;
 using ASFW::Audio::DICE::DiceRestartPhase;
 using ASFW::Audio::DICE::DiceRestartReason;
-using ASFW::Audio::DICE::DiceRestartState;
 using ASFW::Audio::DICE::DiceRestartSession;
+using ASFW::Audio::DICE::DiceRestartState;
 using ASFW::Audio::DICE::IDICEDuplexProtocol;
-using ASFW::Audio::AudioRuntimeRegistry;
-using ASFW::Audio::DiceDuplexRestartCoordinator;
-using ASFW::Audio::IDeviceProtocol;
-using ASFW::Audio::IDiceHostTransport;
 using ASFW::Discovery::CfgKey;
 using ASFW::Discovery::ConfigROM;
 using ASFW::Discovery::DeviceRegistry;
@@ -102,38 +102,24 @@ struct SharedCallLog {
 };
 
 class NullFireWireBus final : public IFireWireBus {
-public:
-    AsyncHandle ReadBlock(Generation,
-                          NodeId,
-                          FWAddress,
-                          uint32_t,
-                          FwSpeed,
+  public:
+    AsyncHandle ReadBlock(Generation, NodeId, FWAddress, uint32_t, FwSpeed,
                           ASFW::Async::InterfaceCompletionCallback callback) override {
         callback(AsyncStatus::kSuccess, {});
         return AsyncHandle{.value = 1};
     }
 
-    AsyncHandle WriteBlock(Generation,
-                           NodeId,
-                           FWAddress,
-                           std::span<const uint8_t>,
-                           FwSpeed,
+    AsyncHandle WriteBlock(Generation, NodeId, FWAddress, std::span<const uint8_t>, FwSpeed,
                            ASFW::Async::InterfaceCompletionCallback callback) override {
         callback(AsyncStatus::kSuccess, {});
         return AsyncHandle{.value = 2};
     }
 
-    AsyncHandle Lock(Generation,
-                     NodeId,
-                     FWAddress,
-                     LockOp,
-                     std::span<const uint8_t>,
-                     uint32_t responseLength,
-                     FwSpeed,
+    AsyncHandle Lock(Generation, NodeId, FWAddress, LockOp, std::span<const uint8_t>,
+                     uint32_t responseLength, FwSpeed,
                      ASFW::Async::InterfaceCompletionCallback callback) override {
         std::array<uint8_t, 8> zeroes{};
-        callback(AsyncStatus::kSuccess,
-                 std::span<const uint8_t>(zeroes.data(), responseLength));
+        callback(AsyncStatus::kSuccess, std::span<const uint8_t>(zeroes.data(), responseLength));
         return AsyncHandle{.value = 3};
     }
 
@@ -146,8 +132,9 @@ public:
 };
 
 class FakeDirectAudioBindingSource final : public ASFW::Audio::Runtime::IDirectAudioBindingSource {
-public:
-    bool CopyDirectAudioBinding(ASFW::Audio::Runtime::DirectAudioBindingSnapshot& out) noexcept override {
+  public:
+    bool CopyDirectAudioBinding(
+        ASFW::Audio::Runtime::DirectAudioBindingSnapshot& out) noexcept override {
         out.generation = 1;
         out.valid = true;
         out.inputBase = reinterpret_cast<float*>(0x1234);
@@ -163,9 +150,8 @@ public:
 };
 
 class FakeDiceHostTransport final : public IDiceHostTransport {
-public:
-    explicit FakeDiceHostTransport(SharedCallLog& log) noexcept
-        : log_(log) {}
+  public:
+    explicit FakeDiceHostTransport(SharedCallLog& log) noexcept : log_(log) {}
 
     kern_return_t BeginSplitDuplex(uint64_t guid) noexcept override {
         log_.Add("host.begin");
@@ -174,9 +160,7 @@ public:
         return beginStatus;
     }
 
-    kern_return_t ReservePlaybackResources(uint64_t guid,
-                                           IRMClient&,
-                                           uint8_t channel,
+    kern_return_t ReservePlaybackResources(uint64_t guid, IRMClient&, uint8_t channel,
                                            uint32_t bandwidthUnits) noexcept override {
         log_.Add("host.reserve_playback");
         lastGuid = guid;
@@ -186,9 +170,7 @@ public:
         return reservePlaybackStatus;
     }
 
-    kern_return_t ReserveCaptureResources(uint64_t guid,
-                                          IRMClient&,
-                                          uint8_t channel,
+    kern_return_t ReserveCaptureResources(uint64_t guid, IRMClient&, uint8_t channel,
                                           uint32_t bandwidthUnits) noexcept override {
         log_.Add("host.reserve_capture");
         lastGuid = guid;
@@ -199,13 +181,10 @@ public:
     }
 
     kern_return_t PrepareReceive(
-        uint8_t channel,
-        HardwareInterface&,
+        uint8_t channel, HardwareInterface&,
         ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
-        ASFW::Encoding::AudioWireFormat wireFormat =
-            ASFW::Encoding::AudioWireFormat::kAM824,
-        uint32_t am824Slots = 0,
-        uint32_t streamChannels = 0) noexcept override {
+        ASFW::Encoding::AudioWireFormat wireFormat = ASFW::Encoding::AudioWireFormat::kAM824,
+        uint32_t am824Slots = 0, uint32_t streamChannels = 0) noexcept override {
         log_.Add("host.prepare_receive");
         lastReceiveChannel = channel;
         lastReceiveBindingSource = bindingSource;
@@ -216,8 +195,7 @@ public:
         return prepareReceiveStatus;
     }
 
-    kern_return_t PrepareTransmit(uint8_t channel,
-                                  HardwareInterface&,
+    kern_return_t PrepareTransmit(uint8_t channel, HardwareInterface&,
                                   uint8_t sourceId) noexcept override {
         log_.Add("host.prepare_transmit");
         lastTransmitChannel = channel;
@@ -227,30 +205,20 @@ public:
     }
 
     kern_return_t PrepareReceiveStream(
-        uint32_t streamIndex,
-        uint8_t channel,
-        HardwareInterface&,
-        ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource,
-        uint32_t channelOffset,
-        uint32_t streamChannels,
-        ASFW::Encoding::AudioWireFormat wireFormat =
-            ASFW::Encoding::AudioWireFormat::kAM824,
+        uint32_t streamIndex, uint8_t channel, HardwareInterface&, uint32_t channelOffset,
+        ASFW::Encoding::AudioWireFormat wireFormat = ASFW::Encoding::AudioWireFormat::kAM824,
         uint32_t am824Slots = 0) noexcept override {
         log_.Add("host.prepare_receive_stream");
         lastSecondaryReceiveIndex = streamIndex;
         lastSecondaryReceiveChannel = channel;
         lastSecondaryReceiveOffset = channelOffset;
-        lastSecondaryReceiveChannels = streamChannels;
-        lastSecondaryReceiveBindingSource = bindingSource;
         (void)wireFormat;
         (void)am824Slots;
         ++prepareReceiveStreamCalls;
         return prepareReceiveStatus;
     }
 
-    kern_return_t PrepareTransmitStream(uint32_t streamIndex,
-                                        uint8_t channel,
-                                        HardwareInterface&,
+    kern_return_t PrepareTransmitStream(uint32_t streamIndex, uint8_t channel, HardwareInterface&,
                                         uint8_t sourceId) noexcept override {
         log_.Add("host.prepare_transmit_stream");
         lastSecondaryTransmitIndex = streamIndex;
@@ -302,8 +270,7 @@ public:
     uint32_t lastTransmitMode{0};
     uint32_t lastTransmitPcmChannels{0};
     uint32_t lastTransmitDataBlockSize{0};
-    ASFW::Encoding::AudioWireFormat lastTransmitWireFormat{
-        ASFW::Encoding::AudioWireFormat::kAM824};
+    ASFW::Encoding::AudioWireFormat lastTransmitWireFormat{ASFW::Encoding::AudioWireFormat::kAM824};
     ASFW::Audio::Runtime::IDirectAudioBindingSource* lastTransmitBindingSource{nullptr};
 
     int beginCalls{0};
@@ -316,8 +283,6 @@ public:
     uint32_t lastSecondaryReceiveIndex{0};
     uint8_t lastSecondaryReceiveChannel{0};
     uint32_t lastSecondaryReceiveOffset{0};
-    uint32_t lastSecondaryReceiveChannels{0};
-    ASFW::Audio::Runtime::IDirectAudioBindingSource* lastSecondaryReceiveBindingSource{nullptr};
     uint32_t lastSecondaryTransmitIndex{0};
     uint8_t lastSecondaryTransmitChannel{0};
     uint8_t lastSecondaryTransmitSourceId{0};
@@ -325,15 +290,14 @@ public:
     int startTransmitCalls{0};
     int stopCalls{0};
 
-private:
+  private:
     SharedCallLog& log_;
 };
 
 class FakeDiceProtocol final : public IDeviceProtocol, public IDICEDuplexProtocol {
-public:
+  public:
     FakeDiceProtocol(SharedCallLog& log, IRMClient& irmClient) noexcept
-        : log_(log)
-        , irmClient_(irmClient) {}
+        : log_(log), irmClient_(irmClient) {}
 
     IOReturn Initialize() override { return kIOReturnSuccess; }
     IOReturn Shutdown() override { return kIOReturnSuccess; }
@@ -375,37 +339,34 @@ public:
             currentCaps_ = prepareCaps_;
         }
 
-        callback(prepareStatus,
-                 DiceDuplexPrepareResult{
-                     .generation = Generation{1},
-                     .channels = channels,
-                     .appliedClock = currentClock_,
-                     .runtimeCaps = currentCaps_,
-                 });
+        callback(prepareStatus, DiceDuplexPrepareResult{
+                                    .generation = Generation{1},
+                                    .channels = channels,
+                                    .appliedClock = currentClock_,
+                                    .runtimeCaps = currentCaps_,
+                                });
     }
 
     void ProgramRx(StageCallback callback) override {
         log_.Add("device.program_rx");
         ++programRxCalls;
-        callback(programRxStatus,
-                 DiceDuplexStageResult{
-                     .generation = Generation{1},
-                     .channels = lastChannels_,
-                     .phase = DiceRestartPhase::kDeviceRxProgrammed,
-                     .runtimeCaps = currentCaps_,
-                 });
+        callback(programRxStatus, DiceDuplexStageResult{
+                                      .generation = Generation{1},
+                                      .channels = lastChannels_,
+                                      .phase = DiceRestartPhase::kDeviceRxProgrammed,
+                                      .runtimeCaps = currentCaps_,
+                                  });
     }
 
     void ProgramTxAndEnableDuplex(StageCallback callback) override {
         log_.Add("device.program_tx");
         ++programTxCalls;
-        callback(programTxStatus,
-                 DiceDuplexStageResult{
-                     .generation = Generation{1},
-                     .channels = lastChannels_,
-                     .phase = DiceRestartPhase::kDeviceTxArmed,
-                     .runtimeCaps = currentCaps_,
-                 });
+        callback(programTxStatus, DiceDuplexStageResult{
+                                      .generation = Generation{1},
+                                      .channels = lastChannels_,
+                                      .phase = DiceRestartPhase::kDeviceTxArmed,
+                                      .runtimeCaps = currentCaps_,
+                                  });
     }
 
     void ConfirmDuplexStart(ConfirmCallback callback) override {
@@ -414,16 +375,15 @@ public:
         if (confirmStatus == kIOReturnSuccess) {
             currentCaps_ = confirmCaps_;
         }
-        callback(confirmStatus,
-                 DiceDuplexConfirmResult{
-                     .generation = Generation{1},
-                     .channels = lastChannels_,
-                     .appliedClock = currentClock_,
-                     .runtimeCaps = currentCaps_,
-                     .notification = 0x20,
-                     .status = 0x201,
-                     .extStatus = 0,
-                 });
+        callback(confirmStatus, DiceDuplexConfirmResult{
+                                    .generation = Generation{1},
+                                    .channels = lastChannels_,
+                                    .appliedClock = currentClock_,
+                                    .runtimeCaps = currentCaps_,
+                                    .notification = 0x20,
+                                    .status = 0x201,
+                                    .extStatus = 0,
+                                });
     }
 
     void ApplyClockConfig(const DiceDesiredClockConfig& desiredClock,
@@ -446,30 +406,28 @@ public:
             currentCaps_ = applyCaps_;
         }
 
-        callback(applyClockStatus,
-                 DiceClockApplyResult{
-                     .generation = Generation{1},
-                     .appliedClock = currentClock_,
-                     .runtimeCaps = currentCaps_,
-                 });
+        callback(applyClockStatus, DiceClockApplyResult{
+                                       .generation = Generation{1},
+                                       .appliedClock = currentClock_,
+                                       .runtimeCaps = currentCaps_,
+                                   });
     }
 
     void ReadDuplexHealth(HealthCallback callback) override {
         log_.Add("device.health");
         const size_t readIndex = static_cast<size_t>(healthReadCalls++);
-        const uint32_t statusValue = healthStatusSequence.empty()
-            ? healthStatusValue
-            : healthStatusSequence[
-                  std::min(readIndex, healthStatusSequence.size() - 1)];
-        callback(healthStatus,
-                 DiceDuplexHealthResult{
-                     .generation = healthGeneration,
-                     .appliedClock = currentClock_,
-                     .runtimeCaps = currentCaps_,
-                     .notification = healthNotification,
-                     .status = statusValue,
-                     .extStatus = healthExtStatusValue,
-                 });
+        const uint32_t statusValue =
+            healthStatusSequence.empty()
+                ? healthStatusValue
+                : healthStatusSequence[std::min(readIndex, healthStatusSequence.size() - 1)];
+        callback(healthStatus, DiceDuplexHealthResult{
+                                   .generation = healthGeneration,
+                                   .appliedClock = currentClock_,
+                                   .runtimeCaps = currentCaps_,
+                                   .notification = healthNotification,
+                                   .status = statusValue,
+                                   .extStatus = healthExtStatusValue,
+                               });
     }
 
     IOReturn StopDuplex() override {
@@ -504,11 +462,9 @@ public:
 
     bool WaitUntilPrepareBlocked(int expectedCalls) {
         std::unique_lock lock(mutex_);
-        return cv_.wait_for(lock,
-                            std::chrono::seconds(2),
-                            [this, expectedCalls] {
-                                return prepareCalls >= expectedCalls && prepareBlocked_;
-                            });
+        return cv_.wait_for(lock, std::chrono::seconds(2), [this, expectedCalls] {
+            return prepareCalls >= expectedCalls && prepareBlocked_;
+        });
     }
 
     DiceDesiredClockConfig currentClock_{kSupportedClock};
@@ -539,7 +495,7 @@ public:
     int healthReadCalls{0};
     int stopCalls{0};
 
-private:
+  private:
     SharedCallLog& log_;
     IRMClient& irmClient_;
     AudioDuplexChannels lastChannels_{};
@@ -555,10 +511,8 @@ private:
     PrepareCallback deferredPrepareCallback_{};
 };
 
-ConfigROM MakeConfigRom(uint64_t guid,
-                        uint32_t vendorId = kFocusriteVendorId,
-                        uint32_t modelId = kSPro24DspModelId,
-                        Generation gen = Generation{1}) {
+ConfigROM MakeConfigRom(uint64_t guid, uint32_t vendorId = kFocusriteVendorId,
+                        uint32_t modelId = kSPro24DspModelId, Generation gen = Generation{1}) {
     ConfigROM rom{};
     rom.gen = gen;
     rom.firstSeen = gen;
@@ -574,16 +528,11 @@ ConfigROM MakeConfigRom(uint64_t guid,
 }
 
 class DiceDuplexRestartCoordinatorTests : public ::testing::Test {
-protected:
+  protected:
     DiceDuplexRestartCoordinatorTests()
-        : irmClient_(bus_)
-        , hostTransport_(log_)
-        , protocol_(std::make_shared<FakeDiceProtocol>(log_, irmClient_))
-        , coordinator_(registry_,
-                       runtime_,
-                       hostTransport_,
-                       hardware_,
-                       &cancel_,
+        : irmClient_(bus_), hostTransport_(log_),
+          protocol_(std::make_shared<FakeDiceProtocol>(log_, irmClient_)),
+          coordinator_(registry_, runtime_, hostTransport_, hardware_, &cancel_,
                        [this](uint64_t) -> ASFW::Audio::Runtime::IDirectAudioBindingSource* {
                            return &bindingSource_;
                        }) {
@@ -596,12 +545,10 @@ protected:
         runtime_.Insert(kTestGuid, protocol);
     }
 
-    void InstallDeviceAtGeneration(Generation gen, const std::shared_ptr<IDeviceProtocol>& protocol) {
-        registry_.UpsertFromROM(MakeConfigRom(kTestGuid,
-                                              kFocusriteVendorId,
-                                              kSPro24DspModelId,
-                                              gen),
-                                LinkPolicy{});
+    void InstallDeviceAtGeneration(Generation gen,
+                                   const std::shared_ptr<IDeviceProtocol>& protocol) {
+        registry_.UpsertFromROM(
+            MakeConfigRom(kTestGuid, kFocusriteVendorId, kSPro24DspModelId, gen), LinkPolicy{});
         runtime_.Insert(kTestGuid, protocol);
         protocol_->healthGeneration = gen;
     }
@@ -610,9 +557,7 @@ protected:
         return coordinator_.GetSession(kTestGuid);
     }
 
-    [[nodiscard]] std::vector<std::string> LogSnapshot() const {
-        return log_.Snapshot();
-    }
+    [[nodiscard]] std::vector<std::string> LogSnapshot() const { return log_.Snapshot(); }
 
     void ClearLog() { log_.Clear(); }
 
@@ -658,7 +603,8 @@ TEST_F(DiceDuplexRestartCoordinatorTests, ColdStartTransitionsIdleToRunning) {
     EXPECT_TRUE(session->deviceRunning);
     EXPECT_TRUE(session->hostTransmitStarted);
     EXPECT_TRUE(session->hostReceiveStarted);
-    EXPECT_EQ(session->runtimeCaps.hostOutputPcmChannels, kDefaultRuntimeCaps.hostOutputPcmChannels);
+    EXPECT_EQ(session->runtimeCaps.hostOutputPcmChannels,
+              kDefaultRuntimeCaps.hostOutputPcmChannels);
     EXPECT_EQ(hostTransport_.reservePlaybackCalls, 1);
     EXPECT_EQ(hostTransport_.reserveCaptureCalls, 1);
     EXPECT_EQ(hostTransport_.prepareReceiveCalls, 1);
@@ -671,32 +617,29 @@ TEST_F(DiceDuplexRestartCoordinatorTests, ColdStartTransitionsIdleToRunning) {
     EXPECT_EQ(protocol_->healthReadCalls, 3);
     EXPECT_EQ(protocol_->confirmCalls, 1);
 
-    EXPECT_EQ(
-        LogSnapshot(),
-        (std::vector<std::string>{
-            "host.begin",
-            "device.prepare",
-            "host.reserve_playback",
-            "host.reserve_capture",
-            "host.prepare_receive",
-            "host.prepare_transmit",
-            "device.health",
-            "device.health",
-            "device.health",
-            "device.program_rx",
-            "device.program_tx",
-            "host.start_receive",
-            "host.start_transmit",
-            "device.confirm",
-        }));
+    EXPECT_EQ(LogSnapshot(), (std::vector<std::string>{
+                                 "host.begin",
+                                 "device.prepare",
+                                 "host.reserve_playback",
+                                 "host.reserve_capture",
+                                 "host.prepare_receive",
+                                 "host.prepare_transmit",
+                                 "device.health",
+                                 "device.health",
+                                 "device.health",
+                                 "device.program_rx",
+                                 "device.program_tx",
+                                 "host.start_receive",
+                                 "host.start_transmit",
+                                 "device.confirm",
+                             }));
 }
 
 TEST_F(DiceDuplexRestartCoordinatorTests, TeardownCancelAbortsInFlightPrepare) {
     protocol_->SetDeferPrepareCallback(true);
 
-    auto start = std::async(std::launch::async, [this] {
-        return coordinator_.StartStreaming(kTestGuid);
-    });
+    auto start =
+        std::async(std::launch::async, [this] { return coordinator_.StartStreaming(kTestGuid); });
 
     ASSERT_TRUE(protocol_->WaitUntilPrepareBlocked(1));
     cancel_.store(true, std::memory_order_release);
@@ -713,11 +656,7 @@ TEST_F(DiceDuplexRestartCoordinatorTests, TeardownCancelAbortsInFlightPrepare) {
 TEST_F(DiceDuplexRestartCoordinatorTests,
        GlobalClockRequiresConsecutiveStableReadsBeforeHostIsochStarts) {
     protocol_->healthStatusSequence = {
-        0x201,
-        0x200,
-        0x201,
-        0x201,
-        0x201,
+        0x201, 0x200, 0x201, 0x201, 0x201,
     };
 
     ASSERT_EQ(coordinator_.StartStreaming(kTestGuid), kIOReturnSuccess);
@@ -727,8 +666,7 @@ TEST_F(DiceDuplexRestartCoordinatorTests,
     EXPECT_EQ(hostTransport_.startTransmitCalls, 1);
 }
 
-TEST_F(DiceDuplexRestartCoordinatorTests,
-       GlobalClockHealthFailureRollsBackBeforeHostIsochStarts) {
+TEST_F(DiceDuplexRestartCoordinatorTests, GlobalClockHealthFailureRollsBackBeforeHostIsochStarts) {
     protocol_->healthStatus = kIOReturnNoDevice;
 
     EXPECT_EQ(coordinator_.StartStreaming(kTestGuid), kIOReturnNoDevice);
@@ -737,10 +675,8 @@ TEST_F(DiceDuplexRestartCoordinatorTests,
     ASSERT_TRUE(session.has_value());
     EXPECT_EQ(session->phase, DiceRestartPhase::kFailed);
     ASSERT_TRUE(session->lastFailure.has_value());
-    EXPECT_EQ(session->lastFailure->failedPhase,
-              DiceRestartPhase::kWaitingGlobalClock);
-    EXPECT_EQ(session->lastFailure->cause,
-              DiceRestartFailureCause::kGlobalClockLock);
+    EXPECT_EQ(session->lastFailure->failedPhase, DiceRestartPhase::kWaitingGlobalClock);
+    EXPECT_EQ(session->lastFailure->cause, DiceRestartFailureCause::kGlobalClockLock);
     EXPECT_EQ(hostTransport_.startReceiveCalls, 0);
     EXPECT_EQ(hostTransport_.startTransmitCalls, 0);
     EXPECT_EQ(hostTransport_.stopCalls, 1);
@@ -774,8 +710,7 @@ TEST_F(DiceDuplexRestartCoordinatorTests, IdleClockApplyUsesDeviceOnlyPathAndRet
         .sampleRateHz = 48000,
     };
 
-    ASSERT_EQ(coordinator_.RequestClockConfig(kTestGuid,
-                                              kSupportedClock,
+    ASSERT_EQ(coordinator_.RequestClockConfig(kTestGuid, kSupportedClock,
                                               DiceRestartReason::kManualReconfigure),
               kIOReturnSuccess);
 
@@ -797,8 +732,7 @@ TEST_F(DiceDuplexRestartCoordinatorTests, RunningClockRequestPerformsFullStopAnd
     ClearLog();
     const int prepareBefore = protocol_->prepareCalls;
 
-    ASSERT_EQ(coordinator_.RequestClockConfig(kTestGuid,
-                                              kSupportedClock,
+    ASSERT_EQ(coordinator_.RequestClockConfig(kTestGuid, kSupportedClock,
                                               DiceRestartReason::kManualReconfigure),
               kIOReturnSuccess);
 
@@ -967,8 +901,8 @@ TEST_F(DiceDuplexRestartCoordinatorTests, LatestPendingClockRequestWinsDuringRes
     ASSERT_TRUE(WaitForPendingClockReason(DiceRestartReason::kRecoverAfterTimingLoss));
 
     std::thread thirdThread([&] {
-        thirdPromise.set_value(coordinator_.RequestClockConfig(
-            kTestGuid, kSupportedClock, DiceRestartReason::kBusResetRebind));
+        thirdPromise.set_value(coordinator_.RequestClockConfig(kTestGuid, kSupportedClock,
+                                                               DiceRestartReason::kBusResetRebind));
     });
 
     // The third request must supersede the second before prepare is released so the drain
@@ -1020,9 +954,7 @@ TEST_F(DiceDuplexRestartCoordinatorTests, StopStreamingAbortsClockRequestsDuring
 
     std::promise<IOReturn> stopPromise;
     std::future<IOReturn> stopFuture = stopPromise.get_future();
-    std::thread stopThread([&] {
-        stopPromise.set_value(coordinator_.StopStreaming(kTestGuid));
-    });
+    std::thread stopThread([&] { stopPromise.set_value(coordinator_.StopStreaming(kTestGuid)); });
 
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     protocol_->SetHoldPrepare(false);
@@ -1051,9 +983,8 @@ TEST_F(DiceDuplexRestartCoordinatorTests, GenerationChangeDuringPrepareInvalidat
 
     std::promise<IOReturn> startPromise;
     std::future<IOReturn> startFuture = startPromise.get_future();
-    std::thread startThread([&] {
-        startPromise.set_value(coordinator_.StartStreaming(kTestGuid));
-    });
+    std::thread startThread(
+        [&] { startPromise.set_value(coordinator_.StartStreaming(kTestGuid)); });
 
     ASSERT_TRUE(protocol_->WaitUntilPrepareBlocked(1));
     InstallDeviceAtGeneration(Generation{2}, protocol_);
@@ -1091,21 +1022,20 @@ TEST_F(DiceDuplexRestartCoordinatorTests, ProgramRxFailureRollsBackHostAndDevice
     EXPECT_TRUE(session->lastFailure->rollbackAttempted);
     EXPECT_FALSE(session->hostReceiveStarted);
     EXPECT_FALSE(session->deviceRunning);
-    EXPECT_EQ(LogSnapshot(),
-              (std::vector<std::string>{
-                  "host.begin",
-                  "device.prepare",
-                  "host.reserve_playback",
-                  "host.reserve_capture",
-                  "host.prepare_receive",
-                  "host.prepare_transmit",
-                  "device.health",
-                  "device.health",
-                  "device.health",
-                  "device.program_rx",
-                  "host.stop",
-                  "device.stop",
-              }));
+    EXPECT_EQ(LogSnapshot(), (std::vector<std::string>{
+                                 "host.begin",
+                                 "device.prepare",
+                                 "host.reserve_playback",
+                                 "host.reserve_capture",
+                                 "host.prepare_receive",
+                                 "host.prepare_transmit",
+                                 "device.health",
+                                 "device.health",
+                                 "device.health",
+                                 "device.program_rx",
+                                 "host.stop",
+                                 "device.stop",
+                             }));
 }
 
 TEST_F(DiceDuplexRestartCoordinatorTests, UnsupportedClockConfigFailsBeforeHostAllocation) {
@@ -1114,8 +1044,7 @@ TEST_F(DiceDuplexRestartCoordinatorTests, UnsupportedClockConfigFailsBeforeHostA
         .clockSelect = kSupportedClock.clockSelect,
     };
 
-    EXPECT_EQ(coordinator_.RequestClockConfig(kTestGuid,
-                                              unsupportedClock,
+    EXPECT_EQ(coordinator_.RequestClockConfig(kTestGuid, unsupportedClock,
                                               DiceRestartReason::kSampleRateChange),
               kIOReturnUnsupported);
     EXPECT_EQ(hostTransport_.beginCalls, 0);
@@ -1124,7 +1053,8 @@ TEST_F(DiceDuplexRestartCoordinatorTests, UnsupportedClockConfigFailsBeforeHostA
     EXPECT_FALSE(GetSession().has_value());
 }
 
-TEST_F(DiceDuplexRestartCoordinatorTests, RecoveryTriggerIsIgnoredWhenSessionIsIdleWithoutFootprint) {
+TEST_F(DiceDuplexRestartCoordinatorTests,
+       RecoveryTriggerIsIgnoredWhenSessionIsIdleWithoutFootprint) {
     ASSERT_EQ(coordinator_.RecoverStreaming(kTestGuid, DiceRestartReason::kRecoverAfterTimingLoss),
               kIOReturnSuccess);
 

--- a/tests/devices/DiceDuplexRestartCoordinatorTests.cpp
+++ b/tests/devices/DiceDuplexRestartCoordinatorTests.cpp
@@ -205,13 +205,17 @@ class FakeDiceHostTransport final : public IDiceHostTransport {
     }
 
     kern_return_t PrepareReceiveStream(
-        uint32_t streamIndex, uint8_t channel, HardwareInterface&, uint32_t channelOffset,
+        uint32_t streamIndex, uint8_t channel, HardwareInterface&,
+        ASFW::Audio::Runtime::IDirectAudioBindingSource* bindingSource, uint32_t channelOffset,
+        uint32_t streamChannels,
         ASFW::Encoding::AudioWireFormat wireFormat = ASFW::Encoding::AudioWireFormat::kAM824,
         uint32_t am824Slots = 0) noexcept override {
         log_.Add("host.prepare_receive_stream");
         lastSecondaryReceiveIndex = streamIndex;
         lastSecondaryReceiveChannel = channel;
         lastSecondaryReceiveOffset = channelOffset;
+        lastSecondaryReceiveChannels = streamChannels;
+        lastSecondaryReceiveBindingSource = bindingSource;
         (void)wireFormat;
         (void)am824Slots;
         ++prepareReceiveStreamCalls;
@@ -283,6 +287,8 @@ class FakeDiceHostTransport final : public IDiceHostTransport {
     uint32_t lastSecondaryReceiveIndex{0};
     uint8_t lastSecondaryReceiveChannel{0};
     uint32_t lastSecondaryReceiveOffset{0};
+    uint32_t lastSecondaryReceiveChannels{0};
+    ASFW::Audio::Runtime::IDirectAudioBindingSource* lastSecondaryReceiveBindingSource{nullptr};
     uint32_t lastSecondaryTransmitIndex{0};
     uint8_t lastSecondaryTransmitChannel{0};
     uint8_t lastSecondaryTransmitSourceId{0};


### PR DESCRIPTION
This includes bug fixes to make sure all 32 channels work on Midas Venice F32.
Basically implements multiple stream feature on DICE devices. The ROM advertises amount of streams and channels. We're reading that and establishing dual ISOCH streams both RX and TX - 1-16 - 1st stream, 17-32 - 2nd stream. 

Tested and working on hardware.