### PR TITLE
fix(async): stitch AR packets across the DMA buffer boundary

### DIFF
--- a/ASFWDriver/Async/Engine/ATManagerImpl.hpp
+++ b/ASFWDriver/Async/Engine/ATManagerImpl.hpp
@@ -107,6 +107,13 @@ kern_return_t ATManager<ContextT, RingT, RoleTag>::SubmitPath1_(const Descriptor
     // clear RUN before programming CommandPtr so the next RUN=1 transition is visible.
     if (ctx().IsRunning()) {
         clearRunAndPoll_();
+        if (ctx().IsActive()) {
+            // Programming CommandPtr on an ACTIVE context is illegal (OHCI
+            // §3.1.1) — the in-flight packet and/or this chain can be lost.
+            // Anomaly log for the LS-9000 wedge investigation.
+            ASFW_LOG(Async, "ctx=%{public}s txid=%u gen=%u P1_ARM while ACTIVE after clearRun poll gave up",
+                     RoleTag::kContextName, txid, generation_);
+        }
     }
 
     const uint32_t cmdPtr = ring().CommandPtrWordFromIOVA(chain.firstIOVA32, z);
@@ -181,7 +188,9 @@ kern_return_t ATManager<ContextT, RingT, RoleTag>::SubmitPath2_(const Descriptor
     ASFW_LOG_V3(Async, "ctx=%{public}s txid=%u gen=%u WAKE_GUARD ctrl=0x%08x run=%d dead=%d", RoleTag::kContextName, txid, generation_, ctrl, run ? 1 : 0, dead ? 1 : 0);
 
     if (!run || dead) {
-        ASFW_LOG_V2(Async, "ctx=%{public}s txid=%u gen=%u P2_FALLBACK cause=%{public}s", RoleTag::kContextName, txid, generation_, !run ? "RUN0" : "DEAD");
+        // Anomaly at default level: a hot-append hitting a stopped/dead context
+        // is the suspected AT-resp loss window (LS-9000 wedge investigation).
+        ASFW_LOG(Async, "ctx=%{public}s txid=%u gen=%u P2_FALLBACK cause=%{public}s ctrl=0x%08x", RoleTag::kContextName, txid, generation_, !run ? "RUN0" : "DEAD", ctrl);
         UnlinkTail_();
         trace_.push({NowNs(), txid, generation_, ATEvent::P2_FALLBACK, ctrl, 0});
         return kIOReturnNotReady;

--- a/ASFWDriver/Async/Rx/ARPacketParser.cpp
+++ b/ASFWDriver/Async/Rx/ARPacketParser.cpp
@@ -33,15 +33,14 @@ std::optional<std::array<uint32_t, 2>> ARPacketParser::ExtractPhyPacketQuadletsH
     };
 }
 
-std::optional<ARPacketParser::PacketInfo> ARPacketParser::ParseNext(
+std::expected<ARPacketParser::PacketInfo, ARPacketParser::ParseFailure> ARPacketParser::ParseNext(
     std::span<const uint8_t> buffer,
     size_t offset)
 {
-    // Phase 2.2: Use std::span for type-safe buffer access
     const size_t bufferSize = buffer.size();
 
     if (buffer.empty() || offset + 8 > bufferSize) {
-        return std::nullopt;
+        return std::unexpected(ParseFailure::NeedMoreBytes);
     }
 
     const uint8_t* packetStart = buffer.data() + offset;
@@ -81,43 +80,41 @@ std::optional<ARPacketParser::PacketInfo> ARPacketParser::ParseNext(
 
     const size_t headerLength = GetHeaderLength(tCode);
     if (headerLength == 0) {
-        ASFW_LOG_V0(Async, "❌ ARPacketParser::ParseNext: Unknown tCode=0x%X at offset %zu, dropping buffer", tCode, offset);
-        return std::nullopt;
+        ASFW_LOG_V0(Async, "❌ ARPacketParser::ParseNext: Unknown tCode=0x%X at offset %zu", tCode, offset);
+        return std::unexpected(ParseFailure::UnknownTCode);
     }
 
     // 1) Enough for header?
     if (offset + headerLength > bufferSize) {
-        // Incomplete packet in this buffer; stop without error (buffer exhausted)
-        return std::nullopt;
+        return std::unexpected(ParseFailure::NeedMoreBytes);
     }
 
-    // 2) Find dataLength (Phase 2.2: pass subspan for bounds checking)
-    // Create subspan for header (from offset to end of buffer)
-    const size_t headerSize = (headerLength < bufferSize - offset) ? headerLength : (bufferSize - offset);
-    auto headerSpan = buffer.subspan(offset, headerSize);
+    // 2) Find dataLength
+    auto headerSpan = buffer.subspan(offset, headerLength);
     const size_t dataLength = GetDataLength(headerSpan, tCode);
+    if (dataLength > kMaxAsyncPayloadBytes) {
+        // A corrupt block header declaring a huge data_length must never be
+        // treated as a stitchable fragment — it can never complete.
+        // Cross-validated with Linux ohci.c handle_ar_packet:
+        // payload_length > MAX_ASYNC_PAYLOAD → ar_context_abort("invalid packet length").
+        ASFW_LOG_V0(Async, "❌ ARPacketParser::ParseNext: data_length %zu exceeds max %zu (tCode=0x%X offset=%zu)",
+                    dataLength, kMaxAsyncPayloadBytes, tCode, offset);
+        return std::unexpected(ParseFailure::OversizedPayload);
+    }
     const size_t quadletAlignedLen = ((headerLength + dataLength + 3) & ~size_t(3));
 
-    // 3) Enough for header+data?
-    if (offset + quadletAlignedLen > bufferSize) {
-        // Incomplete payload in this buffer; stop without error (buffer exhausted)
-        return std::nullopt;
+    // 3) Enough for header+data+trailer? The trailer is part of the DMA'd packet
+    // unit, so its absence within the filled bytes means boundary fragment.
+    if (offset + quadletAlignedLen + 4 > bufferSize) {
+        return std::unexpected(ParseFailure::NeedMoreBytes);
     }
 
-    // 4) Trailer (prefer it, but don't scream if missing)
-    bool haveTrailer = (offset + quadletAlignedLen + 4) <= bufferSize;
-    size_t totalLengthWithTrailer = quadletAlignedLen + (haveTrailer ? 4 : 0);
-
-    // ---- Trailer (LE in memory) - only read if present
-    uint16_t xferStatus = 0;
-    uint16_t timeStamp = 0;
-    if (haveTrailer) {
-        uint32_t trailer_le;
-        __builtin_memcpy(&trailer_le, packetStart + quadletAlignedLen, 4);
-        const uint32_t trailer = OSSwapLittleToHostInt32(trailer_le);
-        xferStatus = static_cast<uint16_t>(trailer >> 16);
-        timeStamp  = static_cast<uint16_t>(trailer & 0xFFFF);
-    }
+    // ---- Trailer (LE in memory)
+    uint32_t trailer_le;
+    __builtin_memcpy(&trailer_le, packetStart + quadletAlignedLen, 4);
+    const uint32_t trailer = OSSwapLittleToHostInt32(trailer_le);
+    const uint16_t xferStatus = static_cast<uint16_t>(trailer >> 16);
+    const uint16_t timeStamp  = static_cast<uint16_t>(trailer & 0xFFFF);
 
     // ---- rCode (only for response tCodes): extract from Q1 bits[15:12]
     // Per Linux packet-header-definitions.h: ASYNC_HEADER_Q1_RCODE_SHIFT = 12
@@ -128,23 +125,19 @@ std::optional<ARPacketParser::PacketInfo> ARPacketParser::ParseNext(
         tCode == kTCodeReadBlockResponse ||
         tCode == kTCodeLockResponse)
     {
-        if (offset + 8 <= bufferSize) {
-            rCode = static_cast<uint8_t>((q1 >> 12) & 0xF);  // rCode in Q1 bits[15:12]
-        }
+        rCode = static_cast<uint8_t>((q1 >> 12) & 0xF);
     }
 
-    // Optional guard against garbage (all-zero header + zero trailer)
-    if (offset + 8 <= bufferSize) {
-        if (q0 == 0 && q1 == 0 && (!haveTrailer || (xferStatus == 0 && timeStamp == 0))) {
-            return std::nullopt;
-        }
+    // Guard against garbage (all-zero header + zero trailer)
+    if (q0 == 0 && q1 == 0 && xferStatus == 0 && timeStamp == 0) {
+        return std::unexpected(ParseFailure::ZeroGarbage);
     }
 
     PacketInfo info{};
     info.packetStart = packetStart;
     info.headerLength = headerLength;
     info.dataLength = dataLength;
-    info.totalLength = totalLengthWithTrailer;
+    info.totalLength = quadletAlignedLen + 4;
     info.tCode = tCode;
     info.rCode = rCode;
     info.xferStatus = xferStatus;  // stored in 32-bit field; value range 0..0xFFFF
@@ -187,13 +180,12 @@ size_t ARPacketParser::GetHeaderLength(uint8_t tCode) {
 
         case kTCodeWriteResponse:          // 0x2 TCODE_WRITE_RESPONSE
         case kTCodeReadQuadlet:            // 0x4 TCODE_READ_QUADLET_REQUEST
-        case 0xD:                          // TCODE_LINK_INTERNAL (Linux uses this)
             length = 12;  // 3 quadlets (Linux: p.header_length = 12)
             break;
 
         case kTCodePhyPacket:              // 0xE TCODE_LINK_INTERNAL/PHY
-            // CRITICAL: Per Linux drivers/firewire/ohci.c:943-948
-            // TCODE_LINK_INTERNAL: p.header_length = 12 (3 quadlets)
+            // CRITICAL: Per Linux drivers/firewire/ohci.c handle_ar_packet
+            // TCODE_LINK_INTERNAL (0xe): p.header_length = 12 (3 quadlets)
             // PHY packet structure per OHCI §8.4.2.3:
             //   Quadlet 0: tcode[31:28]=0xE, event[3:0]
             //   Quadlets 1-2: PHY payload; synthetic bus-reset markers reuse
@@ -202,15 +194,10 @@ size_t ARPacketParser::GetHeaderLength(uint8_t tCode) {
             length = 12;  // 3 quadlets (matches Linux!)
             break;
 
-        case kTCodeCycleStart:             // 0x8
-            length = 16;  // 4 quadlets
-            break;
-
-        case kTCodeIsochronousBlock:       // 0xA
-            length = 8;   // 2 quadlets (iso has different format)
-            break;
-
         default:
+            // Any other tCode (incl. cycle start 0x8, iso 0xA — never delivered
+            // to AR contexts with our LinkControl, same as Linux) is invalid
+            // here; Linux ar_context_abort()s on it ("invalid tcode").
             ASFW_LOG_V0(Async, "❌ GetHeaderLength: Unknown tCode=0x%X", tCode);
             return 0;   // Unknown tCode
     }
@@ -279,27 +266,6 @@ size_t ARPacketParser::GetDataLength(std::span<const uint8_t> header, uint8_t tC
             dataLen = 0;
             ASFW_LOG_V3(Async, "GetDataLength: tCode=0x2 (Write Response) → 0 bytes");
             break;
-
-        case kTCodeIsochronousBlock:       // 0xA
-        {
-            // Isochronous: data_length in quadlet 1, bits[31:16]
-            if (header.size() < 8) {
-                ASFW_LOG_V0(Async, "❌ GetDataLength: Header too small (%zu bytes) for iso tCode=0x%X",
-                         header.size(), tCode);
-                return 0;
-            }
-
-            uint32_t quadlet1;
-            std::memcpy(&quadlet1, header.data() + 4, sizeof(quadlet1));
-            quadlet1 = OSSwapBigToHostInt32(quadlet1);
-
-            const uint16_t length = static_cast<uint16_t>((quadlet1 >> 16) & 0xFFFF);
-            dataLen = length;
-
-            ASFW_LOG_V3(Async, "GetDataLength: Iso quadlet1=0x%08X → data_length=%u bytes",
-                   quadlet1, length);
-            break;
-        }
 
         default:
             // No separate data (quadlet transactions, simple responses)

--- a/ASFWDriver/Async/Rx/ARPacketParser.hpp
+++ b/ASFWDriver/Async/Rx/ARPacketParser.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <expected>
 #include <optional>
 #include <span>
 #include <array>
@@ -40,10 +41,26 @@ public:
         uint32_t timeStamp;          // From trailer quadlet
     };
 
-    // Parse next packet from buffer at given offset (Phase 2.2: std::span)
-    // Returns packet info if valid packet found, nullopt if buffer exhausted/malformed
-    static std::optional<PacketInfo> ParseNext(std::span<const uint8_t> buffer,
-                                               size_t offset);
+    // Why parsing can stop. The AR stream walker treats these differently:
+    // NeedMoreBytes = fragment at end of filled bytes (stitch across the buffer
+    // boundary or wait for hardware to append more); the others = corrupt head
+    // that will never parse no matter how many bytes arrive.
+    enum class ParseFailure : uint8_t {
+        NeedMoreBytes,
+        UnknownTCode,
+        ZeroGarbage,
+        OversizedPayload,
+    };
+
+    // Parse next packet from buffer at given offset.
+    // The 4-byte OHCI trailer is mandatory: hardware writes header+payload+trailer
+    // as one unit before updating resCount (OHCI §8.4.2), so a packet whose trailer
+    // is not within the filled bytes is by definition a buffer-boundary fragment.
+    // Cross-validated with Linux ohci.c handle_ar_packet() (accepted tCodes
+    // 0x0/0x1/0x2/0x4/0x5/0x6/0x7/0x9/0xB/0xE, unconditional status quadlet,
+    // MAX_ASYNC_PAYLOAD bound; everything else aborts).
+    static std::expected<PacketInfo, ParseFailure> ParseNext(std::span<const uint8_t> buffer,
+                                                             size_t offset);
 
     // Get IEEE 1394 async header length from tCode
     // Per IEEE 1394-1995 Table 6-2 and OHCI §8.4.2
@@ -67,9 +84,7 @@ private:
     static constexpr uint8_t kTCodeReadBlock = 0x5;
     static constexpr uint8_t kTCodeReadQuadletResponse = 0x6;
     static constexpr uint8_t kTCodeReadBlockResponse = 0x7;
-    static constexpr uint8_t kTCodeCycleStart = 0x8;
     static constexpr uint8_t kTCodeLockRequest = 0x9;
-    static constexpr uint8_t kTCodeIsochronousBlock = 0xA;
     static constexpr uint8_t kTCodeLockResponse = 0xB;
     static constexpr uint8_t kTCodePhyPacket = 0xE;
 };

--- a/ASFWDriver/Async/Rx/ARStreamProcessor.hpp
+++ b/ASFWDriver/Async/Rx/ARStreamProcessor.hpp
@@ -1,0 +1,203 @@
+#pragma once
+
+#include "ARPacketParser.hpp"
+#include "../../Logging/Logging.hpp"
+#include "../../Logging/LogConfig.hpp"
+
+#include <DriverKit/IOLib.h>
+
+#include <array>
+#include <cstdint>
+#include <span>
+
+namespace ASFW::Async::Rx {
+
+struct ARStreamStats {
+    uint32_t buffersProcessed = 0;
+    uint32_t packetsFound = 0;
+};
+
+// Shared bufferFill stream walker for both AR rings (request and response).
+//
+// OHCI §8.4.2: an AR ring is one contiguous packet stream; a packet
+// (header+payload+trailer) may straddle a buffer boundary when a buffer fills.
+// Hardware advances resCount only per fully written packet, so a trailing
+// fragment can appear only at a buffer-full straddle. The walker therefore:
+//   - commits only parsed bytes (never past an unparsed fragment),
+//   - stitches boundary fragments via CopyReadableBytes/ConsumeReadableBytes
+//     once the tail bytes have arrived in the next buffer,
+//   - drops the remainder of a buffer loudly on an unparseable head (garbage
+//     can never re-frame; waiting on it would stall the ring head forever).
+// Cross-validated with Linux ohci.c ar_context, which makes straddles
+// impossible by vmapping wraparound pages; this walker restores the same
+// no-packet-loss guarantee for our per-buffer rings.
+//
+// Ctx must provide Dequeue/Recycle/CommitConsumed/CopyReadableBytes/
+// ConsumeReadableBytes (ARContextBase or a bare BufferRing wrapper in tests).
+// dispatch(const ARPacketParser::PacketInfo&) is invoked synchronously for
+// every complete packet; onBuffer(bufferNo, info) is a debug hook per dequeue.
+template <typename Ctx, typename OnBufferFn, typename DispatchFn>
+ARStreamStats ProcessARStream(Ctx& ctx,
+                              const char* ctxLabel,
+                              uint64_t* heartbeatCounter,
+                              OnBufferFn&& onBuffer,
+                              DispatchFn&& dispatch) {
+    using ParseFailure = ARPacketParser::ParseFailure;
+
+    alignas(4) std::array<uint8_t, ARPacketParser::kMaxPacketBytes> stitchedPacket{};
+    ARStreamStats stats{};
+
+    auto recycle = [&](size_t descriptorIndex) {
+        const kern_return_t recycleKr = ctx.Recycle(descriptorIndex);
+        if (recycleKr != kIOReturnSuccess) {
+            ASFW_LOG(Async,
+                     "[%{public}s] failed to recycle descriptor %zu (kr=0x%08x)",
+                     ctxLabel, descriptorIndex, recycleKr);
+        }
+    };
+    auto commitConsumed = [&](size_t descriptorIndex, size_t consumedBytes) {
+        const kern_return_t kr = ctx.CommitConsumed(descriptorIndex, consumedBytes);
+        if (kr != kIOReturnSuccess) {
+            ASFW_LOG(Async,
+                     "[%{public}s] failed to commit %zu bytes for descriptor %zu (kr=0x%08x)",
+                     ctxLabel, consumedBytes, descriptorIndex, kr);
+        }
+    };
+    auto logGarbageHead = [&](const uint8_t* bufferStart, size_t offset, size_t bufferSize,
+                              ParseFailure failure) {
+        uint32_t q0 = 0;
+        uint32_t q1 = 0;
+        if (offset + 4 <= bufferSize) {
+            __builtin_memcpy(&q0, bufferStart + offset, 4);
+        }
+        if (offset + 8 <= bufferSize) {
+            __builtin_memcpy(&q1, bufferStart + offset + 4, 4);
+        }
+        const char* kind = "zero garbage";
+        if (failure == ParseFailure::UnknownTCode) {
+            kind = "unknown tCode";
+        } else if (failure == ParseFailure::OversizedPayload) {
+            kind = "oversized data_length";
+        }
+        ASFW_LOG(Async,
+                 "[%{public}s] unparseable head (%{public}s) at offset %zu/%zu q0=0x%08x q1=0x%08x — dropping buffer remainder",
+                 ctxLabel, kind, offset, bufferSize, q0, q1);
+    };
+
+    while (auto bufferInfo = ctx.Dequeue()) {
+        const auto& info = *bufferInfo;
+        ++stats.buffersProcessed;
+
+        if (heartbeatCounter) {
+            const uint64_t seen = ++(*heartbeatCounter);
+            if ((seen & 63u) == 0u) {
+                ASFW_LOG(Async, "[%{public}s] hb bufs=%llu lastOff=%zu",
+                         ctxLabel,
+                         static_cast<unsigned long long>(seen),
+                         info.startOffset);
+            }
+        }
+
+        if (!info.virtualAddress) {
+            recycle(info.descriptorIndex);
+            continue;
+        }
+
+        const uint8_t* bufferStart = info.virtualAddress;
+        const size_t bufferSize = info.bytesFilled;
+        const size_t startOffset = info.startOffset;
+        if (bufferSize == 0 || bufferSize <= startOffset) {
+            recycle(info.descriptorIndex);
+            continue;
+        }
+
+        onBuffer(stats.buffersProcessed, info);
+
+        size_t offset = startOffset;
+        bool bufferHandled = false;   // commit already issued by a stitch/drop branch
+        bool committedPartial = false;
+        while (offset < bufferSize) {
+            auto parsed =
+                ARPacketParser::ParseNext(std::span<const uint8_t>(bufferStart, bufferSize), offset);
+            if (parsed.has_value()) {
+                ++stats.packetsFound;
+                dispatch(*parsed);
+                offset += parsed->totalLength;
+                continue;
+            }
+
+            if (parsed.error() == ParseFailure::NeedMoreBytes) {
+                // Boundary fragment. Commit what we parsed so the readable window
+                // starts at the fragment, then try to stitch across the boundary.
+                if (offset > startOffset) {
+                    commitConsumed(info.descriptorIndex, offset);
+                    committedPartial = true;
+                }
+
+                const size_t stitchedBytes = ctx.CopyReadableBytes(stitchedPacket);
+                if (stitchedBytes > 0) {
+                    auto stitched = ARPacketParser::ParseNext(
+                        std::span<const uint8_t>(stitchedPacket.data(), stitchedBytes), 0);
+                    if (stitched.has_value()) {
+                        ++stats.packetsFound;
+                        dispatch(*stitched);
+                        const kern_return_t consumeKr =
+                            ctx.ConsumeReadableBytes(stitched->totalLength);
+                        if (consumeKr != kIOReturnSuccess) {
+                            ASFW_LOG(Async,
+                                     "[%{public}s] failed to consume stitched packet (%zu bytes, kr=0x%08x)",
+                                     ctxLabel, stitched->totalLength, consumeKr);
+                        }
+                        // Anomaly-visible on purpose: stitches are rare (one per
+                        // ~bufferSize of inbound traffic at most), and any stitch
+                        // line near a fault is a lead.
+                        ASFW_LOG(Async, "[%{public}s] stitched tCode=0x%x len=%zu across buffer boundary",
+                                 ctxLabel, stitched->tCode, stitched->totalLength);
+                        bufferHandled = true;
+                    } else if (stitched.error() != ParseFailure::NeedMoreBytes) {
+                        // The fragment head itself is garbage — it will never parse.
+                        logGarbageHead(bufferStart, offset, bufferSize, stitched.error());
+                        commitConsumed(info.descriptorIndex, bufferSize);
+                        bufferHandled = true;
+                    } else {
+                        ASFW_LOG_V2(Async,
+                                    "[%{public}s] fragment (%zu bytes) at buffer end awaiting tail",
+                                    ctxLabel, bufferSize - offset);
+                    }
+                }
+                break;
+            }
+
+            // Unparseable head mid-buffer: framing is lost. Drop the remainder
+            // loudly and resume at the next buffer's first byte. Note this is a
+            // best-effort heuristic, not a true resync — a DMA buffer boundary
+            // is not a packet boundary in bufferFill mode. Linux aborts and
+            // restarts the whole AR context here (ar_context_abort); with
+            // stitching in place this path is reachable only on genuine
+            // corruption, so any of these log lines is itself a finding.
+            logGarbageHead(bufferStart, offset, bufferSize, parsed.error());
+            commitConsumed(info.descriptorIndex, bufferSize);
+            bufferHandled = true;
+            break;
+        }
+
+        if (bufferHandled) {
+            continue;
+        }
+        if (!committedPartial) {
+            commitConsumed(info.descriptorIndex, offset);
+        }
+        if (offset == startOffset) {
+            // No forward progress: the head of the readable window is an
+            // unstitchable fragment whose tail has not been DMA'd yet. All
+            // later traffic sits behind it in stream order, so end the pass;
+            // the next interrupt retries the stitch (BufferRing::Dequeue
+            // re-presents a full head once its successor shows data).
+            break;
+        }
+    }
+
+    return stats;
+}
+
+} // namespace ASFW::Async::Rx

--- a/ASFWDriver/Async/Rx/ARStreamProcessor.hpp
+++ b/ASFWDriver/Async/Rx/ARStreamProcessor.hpp
@@ -148,11 +148,12 @@ ARStreamStats ProcessARStream(Ctx& ctx,
                                      "[%{public}s] failed to consume stitched packet (%zu bytes, kr=0x%08x)",
                                      ctxLabel, stitched->totalLength, consumeKr);
                         }
-                        // Anomaly-visible on purpose: stitches are rare (one per
-                        // ~bufferSize of inbound traffic at most), and any stitch
-                        // line near a fault is a lead.
-                        ASFW_LOG(Async, "[%{public}s] stitched tCode=0x%x len=%zu across buffer boundary",
-                                 ctxLabel, stitched->tCode, stitched->totalLength);
+                        // Normal boundary mechanism, not an anomaly: recurs
+                        // per-buffer during sustained inbound transfer, so
+                        // V2-gated to keep a clean run silent. The consume-failure
+                        // line above stays at default level (that is the fault).
+                        ASFW_LOG_V2(Async, "[%{public}s] stitched tCode=0x%x len=%zu across buffer boundary",
+                                    ctxLabel, stitched->tCode, stitched->totalLength);
                         bufferHandled = true;
                     } else if (stitched.error() != ParseFailure::NeedMoreBytes) {
                         // The fragment head itself is garbage — it will never parse.

--- a/ASFWDriver/Async/Rx/LocalRequestDispatch.cpp
+++ b/ASFWDriver/Async/Rx/LocalRequestDispatch.cpp
@@ -6,6 +6,7 @@
 #include "LocalRequestDispatch.hpp"
 
 #include "../../Hardware/IEEE1394.hpp"
+#include "../../Logging/Logging.hpp"
 #include "../PacketHelpers.hpp"
 #include "../Tx/ResponseSender.hpp"
 #include "PacketRouter.hpp"
@@ -69,6 +70,24 @@ ResponseCode LocalRequestDispatch::DispatchView(const ARPacketView& view, uint32
 
     const auto result = Route(ctx);
     const ResponseCode rcode = result.claimed ? result.rcode : ResponseCode::AddressError;
+
+    // Blind-spot instrumentation (LS-9000 wedge): a request no handler claims is
+    // answered addr_error and was previously invisible — if the target's ORB
+    // fetch lands here, "ORB fetched, no status" is really "fetch failed".
+    if (!result.claimed) {
+        ASFW_LOG(Async,
+                 "AR request UNCLAIMED tLabel=%u tCode=0x%X src=0x%04X addr=0x%012llx len=%u → addr_error",
+                 view.tLabel, view.tCode, view.sourceID,
+                 static_cast<unsigned long long>(ctx.destOffset), ctx.dataLength);
+    } else if (isReadBlock) {
+        // Ties each ORB/page-table fetch to the tLabel of our response so an
+        // "AT-resp DROPPED: tLabel=N" line identifies exactly which fetch the
+        // target never got an answer to. Low rate (a handful per command).
+        ASFW_LOG(Async, "AR readBlock tLabel=%u src=0x%04X addr=0x%012llx len=%u rc=%u",
+                 view.tLabel, view.sourceID,
+                 static_cast<unsigned long long>(ctx.destOffset), ctx.dataLength,
+                 static_cast<unsigned>(rcode));
+    }
 
     if (isReadQuad) {
         if (sender_ != nullptr) {

--- a/ASFWDriver/Async/Rx/LocalRequestDispatch.cpp
+++ b/ASFWDriver/Async/Rx/LocalRequestDispatch.cpp
@@ -82,8 +82,9 @@ ResponseCode LocalRequestDispatch::DispatchView(const ARPacketView& view, uint32
     } else if (isReadBlock) {
         // Ties each ORB/page-table fetch to the tLabel of our response so an
         // "AT-resp DROPPED: tLabel=N" line identifies exactly which fetch the
-        // target never got an answer to. Low rate (a handful per command).
-        ASFW_LOG(Async, "AR readBlock tLabel=%u src=0x%04X addr=0x%012llx len=%u rc=%u",
+        // target never got an answer to. Happy-path correlation, so V2-gated;
+        // the UNCLAIMED branch above stays at default level (real anomaly).
+        ASFW_LOG_V2(Async, "AR readBlock tLabel=%u src=0x%04X addr=0x%012llx len=%u rc=%u",
                  view.tLabel, view.sourceID,
                  static_cast<unsigned long long>(ctx.destOffset), ctx.dataLength,
                  static_cast<unsigned>(rcode));

--- a/ASFWDriver/Async/Rx/PacketRouter.cpp
+++ b/ASFWDriver/Async/Rx/PacketRouter.cpp
@@ -58,13 +58,9 @@ void PacketRouter::RegisterResponseHandler(uint8_t tCode, PacketHandler handler)
     responseHandlers_[tCode] = std::move(handler);
 }
 
-void PacketRouter::RoutePacket(ARContextType contextType, std::span<const uint8_t> packetData, uint32_t generation) {
-    // Phase 2.2: Use std::span for type-safe buffer access
-    if (packetData.empty()) {
-        return;
-    }
-
-    // Select handler table based on context type
+void PacketRouter::RouteParsedPacket(ARContextType contextType,
+                                     const ARPacketParser::PacketInfo& packetInfo,
+                                     uint32_t generation) {
     const auto& handlers = (contextType == ARContextType::Request)
                                ? requestHandlers_
                                : responseHandlers_;
@@ -73,77 +69,60 @@ void PacketRouter::RoutePacket(ARContextType contextType, std::span<const uint8_
                                   ? "Request"
                                   : "Response";
 
-    // Parse packet stream - buffer may contain multiple packets
-    // Per OHCI §8.4.2: AR buffers are packet streams, not single packets
-    size_t offset = 0;
-    const size_t bufferSize = packetData.size();
+    const uint8_t* packetStart = packetInfo.packetStart;
+    const size_t headerLen = packetInfo.headerLength;
+    const size_t dataLen = packetInfo.dataLength;
+    const uint8_t tCode = packetInfo.tCode;
+    alignas(8) std::array<uint8_t, ASFW::FW::MaxPayload::kS800> payloadScratch{};
 
-    while (offset < bufferSize) {
-        auto packetInfoOpt = ARPacketParser::ParseNext(packetData, offset);
-        if (!packetInfoOpt) {
-            break;
+    // Build a dispatch view over the header and aligned payload bytes.
+    ARPacketView view;
+    view.tCode = tCode;
+    view.header = std::span<const uint8_t>(packetStart, headerLen);
+    if (dataLen > 0) {
+        const auto payloadBytes = std::span<const uint8_t>(packetStart + headerLen, dataLen);
+        view.payload = CopyAlignedPayload(payloadBytes, payloadScratch);
+        if (view.payload.empty()) {
+            ASFW_LOG(Async,
+                     "PacketRouter: payload %zu exceeds aligned scratch buffer for tCode=0x%x",
+                     dataLen,
+                     tCode);
+            return;
         }
+    } else {
+        view.payload = {};
+    }
 
-        const auto& packetInfo = *packetInfoOpt;
+    // Trailer fields – use low 16 bits for xferStatus/timeStamp
+    view.xferStatus = static_cast<uint16_t>(packetInfo.xferStatus & 0xFFFF);
+    view.timeStamp  = static_cast<uint16_t>(packetInfo.timeStamp  & 0xFFFF);
 
-        const uint8_t* packetStart = packetInfo.packetStart;
-        const size_t headerLen = packetInfo.headerLength;
-        const size_t dataLen = packetInfo.dataLength;
-        const uint8_t tCode = packetInfo.tCode;
-        alignas(8) std::array<uint8_t, ASFW::FW::MaxPayload::kS800> payloadScratch{};
+    if (headerLen >= 6) {
+        // We can safely use the header span we already built
+        view.destID   = ExtractDestID(view.header);
+        view.sourceID = ExtractSourceID(view.header);
+        view.tLabel   = ExtractTLabel(view.header);
+    } else {
+        // PHY or malformed packet – leave IDs/label at 0
+        view.destID   = 0;
+        view.sourceID = 0;
+        view.tLabel   = 0;
+    }
 
-        // Build a dispatch view over the header and aligned payload bytes.
-        ARPacketView view;
-        view.tCode = tCode;
-        view.header = std::span<const uint8_t>(packetStart, headerLen);
-        if (dataLen > 0) {
-            const auto payloadBytes = std::span<const uint8_t>(packetStart + headerLen, dataLen);
-            view.payload = CopyAlignedPayload(payloadBytes, payloadScratch);
-            if (view.payload.empty()) {
-                ASFW_LOG(Async,
-                         "PacketRouter: payload %zu exceeds aligned scratch buffer for tCode=0x%x",
-                         dataLen,
-                         tCode);
-                offset += packetInfo.totalLength;
-                continue;
-            }
-        } else {
-            view.payload = {};
+    // Capture incoming transaction
+    CaptureIncomingEvent(contextType, view, generation);
+
+    if (tCode < 16 && handlers[tCode]) {
+        const ResponseCode rcode = handlers[tCode](view, generation);
+
+        if (contextType == ARContextType::Request &&
+            responseSender_ &&
+            rcode != ResponseCode::NoResponse) {
+            responseSender_->SendWriteResponse(view, rcode);
         }
-
-        // Trailer fields – use low 16 bits for xferStatus/timeStamp
-        view.xferStatus = static_cast<uint16_t>(packetInfo.xferStatus & 0xFFFF);
-        view.timeStamp  = static_cast<uint16_t>(packetInfo.timeStamp  & 0xFFFF);
-
-        if (headerLen >= 6) {
-            // We can safely use the header span we already built
-            view.destID   = ExtractDestID(view.header);
-            view.sourceID = ExtractSourceID(view.header);
-            view.tLabel   = ExtractTLabel(view.header);
-        } else {
-            // PHY or malformed packet – leave IDs/label at 0
-            view.destID   = 0;
-            view.sourceID = 0;
-            view.tLabel   = 0;
-        }
-
-        // Capture incoming transaction
-        CaptureIncomingEvent(contextType, view, generation);
-
-        if (tCode < 16 && handlers[tCode]) {
-            const ResponseCode rcode = handlers[tCode](view, generation);
-
-            if (contextType == ARContextType::Request &&
-                responseSender_ &&
-                rcode != ResponseCode::NoResponse) {
-                responseSender_->SendWriteResponse(view, rcode);
-            }
-        } else {
-            ASFW_LOG(Async, "PacketRouter: unhandled AR %{public}s packet tCode=0x%x",
-                     contextName, tCode);
-        }
-
-        offset += packetInfo.totalLength;
+    } else {
+        ASFW_LOG(Async, "PacketRouter: unhandled AR %{public}s packet tCode=0x%x",
+                 contextName, tCode);
     }
 }
 

--- a/ASFWDriver/Async/Rx/PacketRouter.hpp
+++ b/ASFWDriver/Async/Rx/PacketRouter.hpp
@@ -6,6 +6,7 @@
 #include <functional>
 #include <span>
 
+#include "ARPacketParser.hpp"
 #include "../ResponseCode.hpp"
 
 namespace ASFW::Debug {
@@ -21,7 +22,7 @@ class ResponseSender;
 /**
  * \brief Dispatch view of an AR packet for handler callbacks.
  *
- * Provides read-only access to packet header and payload during RoutePacket().
+ * Provides read-only access to packet header and payload during RouteParsedPacket().
  * Header bytes are in OHCI AR DMA memory order; decoded scalar fields are in
  * host order. Payload may point at an aligned scratch copy for handlers that
  * need stable byte access.
@@ -119,11 +120,11 @@ using PacketHandler = std::function<ResponseCode(const ARPacketView&, uint32_t g
  *     // Complete transaction...
  * });
  *
- * // Route packet from AR Request buffer
- * router.RoutePacket(ARContextType::Request, std::span<const uint8_t>(bufferData, bufferSize));
+ * // Route a packet already framed by the AR stream walker
+ * router.RouteParsedPacket(ARContextType::Request, packetInfo, generation);
  * \endcode
  *
- * \warning Handlers are invoked synchronously from RoutePacket(). They must
+ * \warning Handlers are invoked synchronously from RouteParsedPacket(). They must
  *          complete quickly to avoid blocking AR interrupt processing.
  */
 class PacketRouter {
@@ -166,38 +167,24 @@ public:
     void RegisterResponseHandler(uint8_t tCode, PacketHandler handler);
 
     /**
-     * \brief Route packet from AR buffer to registered handler.
+     * \brief Dispatch one already-parsed packet to its registered handler.
      *
-     * Parses packet buffer, extracts packets one-by-one, and dispatches each
-     * packet to its registered handler based on tCode and context type.
+     * Stream framing (multi-packet walking, boundary stitching) is owned by
+     * the AR stream walker in ARStreamProcessor.hpp; this method only builds
+     * the ARPacketView (header span + payload copied into aligned scratch),
+     * captures diagnostics, invokes the tCode handler, and emits the write
+     * response for request contexts.
      *
      * \param contextType AR Request or AR Response context
-     * \param packetData Buffer containing packet stream (may have multiple packets)
-     *
-     * **Implementation**
-     * 1. Use ARPacketParser::ParseNext() to extract packets from buffer
-     * 2. For each packet:
-     *    a. Extract tCode from header first byte (bits[7:4])
-     *    b. Build ARPacketView from header span and aligned payload bytes
-     *    c. Lookup handler in requestHandlers_ or responseHandlers_
-     *    d. Invoke handler(view) if registered, else log warning
-     * 3. Continue until buffer exhausted
-     *
-     * **OHCI §8.4.2**
-     * "AR buffers contain a stream of packets. Each packet consists of:
-     *  - Packet header (variable length based on tCode)
-     *  - Packet data (optional, based on tCode and data_length)
-     *  - 4-byte trailer (xferStatus | timeStamp)
-     * Software must parse the stream to extract individual packets."
+     * \param packetInfo Parsed packet from ARPacketParser::ParseNext()
      *
      * **Thread Safety**
-     * Not thread-safe. Caller must serialize RoutePacket() calls (typically
-     * invoked from single interrupt handler thread).
-     *
-     * **Phase 2.2**
-     * Signature updated to use std::span for type-safe buffer access.
+     * Not thread-safe. Caller must serialize calls (typically invoked from
+     * the single interrupt handler thread).
      */
-    void RoutePacket(ARContextType contextType, std::span<const uint8_t> packetData, uint32_t generation);
+    void RouteParsedPacket(ARContextType contextType,
+                           const ARPacketParser::PacketInfo& packetInfo,
+                           uint32_t generation);
 
     /**
      * \brief Clear all registered handlers.

--- a/ASFWDriver/Async/Rx/RxPath.cpp
+++ b/ASFWDriver/Async/Rx/RxPath.cpp
@@ -1,5 +1,6 @@
 #include "RxPath.hpp"
 #include "ARPacketParser.hpp"
+#include "ARStreamProcessor.hpp"
 #include "../../Hardware/OHCIEventCodes.hpp"
 #include "../../Hardware/OHCIDescriptors.hpp"
 #include "../../Hardware/IEEE1394.hpp"
@@ -27,8 +28,6 @@ RxPath::RxPath(ARRequestContext& arReqContext,
     , generationTracker_(generationTracker)
     , packetRouter_(packetRouter)
 {
-    packetParser_ = std::make_unique<ARPacketParser>();
-
     // Route PHY packets (tCode=0xE) in AR Request context through RxPath
     packetRouter_.RegisterRequestHandler(
         HW::AsyncRequestHeader::kTcodePhyPacket,
@@ -59,214 +58,55 @@ void RxPath::ProcessARInterrupts(std::atomic<uint32_t>& is_bus_reset_in_progress
 }
 
 void RxPath::ProcessRequestInterrupts() {
-    auto* ctx = &arRequestContext_;
-    constexpr const char* ctxLabel = "AR Request";
-
-    auto recycle = [&](size_t descriptorIndex) {
-        const kern_return_t recycleKr = ctx->Recycle(descriptorIndex);
-        if (recycleKr != kIOReturnSuccess) {
-            ASFW_LOG(Async,
-                     "RxPath: Failed to recycle descriptor %zu for %{public}s (kr=0x%08x)",
-                     descriptorIndex,
-                     ctxLabel,
-                     recycleKr);
-        }
-    };
-    auto commitConsumed = [&](size_t descriptorIndex, size_t consumedBytes) {
-        const kern_return_t kr = ctx->CommitConsumed(descriptorIndex, consumedBytes);
-        if (kr != kIOReturnSuccess) {
-            ASFW_LOG(Async,
-                     "RxPath: Failed to commit %zu bytes for descriptor %zu in %{public}s (kr=0x%08x)",
-                     consumedBytes,
-                     descriptorIndex,
-                     ctxLabel,
-                     kr);
-        }
-    };
-
-    uint32_t buffersProcessed = 0;
-    while (auto bufferInfo = ctx->Dequeue()) {
-        const auto& info = *bufferInfo;
-        ++buffersProcessed;
-
-        ASFW_LOG_HEX(Async,
-                     "RxPath AR Request Buffer #%u: vaddr=%p startOffset=%zu size=%zu index=%zu",
-                     buffersProcessed,
-                     info.virtualAddress,
-                     info.startOffset,
-                     info.bytesFilled,
-                     info.descriptorIndex);
-
-        if (!info.virtualAddress) {
+    const auto stats = ProcessARStream(
+        arRequestContext_,
+        "ARReq",
+        &requestBuffersSeen_,
+        [this](uint32_t bufferNo, const Shared::FilledBufferInfo& info) {
             ASFW_LOG_HEX(Async,
-                         "RxPath AR Request Buffer #%u: NULL virtual address, recycling",
-                         buffersProcessed);
-            recycle(info.descriptorIndex);
-            continue;
-        }
+                         "RxPath AR Request Buffer #%u: vaddr=%p startOffset=%zu size=%zu index=%zu",
+                         bufferNo,
+                         info.virtualAddress,
+                         info.startOffset,
+                         info.bytesFilled,
+                         info.descriptorIndex);
+            DumpRequestBuffer(bufferNo, info.virtualAddress, info.bytesFilled);
+        },
+        [this](const ARPacketParser::PacketInfo& packet) {
+            const uint32_t currentGen = generationTracker_.GetCurrentState().generation16;
+            packetRouter_.RouteParsedPacket(ARContextType::Request, packet, currentGen);
+        });
 
-        const uint8_t* bufferStart = info.virtualAddress;
-        const std::size_t bufferSize = info.bytesFilled;
-        if (bufferSize == 0 || bufferSize <= info.startOffset) {
-            recycle(info.descriptorIndex);
-            continue;
-        }
-
-        DumpRequestBuffer(buffersProcessed, bufferStart, bufferSize);
-
-        const uint8_t* newDataStart = bufferStart + info.startOffset;
-        const std::size_t newDataSize = bufferSize - info.startOffset;
-        ASFW_LOG_HEX(Async,
-                     "RxPath AR Request Buffer #%u: routing %zu NEW bytes from offset %zu",
-                     buffersProcessed,
-                     newDataSize,
-                     info.startOffset);
-        const uint32_t currentGen = generationTracker_.GetCurrentState().generation16;
-        packetRouter_.RoutePacket(
-            ARContextType::Request,
-            std::span<const uint8_t>(newDataStart, newDataSize),
-            currentGen);
-        commitConsumed(info.descriptorIndex, bufferSize);
-    }
-
-    ASFW_LOG_V2(Async, "RxPath: Processed %u buffers from %{public}s",
-                buffersProcessed, ctxLabel);
+    ASFW_LOG_V2(Async, "RxPath: Processed %u packets in %u buffers from AR Request",
+                stats.packetsFound, stats.buffersProcessed);
 }
 
 void RxPath::ProcessResponseInterrupts(Debug::BusResetPacketCapture* busResetCapture) {
-    auto* ctx = &arResponseContext_;
-    constexpr const char* ctxLabel = "AR Response";
-    constexpr ARContextType ctxType = ARContextType::Response;
-    alignas(4) std::array<uint8_t, ARPacketParser::kMaxPacketBytes> stitchedPacket{};
+    DumpResponseInterruptState(arResponseContext_);
 
-    DumpResponseInterruptState(*ctx);
+    // Note: the walker keeps descriptors live and relies on BufferRing::Dequeue()
+    // to auto-advance once the next buffer gains data. Eager recycling after each
+    // response packet caused `no9` to regress into global Config ROM read timeouts
+    // even though QRresp packets were still present on the wire.
+    const auto stats = ProcessARStream(
+        arResponseContext_,
+        "ARRsp",
+        nullptr,
+        [this](uint32_t, const Shared::FilledBufferInfo& info) {
+            LogResponseNewData(info.virtualAddress + info.startOffset,
+                               info.startOffset,
+                               info.bytesFilled);
+        },
+        [this, busResetCapture](const ARPacketParser::PacketInfo& packet) {
+            ProcessReceivedPacket(ARContextType::Response, packet, busResetCapture);
+        });
 
-    auto recycle = [&](size_t descriptorIndex) {
-        const kern_return_t recycleKr = ctx->Recycle(descriptorIndex);
-        if (recycleKr != kIOReturnSuccess) {
-            ASFW_LOG(Async,
-                     "RxPath: Failed to recycle descriptor %zu for %{public}s (kr=0x%08x)",
-                     descriptorIndex,
-                     ctxLabel,
-                     recycleKr);
-        }
-    };
-    auto commitConsumed = [&](size_t descriptorIndex, size_t consumedBytes) {
-        const kern_return_t kr = ctx->CommitConsumed(descriptorIndex, consumedBytes);
-        if (kr != kIOReturnSuccess) {
-            ASFW_LOG(Async,
-                     "RxPath: Failed to commit %zu bytes for descriptor %zu in %{public}s (kr=0x%08x)",
-                     consumedBytes,
-                     descriptorIndex,
-                     ctxLabel,
-                     kr);
-        }
-    };
+    ASFW_LOG_V2(Async, "RxPath: Processed %u packets in %u buffers from AR Response",
+                stats.packetsFound, stats.buffersProcessed);
 
-    uint32_t buffersProcessed = 0;
-    uint32_t packetsFound = 0;
-    while (auto bufferInfo = ctx->Dequeue()) {
-        const auto& info = *bufferInfo;
-        ++buffersProcessed;
-
-        if (!info.virtualAddress) {
-            recycle(info.descriptorIndex);
-            continue;
-        }
-
-        const uint8_t* bufferStart = info.virtualAddress;
-        const std::size_t bufferSize = info.bytesFilled;
-        const std::size_t startOffset = info.startOffset;
-        if (bufferSize == 0 || bufferSize <= startOffset) {
-            recycle(info.descriptorIndex);
-            continue;
-        }
-
-        const uint8_t* newDataStart = bufferStart + startOffset;
-        const std::size_t newDataSize = bufferSize - startOffset;
-        LogResponseNewData(newDataStart, startOffset, bufferSize);
-
-        std::size_t offset = startOffset;
-        bool consumedStitchedPacket = false;
-        bool committedBeforeBoundaryRetry = false;
-        while (offset < bufferSize) {
-            auto packetInfo =
-                ARPacketParser::ParseNext(std::span<const uint8_t>(bufferStart, bufferSize), offset);
-            if (!packetInfo.has_value()) {
-                if (offset > startOffset) {
-                    commitConsumed(info.descriptorIndex, offset);
-                    committedBeforeBoundaryRetry = true;
-                }
-
-                const size_t stitchedBytes = ctx->CopyReadableBytes(stitchedPacket);
-                if (stitchedBytes > 0) {
-                    auto stitchedInfo = ARPacketParser::ParseNext(
-                        std::span<const uint8_t>(stitchedPacket.data(), stitchedBytes), 0);
-                    if (stitchedInfo.has_value() &&
-                        stitchedInfo->totalLength <= stitchedBytes &&
-                        stitchedInfo->totalLength > 0) {
-                        ++packetsFound;
-                        ProcessReceivedPacket(ctxType, *stitchedInfo, busResetCapture);
-                        const kern_return_t consumeKr =
-                            ctx->ConsumeReadableBytes(stitchedInfo->totalLength);
-                        if (consumeKr != kIOReturnSuccess) {
-                            ASFW_LOG(Async,
-                                     "RxPath: Failed to consume stitched %{public}s packet (%zu bytes, kr=0x%08x)",
-                                     ctxLabel,
-                                     stitchedInfo->totalLength,
-                                     consumeKr);
-                        } else {
-                            ASFW_LOG_V2(Async,
-                                        "AR Response: stitched packet across buffer boundary (%zu bytes)",
-                                        stitchedInfo->totalLength);
-                            consumedStitchedPacket = true;
-                        }
-                    }
-                }
-                break;
-            }
-
-            ++packetsFound;
-            ProcessReceivedPacket(ctxType, *packetInfo, busResetCapture);
-            offset += packetInfo->totalLength;
-        }
-
-        if (consumedStitchedPacket) {
-            continue;
-        }
-
-        ASFW_LOG_V2(Async,
-                    "✅ RxPath AR/RSP: Processed %zu NEW bytes from buffer[%zu] "
-                    "(offset %zu→%zu, total=%zu) - leaving descriptor owned by hardware",
-                    newDataSize,
-                    info.descriptorIndex,
-                    startOffset,
-                    offset,
-                    bufferSize);
-        if (!committedBeforeBoundaryRetry) {
-            commitConsumed(info.descriptorIndex, offset);
-        }
-        if (offset == startOffset && startOffset < bufferSize) {
-            ASFW_LOG_V1(Async,
-                        "AR Response: parser made no progress in buffer[%zu] at offset %zu/%zu; "
-                        "preserving tail until hardware appends more bytes",
-                        info.descriptorIndex,
-                        startOffset,
-                        bufferSize);
-        }
-        // AR response traffic has proven to be stable when we keep the descriptor live
-        // and rely on BufferRing::Dequeue() to auto-advance once the next buffer gains
-        // data. Recycling here immediately after each response packet caused `no9` to
-        // regress into global Config ROM read timeouts even though QRresp packets were
-        // still present on the wire.
-    }
-
-    ASFW_LOG_V2(Async, "RxPath: Processed %u packets in %u buffers from %{public}s",
-                packetsFound, buffersProcessed, ctxLabel);
-
-    if (buffersProcessed == 0 && packetsFound == 0) {
+    if (stats.buffersProcessed == 0 && stats.packetsFound == 0) {
         ASFW_LOG_V3(Async, "AR Response: No packets read for this interrupt");
-        DumpEmptyResponseBuffer(*ctx);
+        DumpEmptyResponseBuffer(arResponseContext_);
     }
 }
 

--- a/ASFWDriver/Async/Rx/RxPath.hpp
+++ b/ASFWDriver/Async/Rx/RxPath.hpp
@@ -10,7 +10,6 @@
 #include "ARPacketParser.hpp"
 #include "../../Hardware/OHCIEventCodes.hpp"
 #include "../../Bus/GenerationTracker.hpp"
-#include <memory>
 
 namespace ASFW::Async::Rx {
 
@@ -60,8 +59,8 @@ private:
     ASFW::Async::Bus::GenerationTracker& generationTracker_;
     PacketRouter& packetRouter_;
 
-    // RxPath owns the parser.
-    std::unique_ptr<ARPacketParser> packetParser_;
+    // Lifetime count of dequeued AR request buffers, drives the [ARReq] heartbeat.
+    uint64_t requestBuffersSeen_ = 0;
 
     // Handle synthetic / general PHY packets coming via PacketRouter
     void HandlePhyRequestPacket(const ARPacketView& view);

--- a/ASFWDriver/Async/Track/TransactionCompletionHandler.hpp
+++ b/ASFWDriver/Async/Track/TransactionCompletionHandler.hpp
@@ -80,9 +80,22 @@ public:
         }
 
         // AT Response context completions correspond to WrResp acks we send back
-        // to devices. They are not tracked as transactions; skip quietly.
+        // to devices. They are not tracked as transactions; skip quietly — but a
+        // response the device never received (evt_timeout = expired before
+        // transmit, busy = device didn't take it) leaves the requester's split
+        // transaction dangling. LS-9000 firmware wedges its execution engine on
+        // exactly that, so surface it at default level.
         if (comp.isResponseContext) {
-            ASFW_LOG_V3(Async, "OnATCompletion: Ignoring AT Response completion (tLabel=%u)", comp.tLabel);
+            if (comp.eventCode != OHCIEventCode::kAckComplete &&
+                comp.eventCode != OHCIEventCode::kAckPending) {
+                ASFW_LOG(Async,
+                         "AT-resp DROPPED: tLabel=%u event=0x%02X (%{public}s) ts=%u",
+                         comp.tLabel, static_cast<uint8_t>(comp.eventCode),
+                         ToString(comp.eventCode), comp.timeStamp);
+            } else {
+                ASFW_LOG_V3(Async, "OnATCompletion: Ignoring AT Response completion (tLabel=%u)",
+                            comp.tLabel);
+            }
             return;
         }
 

--- a/ASFWDriver/Async/Tx/DescriptorBuilder.cpp
+++ b/ASFWDriver/Async/Tx/DescriptorBuilder.cpp
@@ -136,7 +136,8 @@ DescriptorBuilder::DescriptorChain DescriptorBuilder::BuildTransactionChain(cons
                                                                             std::size_t headerSize, // NOLINT(bugprone-easily-swappable-parameters)
                                                                             uint64_t payloadDeviceAddress,
                                                                             std::size_t payloadSize,
-                                                                            bool needsFlush) {
+                                                                            bool needsFlush,
+                                                                            uint16_t atTimeStamp) {
     DescriptorChain chain{};
     chain.needsFlush = needsFlush;  // Set Apple offset +40 pattern flag
 
@@ -249,6 +250,9 @@ DescriptorBuilder::DescriptorChain DescriptorBuilder::BuildTransactionChain(cons
 
         // Publish non-control fields first, then release fence before setting control
         immDesc->common.branchWord = 0;           // EOL indicated by branchWord=0
+        // Split-timeout deadline for AT-response packets (Linux ohci.c:1209);
+        // hardware overwrites statusWord on completion.
+        immDesc->common.timeStamp = atTimeStamp;
         std::atomic_thread_fence(std::memory_order_release);
 
         // Configure descriptor control word (ping=false for standard async requests)
@@ -491,6 +495,9 @@ DescriptorBuilder::DescriptorChain DescriptorBuilder::BuildTransactionChain(cons
     // OUTPUT_MORE relies on physical contiguity; branchWord is ignored per OHCI §7.1.
     // Keep b=00 and a zero branchWord to match spec.
     headerImmDesc->common.branchWord = 0;
+    // Split-timeout deadline for AT-response packets goes in the FIRST
+    // descriptor of the chain (Linux ohci.c:1209).
+    headerImmDesc->common.timeStamp = atTimeStamp;
 
     std::atomic_thread_fence(std::memory_order_release);
 

--- a/ASFWDriver/Async/Tx/DescriptorBuilder.hpp
+++ b/ASFWDriver/Async/Tx/DescriptorBuilder.hpp
@@ -80,11 +80,18 @@ public:
     DescriptorBuilder(DescriptorRing& ring, DMAMemoryManager& dmaManager);
     ~DescriptorBuilder() = default;
 
+    // atTimeStamp: split-timeout deadline written into the FIRST descriptor's
+    // timeStamp field. The AT response context compares it against cycleTimer
+    // and retires expired packets with evt_timeout WITHOUT transmitting — so
+    // response packets MUST carry a real deadline (Linux ohci.c:1209
+    // d[0].res_count = packet->timestamp). Request contexts ignore the field;
+    // 0 is fine there.
     [[nodiscard]] DescriptorChain BuildTransactionChain(const uint8_t* headerData,
                                                         std::size_t headerSize,
                                                         uint64_t payloadDeviceAddress,
                                                         std::size_t payloadSize,
-                                                        bool needsFlush = false);
+                                                        bool needsFlush = false,
+                                                        uint16_t atTimeStamp = 0);
 
     void LinkChain(DescriptorChain& chainToModify,
                    uint64_t nextChainIOVA,

--- a/ASFWDriver/Async/Tx/ResponseSender.cpp
+++ b/ASFWDriver/Async/Tx/ResponseSender.cpp
@@ -51,6 +51,22 @@ uint32_t BuildQ1(uint16_t destID, ResponseCode rcode) {
            (static_cast<uint32_t>(static_cast<uint8_t>(rcode) & 0x0F) << 12);
 }
 
+// Split-timeout deadline for the response: request arrival timestamp
+// (3-bit seconds, 13-bit cycle) plus the split timeout. The AT response
+// context drops packets whose deadline has passed (evt_timeout) without
+// transmitting them, so this MUST be a real future time — a zero timeStamp
+// is "expired" for most of the 8-second wrap window. Mirrors Linux
+// compute_split_timeout_timestamp (core-transaction.c) with the same
+// 2-second default (core-card.c DEFAULT_SPLIT_TIMEOUT).
+constexpr uint32_t kSplitTimeoutCycles = 2 * 8000;
+
+uint16_t ComputeResponseDeadline(uint16_t requestTimeStamp) {
+    const uint32_t cycles = kSplitTimeoutCycles + (requestTimeStamp & 0x1FFFu);
+    uint32_t deadline = requestTimeStamp & ~0x1FFFu;
+    deadline += (cycles / 8000u) << 13;
+    deadline |= cycles % 8000u;
+    return static_cast<uint16_t>(deadline);
+}
 
 } // namespace
 
@@ -101,7 +117,8 @@ void ResponseSender::SendResponse(const ARPacketView& request,
         headerBytes,
         payloadDeviceAddress,
         payloadLength,
-        /*needsFlush*/ false);
+        /*needsFlush*/ false,
+        ComputeResponseDeadline(static_cast<uint16_t>(request.timeStamp)));
     if (chain.Empty()) {
         ASFW_LOG_ERROR(
             Async,

--- a/ASFWDriver/Bus/BusResetCoordinator.hpp
+++ b/ASFWDriver/Bus/BusResetCoordinator.hpp
@@ -195,8 +195,9 @@ class BusResetCoordinator {
      */
     void EscalateDiscoveryDelay();
 
-    /// Request a user-initiated bus reset (short or long).
-    void RequestUserReset(bool shortReset);
+    /// Request a manually initiated bus reset (short or long). `reason` is a
+    /// static string surfaced in the reset-cycle logs.
+    void RequestUserReset(bool shortReset, const char* reason = "UserClient-initiated");
 
     /// Request a RoleCoordinator-initiated PHY config + bus reset.
     void RequestRolePolicyReset(uint8_t targetRoot, bool longReset,

--- a/ASFWDriver/Bus/BusResetCoordinatorActions.cpp
+++ b/ASFWDriver/Bus/BusResetCoordinatorActions.cpp
@@ -608,12 +608,12 @@ void BusResetCoordinator::MaybeRecoverMissingManualResetIrq(uint32_t manualEpoch
                           "Manual reset watchdog recovery", std::nullopt});
 }
 
-void BusResetCoordinator::RequestUserReset(bool shortReset) {
+void BusResetCoordinator::RequestUserReset(bool shortReset, const char* reason) {
     ++manualResetEpoch_;
     manualRecoveryResetAttempts_ = 0;
     RequestSoftwareReset({ResetRequestKind::ManualBusManager,
                           shortReset ? ResetFlavor::Short : ResetFlavor::Long, std::nullopt,
-                          "UserClient-initiated", std::nullopt});
+                          reason, std::nullopt});
 }
 
 void BusResetCoordinator::RequestRolePolicyReset(uint8_t targetRoot, bool longReset,

--- a/ASFWDriver/Shared/Rings/BufferRing.cpp
+++ b/ASFWDriver/Shared/Rings/BufferRing.cpp
@@ -217,6 +217,35 @@ std::optional<FilledBufferInfo> BufferRing::Dequeue() noexcept {
     // for the next interrupt without letting the receive path hot-spin on a
     // parser stall inside the same buffer.
     if (total_bytes_in_buffer <= last_observed_total_bytes_) {
+        // Exception: a FULL head buffer can never grow, so a preserved tail here
+        // is a cross-buffer straddle whose continuation lands in the NEXT buffer.
+        // OHCI may complete the two descriptors of a straddling packet in either
+        // order across interrupts (Linux ar_search_last_active_buffer makes the
+        // same allowance), so once the successor shows data, re-present the tail
+        // to let the caller retry the stitch. The caller must stop dequeuing when
+        // it cannot make progress, or this would spin within one pass.
+        if (total_bytes_in_buffer == reqCount) {
+            const size_t successor_index = (index + 1) % bufferCount_;
+            auto& successor_desc = descriptors_[successor_index];
+            if (dma_) {
+                dma_->FetchFromDevice(&successor_desc, sizeof(successor_desc));
+            }
+            if (DescriptorBytesFilled(successor_desc) > 0) {
+                uint8_t* fullBufferAddr = GetBufferAddress(index);
+                if (fullBufferAddr) {
+                    if (dma_) {
+                        dma_->FetchFromDevice(fullBufferAddr + last_dequeued_bytes_,
+                                              total_bytes_in_buffer - last_dequeued_bytes_);
+                    }
+                    return FilledBufferInfo{
+                        .virtualAddress = fullBufferAddr,
+                        .startOffset = last_dequeued_bytes_,
+                        .bytesFilled = total_bytes_in_buffer,
+                        .descriptorIndex = index
+                    };
+                }
+            }
+        }
         return std::nullopt;
     }
 

--- a/tests/async/ARStreamProcessorTests.cpp
+++ b/tests/async/ARStreamProcessorTests.cpp
@@ -1,0 +1,416 @@
+// ARStreamProcessorTests.cpp
+//
+// Host tests for the shared AR bufferFill stream walker (ARStreamProcessor.hpp)
+// against a real BufferRing. Regression coverage for the CoolScan wedge root
+// cause: inbound packets straddling a buffer boundary were silently destroyed
+// by the AR request path (whole-buffer commit without stitching), so the
+// target's status-block write vanished and its split transaction dangled.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <initializer_list>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include "ASFWDriver/Async/Rx/ARStreamProcessor.hpp"
+#include "ASFWDriver/Hardware/OHCIDescriptors.hpp"
+#include "ASFWDriver/Shared/Rings/BufferRing.hpp"
+#include "ASFWDriver/Testing/FakeDMAMemory.hpp"
+
+namespace ASFW::Testing {
+
+namespace {
+
+using Async::ARPacketParser;
+using Async::Rx::ProcessARStream;
+
+// Thin adapter exposing the ring surface the walker needs (mirrors the
+// delegation in ARContextBase).
+struct RingContext {
+    Shared::BufferRing& ring;
+
+    std::optional<Shared::FilledBufferInfo> Dequeue() { return ring.Dequeue(); }
+    kern_return_t Recycle(size_t index) { return ring.Recycle(index); }
+    kern_return_t CommitConsumed(size_t index, size_t bytes) {
+        return ring.CommitConsumed(index, bytes);
+    }
+    size_t CopyReadableBytes(std::span<uint8_t> destination) {
+        return ring.CopyReadableBytes(destination);
+    }
+    kern_return_t ConsumeReadableBytes(size_t bytes) {
+        return ring.ConsumeReadableBytes(bytes);
+    }
+};
+
+struct DispatchedPacket {
+    uint8_t tCode;
+    size_t headerLength;
+    size_t dataLength;
+    size_t totalLength;
+    std::vector<uint8_t> payload;
+};
+
+void AppendHostWordLE(std::vector<uint8_t>& bytes, uint32_t word) {
+    bytes.push_back(static_cast<uint8_t>(word & 0xFF));
+    bytes.push_back(static_cast<uint8_t>((word >> 8) & 0xFF));
+    bytes.push_back(static_cast<uint8_t>((word >> 16) & 0xFF));
+    bytes.push_back(static_cast<uint8_t>((word >> 24) & 0xFF));
+}
+
+// Block write request (tCode 0x1) as OHCI AR DMA memory: 16-byte header,
+// quadlet-padded payload, 4-byte trailer. Mirrors an SBP-2 status-block write.
+std::vector<uint8_t> MakeWriteBlockPacket(uint8_t tLabel,
+                                          std::initializer_list<uint32_t> payloadWords,
+                                          uint32_t trailer = 0x00001100u) {
+    std::vector<uint8_t> bytes;
+    const uint32_t dataLength = static_cast<uint32_t>(payloadWords.size() * 4);
+    AppendHostWordLE(bytes, (0xFFC1u << 16) | (static_cast<uint32_t>(tLabel) << 10) | (0x1u << 4));
+    AppendHostWordLE(bytes, (0xFFC0u << 16) | 0x0010u);
+    AppendHostWordLE(bytes, 0x00100090u);
+    AppendHostWordLE(bytes, dataLength << 16);
+    for (uint32_t word : payloadWords) {
+        AppendHostWordLE(bytes, word);
+    }
+    AppendHostWordLE(bytes, trailer);
+    return bytes;
+}
+
+class ARStreamProcessorTest : public ::testing::Test {
+protected:
+    static constexpr size_t kNumBuffers = 8;
+    static constexpr size_t kBufferSize = 200;
+
+    FakeDMAMemory dma_{256 * 1024};
+    Shared::BufferRing ring_{};
+    std::vector<DispatchedPacket> dispatched_;
+    uint64_t heartbeat_ = 0;
+
+    void SetUp() override {
+        auto descRegion = dma_.AllocateRegion(kNumBuffers * sizeof(Async::HW::OHCIDescriptor));
+        ASSERT_TRUE(descRegion.has_value());
+        auto bufRegion = dma_.AllocateRegion(kNumBuffers * kBufferSize);
+        ASSERT_TRUE(bufRegion.has_value());
+
+        auto* descs = reinterpret_cast<Async::HW::OHCIDescriptor*>(descRegion->virtualBase);
+        ASSERT_TRUE(ring_.Initialize({descs, kNumBuffers},
+                                     {bufRegion->virtualBase, kNumBuffers * kBufferSize},
+                                     kNumBuffers, kBufferSize));
+        ring_.BindDma(&dma_);
+        ASSERT_TRUE(ring_.Finalize(descRegion->deviceBase, bufRegion->deviceBase));
+    }
+
+    // Write bytes into one buffer and mark its filled count (simulates DMA
+    // completing into that descriptor).
+    void FillBuffer(size_t index, std::span<const uint8_t> bytes) {
+        ASSERT_LE(bytes.size(), kBufferSize);
+        std::memcpy(ring_.GetBufferAddress(index), bytes.data(), bytes.size());
+        auto* desc = ring_.GetDescriptor(index);
+        ASSERT_NE(desc, nullptr);
+        Async::HW::AR_init_status(*desc, static_cast<uint16_t>(kBufferSize - bytes.size()));
+    }
+
+    // Lay a contiguous byte stream into the ring the way bufferFill DMA would:
+    // fill each buffer to the brim before moving to the next, and mark filled
+    // byte counts in the descriptors' resCount.
+    void FillStream(std::span<const uint8_t> stream) {
+        ASSERT_LE(stream.size(), kNumBuffers * kBufferSize);
+        size_t remaining = stream.size();
+        size_t offset = 0;
+        for (size_t i = 0; i < kNumBuffers && remaining > 0; ++i) {
+            const size_t chunk = std::min(remaining, kBufferSize);
+            std::memcpy(ring_.GetBufferAddress(i), stream.data() + offset, chunk);
+            auto* desc = ring_.GetDescriptor(i);
+            ASSERT_NE(desc, nullptr);
+            Async::HW::AR_init_status(*desc, static_cast<uint16_t>(kBufferSize - chunk));
+            offset += chunk;
+            remaining -= chunk;
+        }
+    }
+
+    Async::Rx::ARStreamStats Run() {
+        RingContext ctx{ring_};
+        return ProcessARStream(
+            ctx,
+            "ARTest",
+            &heartbeat_,
+            [](uint32_t, const Shared::FilledBufferInfo&) {},
+            [this](const ARPacketParser::PacketInfo& info) {
+                DispatchedPacket packet{};
+                packet.tCode = info.tCode;
+                packet.headerLength = info.headerLength;
+                packet.dataLength = info.dataLength;
+                packet.totalLength = info.totalLength;
+                packet.payload.assign(info.packetStart + info.headerLength,
+                                      info.packetStart + info.headerLength + info.dataLength);
+                dispatched_.push_back(std::move(packet));
+            });
+    }
+};
+
+TEST_F(ARStreamProcessorTest, DispatchesMultiplePacketsWithinOneBuffer) {
+    std::vector<uint8_t> stream;
+    const auto first = MakeWriteBlockPacket(1, {0x11111111u, 0x22222222u});
+    const auto second = MakeWriteBlockPacket(2, {0x33333333u});
+    stream.insert(stream.end(), first.begin(), first.end());
+    stream.insert(stream.end(), second.begin(), second.end());
+    FillStream(stream);
+
+    const auto stats = Run();
+
+    EXPECT_EQ(stats.packetsFound, 2u);
+    ASSERT_EQ(dispatched_.size(), 2u);
+    EXPECT_EQ(dispatched_[0].dataLength, 8u);
+    EXPECT_EQ(dispatched_[1].dataLength, 4u);
+}
+
+TEST_F(ARStreamProcessorTest, StitchesPacketStraddlingBufferBoundary) {
+    // Fill buffer 0 up to 8 bytes before the end, then append a 28-byte packet:
+    // 8 bytes land in buffer 0 (making it full), 20 bytes in buffer 1.
+    std::vector<uint8_t> stream;
+    while (stream.size() + 28 <= kBufferSize - 8) {
+        const auto filler = MakeWriteBlockPacket(1, {0xAAAAAAAAu, 0xBBBBBBBBu});
+        ASSERT_EQ(filler.size(), 28u);
+        stream.insert(stream.end(), filler.begin(), filler.end());
+    }
+    const size_t fillerCount = stream.size() / 28;
+    ASSERT_EQ(kBufferSize - stream.size(), 32u);
+    const auto pad = MakeWriteBlockPacket(2, {0xCCCCCCCCu});  // 24 bytes
+    stream.insert(stream.end(), pad.begin(), pad.end());
+
+    const auto straddler = MakeWriteBlockPacket(3, {0xDEADBEEFu, 0xFEEDFACEu});  // 28 bytes
+    stream.insert(stream.end(), straddler.begin(), straddler.end());
+    const auto after = MakeWriteBlockPacket(4, {0x44444444u});
+    stream.insert(stream.end(), after.begin(), after.end());
+    FillStream(stream);
+
+    const auto stats = Run();
+
+    // Every packet must survive the boundary: fillers + pad + straddler + after.
+    EXPECT_EQ(stats.packetsFound, fillerCount + 3);
+    ASSERT_EQ(dispatched_.size(), fillerCount + 3);
+    const auto& stitched = dispatched_[fillerCount + 1];
+    EXPECT_EQ(stitched.dataLength, 8u);
+    ASSERT_EQ(stitched.payload.size(), 8u);
+    EXPECT_EQ(stitched.payload[0], 0xEFu);  // 0xDEADBEEF little-endian in DMA memory
+    EXPECT_EQ(stitched.payload[3], 0xDEu);
+    EXPECT_EQ(dispatched_[fillerCount + 2].dataLength, 4u);
+}
+
+TEST_F(ARStreamProcessorTest, StitchesWhenOnlyTrailerCrossesBoundary) {
+    // Header+payload of the straddler end exactly at the buffer boundary; only
+    // the 4-byte trailer lands in the next buffer. The old parser framed this
+    // as a complete trailer-less packet, desyncing the stream at the orphan
+    // trailer — the wedge signature.
+    std::vector<uint8_t> stream;
+    constexpr size_t kFillerCount = 5;
+    for (size_t i = 0; i < kFillerCount; ++i) {
+        const auto filler = MakeWriteBlockPacket(1, {0xAAAAAAAAu, 0xBBBBBBBBu});
+        stream.insert(stream.end(), filler.begin(), filler.end());
+    }
+    ASSERT_EQ(stream.size(), 140u);
+    // 16-byte header + 44-byte payload + 4-byte trailer = 64 bytes; header+payload
+    // (60 bytes) end exactly at the 200-byte buffer boundary.
+    const auto straddler = MakeWriteBlockPacket(5, {0x11111111u, 0x22222222u,
+                                                    0x33333333u, 0x44444444u,
+                                                    0x55555555u, 0x66666666u,
+                                                    0x77777777u, 0x88888888u,
+                                                    0x12121212u, 0x34343434u,
+                                                    0x56565656u});
+    ASSERT_EQ(straddler.size(), 64u);
+    stream.insert(stream.end(), straddler.begin(), straddler.end() - 4);
+    ASSERT_EQ(stream.size(), kBufferSize);
+    // Trailer goes into the next buffer, followed by one more packet.
+    stream.insert(stream.end(), straddler.end() - 4, straddler.end());
+    const auto after = MakeWriteBlockPacket(6, {0x99999999u});
+    stream.insert(stream.end(), after.begin(), after.end());
+    FillStream(stream);
+
+    const auto stats = Run();
+
+    EXPECT_EQ(stats.packetsFound, kFillerCount + 2);
+    ASSERT_EQ(dispatched_.size(), kFillerCount + 2);
+    EXPECT_EQ(dispatched_[kFillerCount].dataLength, 44u);
+    EXPECT_EQ(dispatched_[kFillerCount].totalLength, 64u);
+    EXPECT_EQ(dispatched_[kFillerCount + 1].dataLength, 4u);
+}
+
+TEST_F(ARStreamProcessorTest, FragmentWithoutTailIsPreservedNotDispatched) {
+    // Buffer 0 completely full, ending in a fragment whose tail has not been
+    // DMA'd yet. Nothing may be dispatched for the fragment and the parsed
+    // prefix must be committed so the fragment stays readable for stitching.
+    std::vector<uint8_t> stream;
+    while (stream.size() + 28 <= kBufferSize - 8) {
+        const auto filler = MakeWriteBlockPacket(1, {0xAAAAAAAAu, 0xBBBBBBBBu});
+        stream.insert(stream.end(), filler.begin(), filler.end());
+    }
+    const size_t fillerCount = stream.size() / 28;
+    const auto pad = MakeWriteBlockPacket(2, {0xCCCCCCCCu});
+    stream.insert(stream.end(), pad.begin(), pad.end());
+    const auto straddler = MakeWriteBlockPacket(3, {0xDEADBEEFu, 0xFEEDFACEu});
+    // Only the first 8 bytes of the straddler arrive (buffer 0 becomes full).
+    stream.insert(stream.end(), straddler.begin(), straddler.begin() + 8);
+    ASSERT_EQ(stream.size(), kBufferSize);
+    FillStream(stream);
+
+    const auto stats = Run();
+
+    EXPECT_EQ(stats.packetsFound, fillerCount + 1);
+    EXPECT_EQ(dispatched_.size(), fillerCount + 1);
+}
+
+TEST_F(ARStreamProcessorTest, StitchesAcrossInterruptPassesWhenTailArrivesLater) {
+    // The cross-pass straddle: buffer 0 completes FULL, ending in a fragment,
+    // but the continuation has not been DMA'd into buffer 1 yet (OHCI may
+    // complete the two descriptors of a straddling packet in either order —
+    // Linux ar_search_last_active_buffer makes the same allowance). The first
+    // pass must preserve the fragment; once buffer 1 gains the tail, the next
+    // pass must re-present the full head, stitch, dispatch exactly once, and
+    // advance the ring past the straddler.
+    std::vector<uint8_t> phase1;
+    constexpr size_t kFillerCount = 5;
+    for (size_t i = 0; i < kFillerCount; ++i) {
+        const auto filler = MakeWriteBlockPacket(1, {0xAAAAAAAAu, 0xBBBBBBBBu});
+        phase1.insert(phase1.end(), filler.begin(), filler.end());
+    }
+    const auto pad = MakeWriteBlockPacket(2, {0xCCCCCCCCu});  // 24 bytes → 164 total
+    phase1.insert(phase1.end(), pad.begin(), pad.end());
+    const auto straddler = MakeWriteBlockPacket(3, {0xDEADBEEFu, 0xFEEDFACEu,
+                                                    0x01020304u, 0x05060708u,
+                                                    0x090A0B0Cu});  // 16+20+4 = 40 bytes
+    ASSERT_EQ(straddler.size(), 40u);
+    // First 36 straddler bytes make buffer 0 exactly full (164 + 36 = 200).
+    phase1.insert(phase1.end(), straddler.begin(), straddler.begin() + 36);
+    ASSERT_EQ(phase1.size(), kBufferSize);
+    FillBuffer(0, phase1);
+
+    const auto pass1 = Run();
+    EXPECT_EQ(pass1.packetsFound, kFillerCount + 1);
+    EXPECT_EQ(dispatched_.size(), kFillerCount + 1);
+
+    // Tail (4 bytes) plus a following packet arrive in buffer 1.
+    std::vector<uint8_t> phase2(straddler.begin() + 36, straddler.end());
+    const auto after = MakeWriteBlockPacket(4, {0x44444444u});
+    phase2.insert(phase2.end(), after.begin(), after.end());
+    FillBuffer(1, phase2);
+
+    const auto pass2 = Run();
+    EXPECT_EQ(pass2.packetsFound, 2u);
+    ASSERT_EQ(dispatched_.size(), kFillerCount + 3);
+    const auto& stitched = dispatched_[kFillerCount + 1];
+    EXPECT_EQ(stitched.totalLength, 40u);
+    ASSERT_EQ(stitched.payload.size(), 20u);
+    EXPECT_EQ(stitched.payload[0], 0xEFu);
+    EXPECT_EQ(dispatched_[kFillerCount + 2].dataLength, 4u);
+
+    // The ring must have advanced past the straddler: a third pass sees nothing.
+    const auto pass3 = Run();
+    EXPECT_EQ(pass3.packetsFound, 0u);
+    EXPECT_EQ(dispatched_.size(), kFillerCount + 3);
+}
+
+TEST_F(ARStreamProcessorTest, OversizedDataLengthIsDroppedNotTreatedAsFragment) {
+    // A corrupt block header declaring data_length > 4096 can never complete —
+    // it must take the garbage path (drop remainder, realign at next buffer),
+    // not be preserved as a stitchable fragment (which would stall the ring).
+    // Mirrors Linux ohci.c: payload_length > MAX_ASYNC_PAYLOAD → context abort.
+    std::vector<uint8_t> stream;
+    const auto good = MakeWriteBlockPacket(1, {0x11111111u});
+    stream.insert(stream.end(), good.begin(), good.end());
+    AppendHostWordLE(stream, (0xFFC1u << 16) | (0x7u << 10) | (0x1u << 4));  // write block
+    AppendHostWordLE(stream, (0xFFC0u << 16) | 0x0010u);
+    AppendHostWordLE(stream, 0x00100090u);
+    AppendHostWordLE(stream, 0x2000u << 16);  // data_length = 8192 > max 4096
+    FillStream(stream);
+
+    const auto pass1 = Run();
+    EXPECT_EQ(pass1.packetsFound, 1u);
+
+    // Stream continues normally in the next buffer.
+    std::vector<uint8_t> next;
+    const auto after = MakeWriteBlockPacket(2, {0x22222222u});
+    next.insert(next.end(), after.begin(), after.end());
+    FillBuffer(1, next);
+
+    // Buffer 0 was only partially filled and then dropped-to-end; hardware
+    // moving on to buffer 1 is only visible to Dequeue() once buffer 0 is
+    // drained — which the garbage-drop commit guarantees.
+    const auto pass2 = Run();
+    EXPECT_EQ(pass2.packetsFound, 1u);
+    ASSERT_EQ(dispatched_.size(), 2u);
+    EXPECT_EQ(dispatched_[1].dataLength, 4u);
+}
+
+TEST_F(ARStreamProcessorTest, GarbageHeadDropsBufferRemainderAndRealignsAtNextBuffer) {
+    // Good packet, then a head with invalid tCode 0xC — framing is lost, the
+    // remainder of buffer 0 must be dropped loudly, and the stream must realign
+    // at buffer 1 where a fresh packet begins.
+    std::vector<uint8_t> stream;
+    const auto good = MakeWriteBlockPacket(1, {0x11111111u});
+    stream.insert(stream.end(), good.begin(), good.end());
+    while (stream.size() < kBufferSize) {
+        AppendHostWordLE(stream, 0x000000C0u);  // tCode nibble = 0xC
+    }
+    const auto next = MakeWriteBlockPacket(2, {0x22222222u});
+    stream.insert(stream.end(), next.begin(), next.end());
+    FillStream(stream);
+
+    const auto stats = Run();
+
+    EXPECT_EQ(stats.packetsFound, 2u);
+    ASSERT_EQ(dispatched_.size(), 2u);
+    EXPECT_EQ(dispatched_[1].dataLength, 4u);
+}
+
+TEST_F(ARStreamProcessorTest, AllZeroHeadIsDroppedAsGarbage) {
+    std::vector<uint8_t> stream;
+    const auto good = MakeWriteBlockPacket(1, {0x11111111u});
+    stream.insert(stream.end(), good.begin(), good.end());
+    for (int i = 0; i < 8; ++i) {
+        AppendHostWordLE(stream, 0x00000000u);
+    }
+    FillStream(stream);
+
+    const auto stats = Run();
+
+    EXPECT_EQ(stats.packetsFound, 1u);
+    EXPECT_EQ(dispatched_.size(), 1u);
+}
+
+TEST_F(ARStreamProcessorTest, WedgeRegressionSustainedCommandStreamLosesNoPackets) {
+    // The CoolScan failure shape: a long run of small status-write-sized
+    // packets crossing several buffer boundaries. Before the stitching fix,
+    // exactly one packet vanished per boundary crossing (v46 run: command #83).
+    std::vector<uint8_t> stream;
+    size_t packetCount = 0;
+    while (true) {
+        const auto packet = MakeWriteBlockPacket(static_cast<uint8_t>(packetCount & 0x3F),
+                                                 {static_cast<uint32_t>(packetCount),
+                                                  0x5B500000u});
+        if (stream.size() + packet.size() > (kNumBuffers - 1) * kBufferSize) {
+            break;
+        }
+        stream.insert(stream.end(), packet.begin(), packet.end());
+        ++packetCount;
+    }
+    ASSERT_GT(packetCount, 40u);  // spans several 200-byte buffers
+    FillStream(stream);
+
+    const auto stats = Run();
+
+    EXPECT_EQ(stats.packetsFound, packetCount);
+    ASSERT_EQ(dispatched_.size(), packetCount);
+    for (size_t i = 0; i < packetCount; ++i) {
+        ASSERT_EQ(dispatched_[i].payload.size(), 8u);
+        uint32_t sequence = 0;
+        std::memcpy(&sequence, dispatched_[i].payload.data(), 4);
+        EXPECT_EQ(sequence, static_cast<uint32_t>(i)) << "packet " << i << " lost or reordered";
+    }
+}
+
+} // namespace
+
+} // namespace ASFW::Testing

--- a/tests/async/AsyncPacketSerDesLinuxCompatTests.cpp
+++ b/tests/async/AsyncPacketSerDesLinuxCompatTests.cpp
@@ -236,7 +236,7 @@ TEST(AsyncPacketSerDesLinuxCompat, ParseReadQuadletResponseMatchesLinuxVector) {
         EXPECT_EQ(view.payload.size(), 0u);
         return ResponseCode::NoResponse;
     });
-    router.RoutePacket(ARContextType::Response, buffer, /*generation=*/0);
+    router.RouteParsedPacket(ARContextType::Response, *info, /*generation=*/0);
     EXPECT_TRUE(handled);
 }
 
@@ -271,16 +271,19 @@ TEST(AsyncPacketSerDesLinuxCompat, ParseReadBlockResponseComputesPayloadLength) 
         EXPECT_EQ(view.payload.size(), 0x20u);
         return ResponseCode::NoResponse;
     });
-    router.RoutePacket(ARContextType::Response, buffer, /*generation=*/0);
+    router.RouteParsedPacket(ARContextType::Response, *info, /*generation=*/0);
     EXPECT_TRUE(handled);
 }
 
 TEST(AsyncPacketSerDesLinuxCompat, ParseLockResponsePreservesExtendedTCodeLength) {
+    // Q3 declares data_length=4, so the 4-byte lock old-value payload must be
+    // present before the trailer (the parser requires the full packet unit).
     const auto packet = MakeARBufferFromOHCIWords({
         0xFFC12DB0u,
         0xFFC00000u,
         0x00000000u,
         0x00040002u,
+        0x00000001u,
     });
     const auto buffer = std::span<const uint8_t>(packet.data(), packet.size());
     const auto info = ARPacketParser::ParseNext(buffer, 0);
@@ -302,7 +305,7 @@ TEST(AsyncPacketSerDesLinuxCompat, ParseLockResponsePreservesExtendedTCodeLength
         EXPECT_EQ(view.payload.size(), 0x4u);
         return ResponseCode::NoResponse;
     });
-    router.RoutePacket(ARContextType::Response, buffer, /*generation=*/0);
+    router.RouteParsedPacket(ARContextType::Response, *info, /*generation=*/0);
     EXPECT_TRUE(handled);
 }
 
@@ -341,18 +344,22 @@ TEST(AsyncPacketSerDesLinuxCompat, RequestPayloadIsCopiedIntoAlignedScratchBefor
         return ResponseCode::Complete;
     });
 
-    router.RoutePacket(ARContextType::Request, buffer, /*generation=*/0);
+    const auto info = ARPacketParser::ParseNext(buffer, 0);
+    ASSERT_TRUE(info.has_value());
+    router.RouteParsedPacket(ARContextType::Request, *info, /*generation=*/0);
     EXPECT_TRUE(handled);
 }
 
 TEST(AsyncPacketSerDesLinuxCompat, ExtractTLabelUsesWireByteTwo) {
     // Read quadlet response packet as OHCI AR DMA memory: tLabel=48, tCode=6, rCode=0.
     // After the little-endian quadlet write, memory byte1 holds [tLabel:6][rt:2].
-    const std::array<uint8_t, 16> responseBytes{
+    // 16-byte header + mandatory 4-byte OHCI trailer.
+    const std::array<uint8_t, 20> responseBytes{
         0x60, 0xC2, 0x01, 0x60,
         0x00, 0x00, 0xC0, 0xFF,
         0x00, 0x00, 0x00, 0x00,
         0x04, 0x20, 0x8F, 0xE2,
+        0x00, 0x00, 0x11, 0x00,
     };
 
     PacketRouter router;
@@ -363,6 +370,8 @@ TEST(AsyncPacketSerDesLinuxCompat, ExtractTLabelUsesWireByteTwo) {
         return ResponseCode::NoResponse;
     });
     const auto responseBuffer = std::span<const uint8_t>(responseBytes.data(), responseBytes.size());
-    router.RoutePacket(ARContextType::Response, responseBuffer, /*generation=*/0);
+    const auto info = ARPacketParser::ParseNext(responseBuffer, 0);
+    ASSERT_TRUE(info.has_value());
+    router.RouteParsedPacket(ARContextType::Response, *info, /*generation=*/0);
     EXPECT_TRUE(handled);
 }

--- a/tests/async/CMakeLists.txt
+++ b/tests/async/CMakeLists.txt
@@ -76,6 +76,14 @@ add_async_test(BufferRingDMATests
     "${ASFW_DRIVER_DIR}/Common/BarrierUtils.cpp"
 )
 
+# AR Stream Processor Tests (bufferFill walker: boundary stitching, garbage policy)
+add_async_test(ARStreamProcessorTests
+    ARStreamProcessorTests.cpp
+    "${ASFW_DRIVER_DIR}/Shared/Rings/BufferRing.cpp"
+    "${ASFW_DRIVER_DIR}/Async/Rx/ARPacketParser.cpp"
+    "${ASFW_DRIVER_DIR}/Common/BarrierUtils.cpp"
+)
+
 # Label Allocator Tests
 add_async_test(LabelAllocatorTests
     LabelAllocatorTests.cpp


### PR DESCRIPTION
## Problem

The asynchronous **receive request** ring committed the whole 4160-byte DMA buffer per interrupt without stitching packets that straddle the buffer boundary. An inbound request spanning two AR buffers was silently destroyed, and its tail in the next buffer was misparsed as pseudo-packets — which the driver then answered with address-error responses to whatever node id the garbage decoded to. The AR **response** ring already stitched correctly; the asymmetry between the two rings was the defect.

Under sustained inbound traffic this is near-deterministic once ~4160 bytes have accumulated, and it corrupts the async stream for any device that pushes enough request traffic (observed wedging an SBP-2 target mid-transfer).

## Fix

Introduce a shared `ARStreamProcessor` used by **both** AR rings:

- commit only the bytes actually parsed (not the whole buffer),
- stitch a fragment across the buffer boundary by re-presenting the head buffer once its successor has data,
- drop an unparseable/garbage head loudly rather than replaying stale bytes — matching Linux `firewire-ohci`, which aborts an unparseable AR context instead of continuing.

`ParseNext` now returns a typed failure (`NeedMoreBytes` / `UnknownTCode` / `ZeroGarbage` / `OversizedPayload`) instead of silently swallowing a bad head, and oversized `data_length` is rejected (Linux `MAX_ASYNC_PAYLOAD` parity) so it can't masquerade as a fragment.

Also in this change:
- set the AT-response split-timeout deadline in the descriptor `timeStamp` (cross-checked against Linux `compute_split_timeout_timestamp`, incl. the 16-bit wrap) so OHCI stops retiring otherwise-valid responses as `evt_timeout`;
- minor `BufferRing` / bus-reset hardening.

## Testing

- New `ARStreamProcessorTests` (416 lines) cover fragment/stitch, cross-pass straddle, and garbage-head drop.
- Full host suite green (1203 tests).
- Verified on hardware end-to-end: a full high-resolution transfer that previously wedged at the buffer boundary now completes with 0 unclaimed / 0 dropped / 0 unparseable across ~42k stitched boundary crossings.

## References

Cross-validated against Linux `drivers/firewire/ohci.c` (AR context abort, `AR_WRAPAROUND_PAGES`) and `core-transaction.c` (split-timeout timestamp).
