### PR TITLE
FW-69b: extract RestartSessionStore (session store + restart-id allocator)

### DIFF
--- a/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
@@ -318,11 +318,11 @@ IOReturn DiceDuplexRestartCoordinator::RequestClockConfig(
             supersededRequest = existingIt->second;
         }
         pendingClockRequests_[guid] = request;
-        const auto sessionIt = sessions_.find(guid);
-        if (sessionIt != sessions_.end()) {
-            sessionIt->second.pendingClock = request.desiredClock;
-            sessionIt->second.pendingReason = request.reason;
-            sessionIt->second.hasPendingClockRequest = true;
+        auto* sessionPtr = store_.FindSessionLocked(guid);
+        if (sessionPtr != nullptr) {
+            sessionPtr->pendingClock = request.desiredClock;
+            sessionPtr->pendingReason = request.reason;
+            sessionPtr->hasPendingClockRequest = true;
         }
     } else {
         gate_.AcquireLocked(guid);
@@ -428,7 +428,7 @@ void DiceDuplexRestartCoordinator::ClearSession(uint64_t guid) noexcept {
     }
 
     IOLockLock(lock_);
-    sessions_.erase(guid);
+    store_.EraseSessionLocked(guid);
     pendingClockRequests_.erase(guid);
     completedClockRequests_.erase(guid);
     gate_.ReleaseLocked(guid);
@@ -437,17 +437,7 @@ void DiceDuplexRestartCoordinator::ClearSession(uint64_t guid) noexcept {
 }
 
 std::optional<DiceRestartSession> DiceDuplexRestartCoordinator::GetSession(uint64_t guid) const noexcept {
-    if (!lock_ || guid == 0) {
-        return std::nullopt;
-    }
-
-    IOLockLock(lock_);
-    const auto it = sessions_.find(guid);
-    const auto session = (it != sessions_.end())
-        ? std::optional<DiceRestartSession>(it->second)
-        : std::nullopt;
-    IOLockUnlock(lock_);
-    return session;
+    return store_.GetSession(guid);
 }
 
 IOReturn DiceDuplexRestartCoordinator::RunStartStreaming(uint64_t guid) noexcept {
@@ -1618,14 +1608,7 @@ bool DiceDuplexRestartCoordinator::IsStopRequested(uint64_t guid) const noexcept
 }
 
 uint64_t DiceDuplexRestartCoordinator::AllocateRestartId() noexcept {
-    if (!lock_) {
-        return 0;
-    }
-
-    IOLockLock(lock_);
-    const uint64_t restartId = nextRestartId_++;
-    IOLockUnlock(lock_);
-    return restartId;
+    return store_.AllocateRestartId();
 }
 
 bool DiceDuplexRestartCoordinator::IsRestartEpochCurrent(uint64_t guid,
@@ -1643,10 +1626,10 @@ bool DiceDuplexRestartCoordinator::IsRestartEpochCurrent(uint64_t guid,
     }
 
     IOLockLock(lock_);
-    const auto sessionIt = sessions_.find(guid);
-    const bool sessionMatches = (sessionIt != sessions_.end()) &&
-        sessionIt->second.restartId == restartId &&
-        sessionIt->second.topologyGeneration == topologyGeneration;
+    const auto* sessionPtr = store_.FindSessionLocked(guid);
+    const bool sessionMatches = (sessionPtr != nullptr) &&
+        sessionPtr->restartId == restartId &&
+        sessionPtr->topologyGeneration == topologyGeneration;
     IOLockUnlock(lock_);
     if (!sessionMatches) {
         return false;
@@ -1675,11 +1658,11 @@ bool DiceDuplexRestartCoordinator::TryConsumePendingClockRequest(uint64_t guid,
 
     outRequest = it->second;
     pendingClockRequests_.erase(it);
-    const auto sessionIt = sessions_.find(guid);
-    if (sessionIt != sessions_.end()) {
-        sessionIt->second.pendingClock = {};
-        sessionIt->second.pendingReason = DiceRestartReason::kInitialStart;
-        sessionIt->second.hasPendingClockRequest = false;
+    auto* sessionPtr = store_.FindSessionLocked(guid);
+    if (sessionPtr != nullptr) {
+        sessionPtr->pendingClock = {};
+        sessionPtr->pendingReason = DiceRestartReason::kInitialStart;
+        sessionPtr->hasPendingClockRequest = false;
     }
     IOLockUnlock(lock_);
     return true;
@@ -1735,9 +1718,9 @@ void DiceDuplexRestartCoordinator::CompleteClockRequest(const DiceClockRequestCo
         store.byToken.erase(evictedToken);
     }
 
-    auto sessionIt = sessions_.find(guid);
-    if (sessionIt != sessions_.end()) {
-        sessionIt->second.lastClockCompletion = completion;
+    auto* sessionPtr = store_.FindSessionLocked(guid);
+    if (sessionPtr != nullptr) {
+        sessionPtr->lastClockCompletion = completion;
     }
     IOLockUnlock(lock_);
 
@@ -1781,28 +1764,15 @@ void DiceDuplexRestartCoordinator::RecordTeardownAbort(const char* stage,
              kIOReturnAborted);
 }
 
+// FW-69b: session persistence + the restart-id allocator now live in RestartSessionStore
+// (store_). These entry points are thin forwarders to its self-locking API; behaviour is
+// byte-for-byte the former inline bodies (store_ borrows the same lock_).
 DiceRestartSession DiceDuplexRestartCoordinator::LoadSession(uint64_t guid) const noexcept {
-    if (!lock_ || guid == 0) {
-        return DiceRestartSession{.guid = guid};
-    }
-
-    IOLockLock(lock_);
-    const auto it = sessions_.find(guid);
-    DiceRestartSession session = (it != sessions_.end())
-        ? it->second
-        : DiceRestartSession{.guid = guid};
-    IOLockUnlock(lock_);
-    return session;
+    return store_.LoadSession(guid);
 }
 
 void DiceDuplexRestartCoordinator::StoreSession(const DiceRestartSession& session) noexcept {
-    if (!lock_ || session.guid == 0) {
-        return;
-    }
-
-    IOLockLock(lock_);
-    sessions_[session.guid] = session;
-    IOLockUnlock(lock_);
+    store_.StoreSession(session);
 }
 
 } // namespace ASFW::Audio

--- a/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.hpp
@@ -7,6 +7,7 @@
 
 #include "DiceHostTransport.hpp"
 #include "DuplexOperationGate.hpp"
+#include "RestartSessionStore.hpp"
 
 #include "../../../Discovery/DeviceRegistry.hpp"
 #include "../../../Hardware/HardwareInterface.hpp"
@@ -151,11 +152,12 @@ private:
     // FW-68: per-GUID active-session + stop-intent gating. Borrows &lock_ (see
     // DuplexOperationGate) so its critical sections share the coordinator's single lock.
     Backends::DuplexOperationGate gate_{&lock_};
-    std::unordered_map<uint64_t, DICE::DiceRestartSession> sessions_{};
+    // FW-69b: per-GUID session persistence + restart-id allocator. Borrows &lock_ (see
+    // RestartSessionStore) so its critical sections share the coordinator's single lock.
+    Backends::RestartSessionStore store_{&lock_};
     std::unordered_map<uint64_t, PendingClockRequest> pendingClockRequests_{};
     std::unordered_map<uint64_t, ClockCompletionStore> completedClockRequests_{};
     uint64_t nextClockToken_{1};
-    uint64_t nextRestartId_{1};
     std::atomic<uint64_t> teardownAbortCount_{0};
 
     static constexpr uint32_t kSyncBridgeTimeoutMs = 12000;

--- a/ASFWDriver/Audio/Protocols/Backends/RestartSessionStore.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/RestartSessionStore.hpp
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2026 ASFireWire Project
+//
+// RestartSessionStore.hpp
+//
+// FW-69b (Step 5 of FW-64, store half): the per-GUID restart-session persistence + restart-id
+// allocator extracted from DiceDuplexRestartCoordinator. Owns the sessions_ map and
+// nextRestartId_.
+//
+// Behaviour-preserving extraction, same shape as the FW-68 DuplexOperationGate: the store
+// BORROWS the coordinator's existing IOLock* (via a pointer to it) rather than owning one,
+// because sessions_ is read/mutated inside multi-domain single-lock critical sections that also
+// touch the clock-request maps and the operation gate (RequestClockConfig, ClearSession,
+// TryConsumePendingClockRequest, CompleteClockRequest). Owning a separate lock would split those
+// atomic sections. So the store exposes two tiers:
+//   * self-locking methods (LoadSession/StoreSession/GetSession/AllocateRestartId) that reproduce
+//     the former coordinator members byte-for-byte, for callers that do not already hold the lock;
+//   * *Locked accessors (FindSessionLocked/EraseSessionLocked) that assume the caller already
+//     holds the lock, for the multi-domain sections that must stay one uninterrupted hold.
+//
+// Names keep their Dice* prefix for now (neutral rename is FW-73). The FSM journal is the
+// separate FW-69a component (RestartJournal.hpp).
+
+#pragma once
+
+#include "../DICE/Core/DICERestartSession.hpp"
+
+#include <DriverKit/IOLib.h>
+
+#include <cstdint>
+#include <optional>
+#include <unordered_map>
+
+namespace ASFW::Audio::Backends {
+
+using ASFW::Audio::DICE::DiceRestartSession;
+
+class RestartSessionStore {
+public:
+    // `lock` points at the coordinator's IOLock* member (allocated in its constructor body after
+    // this store is constructed, then stable for its lifetime); the store reads it fresh each call.
+    explicit RestartSessionStore(IOLock** lock) noexcept : lockRef_(lock) {}
+
+    // --- self-locking API: byte-for-byte reproductions of the former coordinator members
+    //     LoadSession / StoreSession / GetSession / AllocateRestartId.
+
+    [[nodiscard]] DiceRestartSession LoadSession(uint64_t guid) const noexcept {
+        IOLock* const lock = *lockRef_;
+        if (!lock || guid == 0) {
+            return DiceRestartSession{.guid = guid};
+        }
+        IOLockLock(lock);
+        const auto it = sessions_.find(guid);
+        DiceRestartSession session = (it != sessions_.end())
+            ? it->second
+            : DiceRestartSession{.guid = guid};
+        IOLockUnlock(lock);
+        return session;
+    }
+
+    void StoreSession(const DiceRestartSession& session) noexcept {
+        IOLock* const lock = *lockRef_;
+        if (!lock || session.guid == 0) {
+            return;
+        }
+        IOLockLock(lock);
+        sessions_[session.guid] = session;
+        IOLockUnlock(lock);
+    }
+
+    [[nodiscard]] std::optional<DiceRestartSession> GetSession(uint64_t guid) const noexcept {
+        IOLock* const lock = *lockRef_;
+        if (!lock || guid == 0) {
+            return std::nullopt;
+        }
+        IOLockLock(lock);
+        const auto it = sessions_.find(guid);
+        const auto session = (it != sessions_.end())
+            ? std::optional<DiceRestartSession>(it->second)
+            : std::nullopt;
+        IOLockUnlock(lock);
+        return session;
+    }
+
+    [[nodiscard]] uint64_t AllocateRestartId() noexcept {
+        IOLock* const lock = *lockRef_;
+        if (!lock) {
+            return 0;
+        }
+        IOLockLock(lock);
+        const uint64_t restartId = nextRestartId_++;
+        IOLockUnlock(lock);
+        return restartId;
+    }
+
+    // --- lock-held accessors: the caller already holds *lockRef_. Do only the map op, so the
+    //     coordinator's multi-domain critical sections stay one uninterrupted hold. These match
+    //     the former inline `sessions_.find(guid)` / `sessions_.erase(guid)` uses exactly.
+
+    [[nodiscard]] DiceRestartSession* FindSessionLocked(uint64_t guid) noexcept {
+        const auto it = sessions_.find(guid);
+        return it != sessions_.end() ? &it->second : nullptr;
+    }
+
+    [[nodiscard]] const DiceRestartSession* FindSessionLocked(uint64_t guid) const noexcept {
+        const auto it = sessions_.find(guid);
+        return it != sessions_.end() ? &it->second : nullptr;
+    }
+
+    void EraseSessionLocked(uint64_t guid) noexcept {
+        sessions_.erase(guid);
+    }
+
+private:
+    IOLock** lockRef_;  // borrowed: &coordinator.lock_ (not owned; never allocated/freed here)
+    std::unordered_map<uint64_t, DiceRestartSession> sessions_{};
+    uint64_t nextRestartId_{1};
+};
+
+} // namespace ASFW::Audio::Backends

--- a/tests/devices/CMakeLists.txt
+++ b/tests/devices/CMakeLists.txt
@@ -75,6 +75,11 @@ add_device_test(RestartJournalTests
     RestartJournalTests.cpp
 )
 
+# DICE restart-session store tests (FW-69b, header-only lock-borrowing store)
+add_device_test(RestartSessionStoreTests
+    RestartSessionStoreTests.cpp
+)
+
 # Apogee protocol boolean control mapping tests
 add_device_test(ApogeeBooleanControlMappingTests
     ApogeeBooleanControlMappingTests.cpp

--- a/tests/devices/RestartSessionStoreTests.cpp
+++ b/tests/devices/RestartSessionStoreTests.cpp
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2026 ASFireWire Project
+//
+// FW-69b characterization tests for RestartSessionStore — the per-GUID session store + restart-id
+// allocator extracted from DiceDuplexRestartCoordinator. Pins the observable contract of the
+// former coordinator members (LoadSession/StoreSession/GetSession/AllocateRestartId) and the
+// lock-held accessors (FindSessionLocked/EraseSessionLocked) used inside the coordinator's
+// multi-domain critical sections. Host tests, no hardware.
+
+#include <gtest/gtest.h>
+
+#include <DriverKit/IOLib.h>
+
+#include "Audio/Protocols/Backends/RestartSessionStore.hpp"
+
+namespace {
+
+using namespace ASFW::Audio::Backends;
+
+class RestartSessionStoreTest : public ::testing::Test {
+protected:
+    void SetUp() override { ASSERT_NE(lock_, nullptr); }
+    void TearDown() override {
+        if (lock_) {
+            IOLockFree(lock_);
+        }
+    }
+
+    IOLock* lock_ = IOLockAlloc();
+    RestartSessionStore store_{&lock_};
+};
+
+// LoadSession returns a default session stamped with the guid on a miss (former member behaviour).
+TEST_F(RestartSessionStoreTest, LoadMissReturnsDefaultWithGuid) {
+    const auto s = store_.LoadSession(0x11);
+    EXPECT_EQ(s.guid, 0x11u);
+    EXPECT_EQ(s.restartId, 0u);
+}
+
+TEST_F(RestartSessionStoreTest, StoreThenLoadAndGetRoundTrip) {
+    DiceRestartSession s{};
+    s.guid = 0x22;
+    s.restartId = 9;
+    store_.StoreSession(s);
+
+    const auto loaded = store_.LoadSession(0x22);
+    EXPECT_EQ(loaded.guid, 0x22u);
+    EXPECT_EQ(loaded.restartId, 9u);
+
+    const auto got = store_.GetSession(0x22);
+    ASSERT_TRUE(got.has_value());
+    EXPECT_EQ(got->restartId, 9u);
+}
+
+TEST_F(RestartSessionStoreTest, GetMissIsNullopt) {
+    EXPECT_FALSE(store_.GetSession(0x33).has_value());
+}
+
+// guid==0 guards on Load/Store/Get match the former members (Load returns default, Store no-ops).
+TEST_F(RestartSessionStoreTest, ZeroGuidGuardsMatchOriginals) {
+    DiceRestartSession s{};  // guid == 0
+    s.restartId = 7;
+    store_.StoreSession(s);                       // guarded no-op
+    EXPECT_FALSE(store_.GetSession(0).has_value());
+    EXPECT_EQ(store_.LoadSession(0).guid, 0u);    // default{.guid=0}
+}
+
+TEST_F(RestartSessionStoreTest, AllocateRestartIdMonotonicFromOne) {
+    EXPECT_EQ(store_.AllocateRestartId(), 1u);
+    EXPECT_EQ(store_.AllocateRestartId(), 2u);
+    EXPECT_EQ(store_.AllocateRestartId(), 3u);
+}
+
+// The store borrows &lock_ and reads it fresh each call: a null lock short-circuits every
+// self-locking method exactly as the former members did, and it starts working once allocated.
+TEST(RestartSessionStoreNullLock, NoLockShortCircuitsSelfLockingApi) {
+    IOLock* lock = nullptr;
+    RestartSessionStore store{&lock};
+    EXPECT_EQ(store.LoadSession(0x11).guid, 0x11u);  // default (no lock)
+    EXPECT_EQ(store.AllocateRestartId(), 0u);        // 0 on no lock
+    EXPECT_FALSE(store.GetSession(0x11).has_value());
+    DiceRestartSession s{};
+    s.guid = 0x11;
+    s.restartId = 5;
+    store.StoreSession(s);                           // no-op, must not deref null lock
+    EXPECT_FALSE(store.GetSession(0x11).has_value());
+
+    lock = IOLockAlloc();
+    ASSERT_NE(lock, nullptr);
+    store.StoreSession(s);
+    EXPECT_EQ(store.LoadSession(0x11).restartId, 5u);
+    IOLockFree(lock);
+}
+
+// FindSessionLocked returns a mutable pointer to the in-map session; mutations persist and are
+// visible via the self-locking reads (same underlying map) — this is what the coordinator's
+// multi-domain holds rely on.
+TEST_F(RestartSessionStoreTest, FindSessionLockedMutatesInPlace) {
+    DiceRestartSession s{};
+    s.guid = 0x44;
+    store_.StoreSession(s);
+
+    auto* p = store_.FindSessionLocked(0x44);
+    ASSERT_NE(p, nullptr);
+    p->restartId = 12;
+    p->hasPendingClockRequest = true;
+
+    const auto got = store_.GetSession(0x44);
+    ASSERT_TRUE(got.has_value());
+    EXPECT_EQ(got->restartId, 12u);
+    EXPECT_TRUE(got->hasPendingClockRequest);
+}
+
+TEST_F(RestartSessionStoreTest, FindMissIsNullptrAndEraseRemoves) {
+    EXPECT_EQ(store_.FindSessionLocked(0x55), nullptr);
+    DiceRestartSession s{};
+    s.guid = 0x55;
+    store_.StoreSession(s);
+    EXPECT_NE(store_.FindSessionLocked(0x55), nullptr);
+    store_.EraseSessionLocked(0x55);
+    EXPECT_EQ(store_.FindSessionLocked(0x55), nullptr);
+    EXPECT_FALSE(store_.GetSession(0x55).has_value());
+}
+
+// The const FindSessionLocked overload is callable on a const store (used by the const
+// IsRestartEpochCurrent path).
+TEST_F(RestartSessionStoreTest, ConstFindSessionLockedReads) {
+    DiceRestartSession s{};
+    s.guid = 0x66;
+    s.restartId = 3;
+    store_.StoreSession(s);
+
+    const RestartSessionStore& c = store_;
+    const auto* p = c.FindSessionLocked(0x66);
+    ASSERT_NE(p, nullptr);
+    EXPECT_EQ(p->restartId, 3u);
+    EXPECT_EQ(c.FindSessionLocked(0x77), nullptr);
+}
+
+}  // namespace


### PR DESCRIPTION
# FW-69b: extract RestartSessionStore (session store + restart-id allocator)

Step 5 of FW-64, **store half** — completes FW-69 (FW-69a was the journal). Behaviour-preserving,
no atomicity/ordering change.

## What

Lifts the per-GUID session persistence (`sessions_` map) and the restart-id allocator
(`nextRestartId_`) out of the coordinator into `Audio/Protocols/Backends/RestartSessionStore.hpp`
(class `RestartSessionStore`, namespace `ASFW::Audio::Backends`). The four former members
`LoadSession` / `StoreSession` / `GetSession` / `AllocateRestartId` become thin forwarders.

## Lock-borrowing — same pattern as the merged FW-68 gate

`sessions_` is read/mutated inside **four multi-domain single-lock critical sections** that also
touch the clock-request maps and the operation gate: `RequestClockConfig`, `ClearSession`,
`TryConsumePendingClockRequest`, `CompleteClockRequest` (plus `IsRestartEpochCurrent`'s own hold).
A store owning its own lock would split those atomic sections. So — exactly as `DuplexOperationGate`
does — the store **borrows** the coordinator's `lock_` (via `IOLock** = &lock_`, never owns one)
and exposes two tiers:

- **self-locking** `LoadSession`/`StoreSession`/`GetSession`/`AllocateRestartId` — reproduce the
  former members for standalone callers;
- **lock-held** `FindSessionLocked` (const + non-const, returns `DiceRestartSession*`/`nullptr`) and
  `EraseSessionLocked` — called by the multi-domain holds *while already holding `lock_`*, so each
  keeps one uninterrupted `IOLockLock`/`IOLockUnlock` span.

`IsRestartEpochCurrent`/`ClearSession`/`RequestClockConfig`/`TryConsume`/`CompleteClockRequest` keep
their exact lock structure and swap the inline `sessions_.find`/`sessions_.erase` for the `*Locked`
accessors. The `FindSessionLocked` pointer is used only within its lock hold and `sessions_` is not
mutated under it, so it's exactly equivalent to the former `sessionIt->second` iterator use.

## Atomicity — verified at the diff level

Host tests stub `IOLock` to a no-op, so in-hold atomicity can't be *functionally* tested — but it's
verifiable by inspection, and the diff makes it mechanical:

- **0 `IOLock` lines added, 8 removed** — exactly the 4 forwarder'd store methods' lock+unlock. The
  five in-hold conversions touch **zero** lock lines. Every critical section keeps its span; the
  `*Locked` accessors contain no locking (no double-lock), and no self-locking method is ever called
  while `lock_` is held (no deadlock).

`RestartSessionStore` is a class with in-class (implicitly inline) members, so no ODR hazard.

## Tests

New `RestartSessionStoreTests` — 9 tests: load-miss → `default{.guid}`; store/load/get round-trip;
get-miss → nullopt; `guid==0` guards; `AllocateRestartId` monotonic from 1; null-lock short-circuit +
fresh-read-each-call; `FindSessionLocked` mutate-in-place visible via the self-locking read; find-miss
→ nullptr + erase; const overload. The coordinator's 20 integration tests exercise the in-hold paths.

*(A future nicety, not in this behaviour-preserving slice: an instrumented `IOLock` test double could
machine-check "exactly one hold per multi-domain section" across the whole cluster, rather than by
diff review. Happy to add it as a separate change if useful.)*

## Verification

- `RestartSessionStoreTests`: 9/9
- `DiceDuplexRestartCoordinatorTests`: still 20/20 (unchanged)
- Full host suite: **1203/1203** (was 1194 + 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
