### PR TITLE
feat(audio): PreSonus StudioLive 16.0.2 DICE profile (hardware-verified)

### DIFF
--- a/ASFWDriver/Audio/DriverKit/Config/DICE/DiceProfileRegistry.cpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/DiceProfileRegistry.cpp
@@ -8,6 +8,7 @@
 #include "Isoch/Profiles/FocusriteSaffireProfile.hpp"
 #include "Isoch/Profiles/GenericDiceProfile.hpp"
 #include "Isoch/Profiles/MidasVeniceProfile.hpp"
+#include "Isoch/Profiles/PreSonusStudioLiveProfile.hpp"
 
 namespace ASFW::Isoch::Audio::DICE {
 
@@ -15,11 +16,13 @@ namespace {
 Profiles::GenericDiceProfile gGenericProfile{};
 Profiles::FocusriteSaffireProfile gFocusriteProfile{};
 Profiles::MidasVeniceProfile gMidasVeniceProfile{};
+Profiles::PreSonusStudioLiveProfile gPreSonusStudioLiveProfile{};
 } // namespace
 
 DiceProfileRegistry::DiceProfileRegistry() noexcept {
     (void)RegisterProfile(&gFocusriteProfile);
     (void)RegisterProfile(&gMidasVeniceProfile);
+    (void)RegisterProfile(&gPreSonusStudioLiveProfile);
 }
 
 bool DiceProfileRegistry::RegisterProfile(const IDiceDeviceProfile* profile) noexcept {

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/PreSonusStudioLiveProfile.cpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/PreSonusStudioLiveProfile.cpp
@@ -1,0 +1,117 @@
+// PreSonusStudioLiveProfile.cpp
+// PreSonus StudioLive 16.0.2 FireWire profile (DICE/TCAT).
+//
+// StudioLive 16.0.2: 16-channel mixer with a 16-in/16-out FireWire interface.
+// Stream geometry captured live from the hardware (2026-07-08) via the DICE
+// register space at 48 kHz: a single isochronous stream per direction with
+// NB_AUDIO=16, NB_MIDI=1 (DBS = 17), S400. Clock capabilities register
+// (0x13000006) advertises 44.1/48 kHz only — no mid/high rate modes — so the
+// low-rate geometry below covers every rate the device supports.
+// Cross-checked with Linux snd-dice (fully generic DICE path, no PreSonus
+// StudioLive quirks) and libffado 2.5.0 (vendor 0x000a92, model 0x000013).
+
+#include "PreSonusStudioLiveProfile.hpp"
+
+namespace ASFW::Isoch::Audio::DICE::Profiles {
+
+namespace {
+
+constexpr uint32_t kPreSonusVendorId      = 0x000a92;
+constexpr uint32_t kStudioLive1602ModelId = 0x000013;
+
+constexpr uint32_t kPcmChannels = 16;
+constexpr uint32_t kMidiSlots   = 1;
+constexpr uint32_t kDbs         = kPcmChannels + kMidiSlots;
+
+void FillStreamConfig(DiceStreamConfig& out, DiceStreamDirection direction) noexcept {
+    out = DiceStreamConfig{};
+    out.direction    = direction;
+    out.sampleRate   = 48000;
+    out.streamMode   = Encoding::StreamMode::kBlocking;
+    out.sid          = 0;
+    out.framesPerDataPacket = 8;
+    out.fdf          = 0x02;
+    out.fmt          = 0x10;
+    out.pcmChannels  = kPcmChannels;
+    out.midiSlots    = kMidiSlots;
+    out.dbs          = kDbs;
+}
+
+} // namespace
+
+const char* PreSonusStudioLiveProfile::Name() const noexcept {
+    return "PreSonus StudioLive 16.0.2 (DICE)";
+}
+
+bool PreSonusStudioLiveProfile::Matches(const DiceDeviceIdentity& identity) const noexcept {
+    // Exact vendor+model only: the PreSonus OUI also covers BeBoB-era devices
+    // (FireBox/FP10/Inspire) and the DICE FireStudio, which need different handling.
+    return identity.vendorId == kPreSonusVendorId && identity.modelId == kStudioLive1602ModelId;
+}
+
+DiceDeviceQuirks PreSonusStudioLiveProfile::Quirks() const noexcept {
+    DiceDeviceQuirks quirks{};
+    // Same TCAT DICE chip family as Focusrite Saffire / Midas Venice — same wire encoding.
+    quirks.tx.hostToDevicePcmEncoding  = Encoding::AudioWireFormat::kRawPcm24In32;
+    quirks.tx.dbsPolicy                = DbsPolicy::Constant;
+    quirks.tx.defaultNonAudioSlotWord  = 0x80000000;
+    quirks.tx.initializeNonAudioSlots  = true;
+    quirks.tx.preserveFdfInNoDataPackets = true;
+    quirks.rx.deviceToHostPcmEncoding  = Encoding::AudioWireFormat::kAM824;
+    quirks.rx.dbsPolicy                = DbsPolicy::Constant;
+    return quirks;
+}
+
+bool PreSonusStudioLiveProfile::BuildDefaultTxStreamConfig(DiceStreamConfig& outConfig) const noexcept {
+    FillStreamConfig(outConfig, DiceStreamDirection::HostToDevice);
+    return true;
+}
+
+bool PreSonusStudioLiveProfile::BuildDefaultRxStreamConfig(DiceStreamConfig& outConfig) const noexcept {
+    FillStreamConfig(outConfig, DiceStreamDirection::DeviceToHost);
+    return true;
+}
+
+// Safety offsets follow the Focusrite Saffire baseline (the tested TCAT ladder):
+// Tx 6 packets, Rx 16 packets, scaled by frames-per-packet per rate mode. The
+// device only advertises the low rate mode (8 frames per packet), so the higher
+// branches are defensive.
+uint32_t PreSonusStudioLiveProfile::TxSafetyOffsetFrames(double sampleRate) const noexcept {
+    uint32_t framesPerPacket = 8;
+    uint32_t rateAddend = 0;
+    if (sampleRate > 96000.0) {
+        framesPerPacket = 32;
+        rateAddend = 4;
+    } else if (sampleRate > 48000.0) {
+        framesPerPacket = 16;
+        rateAddend = 2;
+    }
+    return (6 + rateAddend) * framesPerPacket;
+}
+
+uint32_t PreSonusStudioLiveProfile::RxSafetyOffsetFrames(double sampleRate) const noexcept {
+    uint32_t framesPerPacket = 8;
+    uint32_t rateAddend = 0;
+    if (sampleRate > 96000.0) {
+        framesPerPacket = 32;
+        rateAddend = 4;
+    } else if (sampleRate > 48000.0) {
+        framesPerPacket = 16;
+        rateAddend = 2;
+    }
+    return (16 + rateAddend) * framesPerPacket;
+}
+
+uint32_t PreSonusStudioLiveProfile::TxReportedLatencyFrames(double sampleRate) const noexcept {
+    if (sampleRate > 96000.0) return 119;
+    if (sampleRate > 48000.0) return 59;
+    return 29;
+}
+
+uint32_t PreSonusStudioLiveProfile::RxReportedLatencyFrames(double sampleRate) const noexcept {
+    if (sampleRate > 96000.0) return 119;
+    if (sampleRate > 48000.0) return 59;
+    return 29;
+}
+
+} // namespace ASFW::Isoch::Audio::DICE::Profiles

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/PreSonusStudioLiveProfile.hpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/PreSonusStudioLiveProfile.hpp
@@ -1,0 +1,28 @@
+// PreSonusStudioLiveProfile.hpp
+// PreSonus StudioLive 16.0.2 FireWire profile (DICE/TCAT).
+
+#pragma once
+
+#include "../../DiceDeviceProfile.hpp"
+
+namespace ASFW::Isoch::Audio::DICE::Profiles {
+
+class PreSonusStudioLiveProfile final : public IDiceDeviceProfile {
+public:
+    [[nodiscard]] const char* Name() const noexcept override;
+
+    [[nodiscard]] bool Matches(const DiceDeviceIdentity& identity) const noexcept override;
+
+    [[nodiscard]] DiceDeviceQuirks Quirks() const noexcept override;
+
+    [[nodiscard]] bool BuildDefaultTxStreamConfig(DiceStreamConfig& outConfig) const noexcept override;
+    [[nodiscard]] bool BuildDefaultRxStreamConfig(DiceStreamConfig& outConfig) const noexcept override;
+
+    [[nodiscard]] uint32_t TxSafetyOffsetFrames(double sampleRate) const noexcept override;
+    [[nodiscard]] uint32_t RxSafetyOffsetFrames(double sampleRate) const noexcept override;
+
+    [[nodiscard]] uint32_t TxReportedLatencyFrames(double sampleRate) const noexcept override;
+    [[nodiscard]] uint32_t RxReportedLatencyFrames(double sampleRate) const noexcept override;
+};
+
+} // namespace ASFW::Isoch::Audio::DICE::Profiles

--- a/ASFWDriver/Audio/Protocols/DeviceProtocolFactory.cpp
+++ b/ASFWDriver/Audio/Protocols/DeviceProtocolFactory.cpp
@@ -56,6 +56,15 @@ std::unique_ptr<IDeviceProtocol> DeviceProtocolFactory::Create(
         return std::make_unique<DICE::TCAT::DICETcatProtocol>(busOps, busInfo, nodeId, irmClient);
     }
 
+    if (vendorId == kPreSonusVendorId && modelId == kStudioLive1602ModelId) {
+        ASFW_LOG(DICE,
+                 "Creating generic DICETcatProtocol for PreSonus StudioLive 16.0.2 vendor=0x%06x model=0x%06x node=0x%04x",
+                 vendorId,
+                 modelId,
+                 nodeId);
+        return std::make_unique<DICE::TCAT::DICETcatProtocol>(busOps, busInfo, nodeId, irmClient);
+    }
+
     // Check for Apogee Duet FireWire (AV/C + vendor-dependent commands).
     if (vendorId == kApogeeVendorId && modelId == kApogeeDuetModelId) {
         ASFW_LOG(Audio,

--- a/ASFWDriver/Audio/Protocols/DeviceProtocolFactory.hpp
+++ b/ASFWDriver/Audio/Protocols/DeviceProtocolFactory.hpp
@@ -56,6 +56,9 @@ public:
     static constexpr uint32_t kAlesisMultiMixModelId = DeviceProfiles::Audio::kAlesisMultiMixModelId;
     static constexpr uint32_t kMidasVendorId = DeviceProfiles::Audio::kMidasVendorId;
     static constexpr uint32_t kMidasVeniceModelId = DeviceProfiles::Audio::kMidasVeniceModelId;
+    static constexpr uint32_t kPreSonusVendorId = DeviceProfiles::Audio::kPreSonusVendorId;
+    static constexpr uint32_t kStudioLive1602ModelId =
+        DeviceProfiles::Audio::kStudioLive1602ModelId;
     static constexpr uint32_t kFocusriteGuidModelSPro40Tcd3070 =
         DeviceProfiles::Audio::kFocusriteGuidModelSPro40Tcd3070;
     static constexpr const char* kFocusriteVendorName = DeviceProfiles::Audio::kFocusriteVendorName;
@@ -75,6 +78,9 @@ public:
     static constexpr const char* kMidasVendorName = DeviceProfiles::Audio::kMidasVendorName;
     static constexpr const char* kMidasVeniceModelName =
         DeviceProfiles::Audio::kMidasVeniceModelName;
+    static constexpr const char* kPreSonusVendorName = DeviceProfiles::Audio::kPreSonusVendorName;
+    static constexpr const char* kStudioLive1602ModelName =
+        DeviceProfiles::Audio::kStudioLive1602ModelName;
 
     struct KnownIdentity {
         uint32_t vendorId{0};

--- a/ASFWDriver/DeviceProfiles/Audio/AudioDeviceIds.hpp
+++ b/ASFWDriver/DeviceProfiles/Audio/AudioDeviceIds.hpp
@@ -40,6 +40,12 @@ inline constexpr uint32_t kAlesisMultiMixModelId = 0x000000;
 inline constexpr uint32_t kMidasVendorId       = 0x10c73f;
 inline constexpr uint32_t kMidasVeniceModelId  = 0x000001;
 
+// ---- PreSonus (DICE / TCAT family) ----
+// The OUI is shared with PreSonus BeBoB-era devices (FireBox/FP10/Inspire) and the
+// DICE FireStudio (model 0x000008); only exact vendor+model pairs may match.
+inline constexpr uint32_t kPreSonusVendorId      = 0x000a92;
+inline constexpr uint32_t kStudioLive1602ModelId = 0x000013;
+
 // ---- Display names ----
 inline constexpr const char* kFocusriteVendorName     = "Focusrite";
 inline constexpr const char* kSPro40ModelName         = "Saffire Pro 40";
@@ -55,5 +61,7 @@ inline constexpr const char* kAlesisVendorName        = "Alesis";
 inline constexpr const char* kAlesisMultiMixModelName = "MultiMix FireWire";
 inline constexpr const char* kMidasVendorName         = "Midas";
 inline constexpr const char* kMidasVeniceModelName    = "Venice F32";
+inline constexpr const char* kPreSonusVendorName      = "PreSonus";
+inline constexpr const char* kStudioLive1602ModelName = "StudioLive 16.0.2";
 
 } // namespace ASFW::DeviceProfiles::Audio

--- a/ASFWDriver/DeviceProfiles/Audio/AudioDeviceIds.hpp
+++ b/ASFWDriver/DeviceProfiles/Audio/AudioDeviceIds.hpp
@@ -43,8 +43,14 @@ inline constexpr uint32_t kMidasVeniceModelId  = 0x000001;
 // ---- PreSonus (DICE / TCAT family) ----
 // The OUI is shared with PreSonus BeBoB-era devices (FireBox/FP10/Inspire) and the
 // DICE FireStudio (model 0x000008); only exact vendor+model pairs may match.
+// Sibling StudioLive model IDs from libffado 2.5.0; only the 16.0.2 is
+// hardware-verified — the siblings are recognized by name but not audio-enabled
+// until their stream geometry is captured from real hardware.
 inline constexpr uint32_t kPreSonusVendorId      = 0x000a92;
 inline constexpr uint32_t kStudioLive1602ModelId = 0x000013;
+inline constexpr uint32_t kStudioLive1642ModelId = 0x000010;
+inline constexpr uint32_t kStudioLive2442ModelId = 0x000012;
+inline constexpr uint32_t kStudioLive3242ModelId = 0x000014;
 
 // ---- Display names ----
 inline constexpr const char* kFocusriteVendorName     = "Focusrite";
@@ -63,5 +69,8 @@ inline constexpr const char* kMidasVendorName         = "Midas";
 inline constexpr const char* kMidasVeniceModelName    = "Venice F32";
 inline constexpr const char* kPreSonusVendorName      = "PreSonus";
 inline constexpr const char* kStudioLive1602ModelName = "StudioLive 16.0.2";
+inline constexpr const char* kStudioLive1642ModelName = "StudioLive 16.4.2";
+inline constexpr const char* kStudioLive2442ModelName = "StudioLive 24.4.2";
+inline constexpr const char* kStudioLive3242ModelName = "StudioLive 32.4.2";
 
 } // namespace ASFW::DeviceProfiles::Audio

--- a/ASFWDriver/DeviceProfiles/Audio/AudioProfileRegistry.hpp
+++ b/ASFWDriver/DeviceProfiles/Audio/AudioProfileRegistry.hpp
@@ -18,6 +18,7 @@
 #include "Vendors/ApogeeAudioProfiles.hpp"
 #include "Vendors/FocusriteAudioProfiles.hpp"
 #include "Vendors/MidasAudioProfiles.hpp"
+#include "Vendors/PreSonusAudioProfiles.hpp"
 
 #include <optional>
 
@@ -33,6 +34,7 @@ public:
         if (auto hint = Apogee::LookupIdentity(query)) { return hint; }
         if (auto hint = Alesis::LookupIdentity(query)) { return hint; }
         if (auto hint = Midas::LookupIdentity(query)) { return hint; }
+        if (auto hint = PreSonus::LookupIdentity(query)) { return hint; }
         if (auto hint = Focusrite::LookupIdentityByGuid(query)) { return hint; }
         return std::nullopt;
     }
@@ -46,6 +48,7 @@ public:
         if (auto hint = Apogee::LookupAudioProfile(query)) { return hint; }
         if (auto hint = Alesis::LookupAudioProfile(query)) { return hint; }
         if (auto hint = Midas::LookupAudioProfile(query)) { return hint; }
+        if (auto hint = PreSonus::LookupAudioProfile(query)) { return hint; }
         return std::nullopt;
     }
 };

--- a/ASFWDriver/DeviceProfiles/Audio/Vendors/PreSonusAudioProfiles.hpp
+++ b/ASFWDriver/DeviceProfiles/Audio/Vendors/PreSonusAudioProfiles.hpp
@@ -1,0 +1,40 @@
+// PreSonusAudioProfiles.hpp - PreSonus FireWire audio device knowledge (DICE/TCAT).
+// Knows ONLY PreSonus devices; performs no runtime protocol construction.
+
+#pragma once
+
+#include "../../Common/DeviceProfileTypes.hpp"
+#include "../AudioDeviceIds.hpp"
+#include "../AudioProfileTypes.hpp"
+
+#include <optional>
+
+namespace ASFW::DeviceProfiles::Audio::PreSonus {
+
+[[nodiscard]] constexpr std::optional<DeviceIdentityHint>
+LookupIdentity(const DeviceProfileQuery& query) noexcept {
+    if (query.vendorId == kPreSonusVendorId && query.modelId == kStudioLive1602ModelId) {
+        return DeviceIdentityHint{.vendorId = query.vendorId,
+                                  .modelId = query.modelId,
+                                  .vendorName = kPreSonusVendorName,
+                                  .modelName = kStudioLive1602ModelName,
+                                  .source = MatchSource::VendorModel};
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] constexpr std::optional<AudioProfileHint>
+LookupAudioProfile(const DeviceProfileQuery& query) noexcept {
+    if (query.vendorId == kPreSonusVendorId && query.modelId == kStudioLive1602ModelId) {
+        // Identity captured live from the hardware (2026-07-08): GUID
+        // 0x000A920404FE2011, unit directory specifier 0x000A92 version 0x000001.
+        // Cross-checked with libffado 2.5.0 device config (vendor 0x000a92,
+        // model 0x000013, driver DICE) and Linux snd-dice (generic path, no quirks).
+        return AudioProfileHint{.family = AudioProtocolFamily::DICE,
+                                .mode = AudioIntegrationMode::kHardcodedNub,
+                                .source = MatchSource::VendorModel};
+    }
+    return std::nullopt;
+}
+
+} // namespace ASFW::DeviceProfiles::Audio::PreSonus

--- a/ASFWDriver/DeviceProfiles/Audio/Vendors/PreSonusAudioProfiles.hpp
+++ b/ASFWDriver/DeviceProfiles/Audio/Vendors/PreSonusAudioProfiles.hpp
@@ -13,14 +13,24 @@ namespace ASFW::DeviceProfiles::Audio::PreSonus {
 
 [[nodiscard]] constexpr std::optional<DeviceIdentityHint>
 LookupIdentity(const DeviceProfileQuery& query) noexcept {
-    if (query.vendorId == kPreSonusVendorId && query.modelId == kStudioLive1602ModelId) {
-        return DeviceIdentityHint{.vendorId = query.vendorId,
-                                  .modelId = query.modelId,
-                                  .vendorName = kPreSonusVendorName,
-                                  .modelName = kStudioLive1602ModelName,
-                                  .source = MatchSource::VendorModel};
+    if (query.vendorId != kPreSonusVendorId) {
+        return std::nullopt;
     }
-    return std::nullopt;
+    // StudioLive siblings are recognized by name only until their stream geometry
+    // is captured from hardware — see LookupAudioProfile.
+    const char* modelName = nullptr;
+    switch (query.modelId) {
+    case kStudioLive1602ModelId: modelName = kStudioLive1602ModelName; break;
+    case kStudioLive1642ModelId: modelName = kStudioLive1642ModelName; break;
+    case kStudioLive2442ModelId: modelName = kStudioLive2442ModelName; break;
+    case kStudioLive3242ModelId: modelName = kStudioLive3242ModelName; break;
+    default: return std::nullopt;
+    }
+    return DeviceIdentityHint{.vendorId = query.vendorId,
+                              .modelId = query.modelId,
+                              .vendorName = kPreSonusVendorName,
+                              .modelName = modelName,
+                              .source = MatchSource::VendorModel};
 }
 
 [[nodiscard]] constexpr std::optional<AudioProfileHint>
@@ -34,6 +44,9 @@ LookupAudioProfile(const DeviceProfileQuery& query) noexcept {
                                 .mode = AudioIntegrationMode::kHardcodedNub,
                                 .source = MatchSource::VendorModel};
     }
+    // StudioLive 16.4.2 / 24.4.2 / 32.4.2 intentionally return no profile: their
+    // TX/RX channel counts differ from the 16.0.2 and have not been captured from
+    // hardware, and a wrong DBS means the device never locks to the host stream.
     return std::nullopt;
 }
 

--- a/README.md
+++ b/README.md
@@ -140,11 +140,13 @@ Audio-device support in tree today:
 - Focusrite Saffire Pro 14
 - Focusrite Saffire Pro 24
 - Focusrite Saffire Pro 24 DSP
+- PreSonus StudioLive 16.0.2
 
 Personally tested with working audio:
 
 - Apogee Duet FireWire
 - Focusrite Saffire Pro 24 DSP
+- PreSonus StudioLive 16.0.2
 
 Recognized but not enabled yet:
 
@@ -152,6 +154,7 @@ Recognized but not enabled yet:
 - Focusrite Saffire Pro 40
 - Focusrite Saffire Pro 40 TCD3070
 - Focusrite Liquid Saffire 56
+- PreSonus StudioLive 16.4.2 / 24.4.2 / 32.4.2 (stream layout not yet captured from hardware)
 
 In theory the driver can be extended to other OHCI controllers and many more FireWire devices, but hardware access is still the limiting factor. Host-controller matching and audio-device enablement are intentionally conservative until more real machines are tested.
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ What is real today:
 - Async FireWire transactions are in place and used by discovery and protocol code.
 - AV/C FCP and CMP plumbing exists and is working on the main test rig.
 - Audio publication and experimental streaming paths exist in-tree.
-- Personally tested audio hardware now includes the Apogee Duet FireWire path and Focusrite Saffire Pro 24 DSP.
-- Experimental DICE support is now enabled in-tree for Focusrite Saffire Pro 14, Saffire Pro 24, and Saffire Pro 24 DSP.
+- Personally tested audio hardware now includes the Apogee Duet FireWire path, Focusrite Saffire Pro 24 DSP, and PreSonus StudioLive 16.0.2 (full duplex 16-in/16-out streaming).
+- Experimental DICE support is now enabled in-tree for Focusrite Saffire Pro 14, Saffire Pro 24, Saffire Pro 24 DSP, and PreSonus StudioLive 16.0.2.
 - Focusrite Saffire Pro 26, Saffire Pro 40, Saffire Pro 40 TCD3070, and Liquid Saffire 56 are recognized but intentionally not enabled yet because the current generic DICE backend is still effectively single-stream.
+- PreSonus StudioLive 16.4.2, 24.4.2, and 32.4.2 are recognized by name but not audio-enabled yet: their FireWire channel counts differ from the 16.0.2 and must be captured from real hardware first (a wrong channel count means the device never locks to the stream). If you own one, see the call for testing below.
 - The project is still not stable enough to recommend as a drop-in replacement for Apple's old FireWire stack.
 
 ## Call for testing
@@ -58,6 +59,9 @@ Please test these currently enabled DICE devices:
 - Focusrite Saffire Pro 14
 - Focusrite Saffire Pro 24
 - Focusrite Saffire Pro 24 DSP
+- PreSonus StudioLive 16.0.2 (personally tested on one unit; broader validation welcome)
+
+StudioLive 16.4.2 / 24.4.2 / 32.4.2 owners can help too: the driver recognizes these mixers but does not enable audio yet because their stream layout has not been captured from hardware. If you own one, open an issue — a short register capture using the ASFW app is all that is needed to add support.
 
 If you try ASFireWire on one of them, please open a GitHub issue or reach out with:
 

--- a/tests/audio/AudioProfileRegistryTests.cpp
+++ b/tests/audio/AudioProfileRegistryTests.cpp
@@ -167,6 +167,30 @@ TEST(AudioProfileRegistryTests, RejectsOtherPreSonusModels) {
                      .has_value());
 }
 
+TEST(AudioProfileRegistryTests, KeepsStudioLiveSiblingsRecognizedButDisabled) {
+    // 16.4.2 / 24.4.2 / 32.4.2 share the StudioLive series but their stream
+    // geometry (channel counts) has not been captured from hardware, so they are
+    // recognized by name only — same pattern as the multistream Focusrite models.
+    struct Sibling {
+        uint32_t modelId;
+        const char* modelName;
+    };
+    const Sibling siblings[] = {
+        {ids::kStudioLive1642ModelId, ids::kStudioLive1642ModelName},
+        {ids::kStudioLive2442ModelId, ids::kStudioLive2442ModelName},
+        {ids::kStudioLive3242ModelId, ids::kStudioLive3242ModelName},
+    };
+    for (const auto& sibling : siblings) {
+        const auto identity = AudioProfileRegistry::LookupIdentity(
+            ByVendorModel(ids::kPreSonusVendorId, sibling.modelId));
+        ASSERT_TRUE(identity.has_value());
+        EXPECT_STREQ(identity->vendorName, ids::kPreSonusVendorName);
+        EXPECT_STREQ(identity->modelName, sibling.modelName);
+        EXPECT_EQ(ModeFor(ids::kPreSonusVendorId, sibling.modelId),
+                  AudioIntegrationMode::kNone);
+    }
+}
+
 TEST(AudioProfileRegistryTests, RecognizesMidasVeniceDiceProfile) {
     const auto identity = AudioProfileRegistry::LookupIdentity(
         ByVendorModel(ids::kMidasVendorId, ids::kMidasVeniceModelId));

--- a/tests/audio/AudioProfileRegistryTests.cpp
+++ b/tests/audio/AudioProfileRegistryTests.cpp
@@ -51,6 +51,8 @@ TEST(AudioProfileRegistryTests, SelectsIntegrationModeForKnownDevices) {
               AudioIntegrationMode::kHardcodedNub);
     EXPECT_EQ(ModeFor(ids::kMidasVendorId, ids::kMidasVeniceModelId),
               AudioIntegrationMode::kHardcodedNub);
+    EXPECT_EQ(ModeFor(ids::kPreSonusVendorId, ids::kStudioLive1602ModelId),
+              AudioIntegrationMode::kHardcodedNub);
 }
 
 TEST(AudioProfileRegistryTests, RejectsUnknownDevices) {
@@ -91,6 +93,9 @@ TEST(AudioProfileRegistryTests, RecognizesKnownVendorModelPairs) {
                     .has_value());
     EXPECT_TRUE(AudioProfileRegistry::LookupIdentity(
                     ByVendorModel(ids::kMidasVendorId, ids::kMidasVeniceModelId))
+                    .has_value());
+    EXPECT_TRUE(AudioProfileRegistry::LookupIdentity(
+                    ByVendorModel(ids::kPreSonusVendorId, ids::kStudioLive1602ModelId))
                     .has_value());
 }
 
@@ -135,6 +140,31 @@ TEST(AudioProfileRegistryTests, RecognizesAlesisMultiMixDiceProfile) {
     ASSERT_TRUE(profile.has_value());
     EXPECT_EQ(profile->mode, AudioIntegrationMode::kHardcodedNub);
     EXPECT_EQ(profile->family, AudioProtocolFamily::DICE);
+}
+
+TEST(AudioProfileRegistryTests, RecognizesPreSonusStudioLive1602DiceProfile) {
+    const auto identity = AudioProfileRegistry::LookupIdentity(
+        ByVendorModel(ids::kPreSonusVendorId, ids::kStudioLive1602ModelId));
+    ASSERT_TRUE(identity.has_value());
+    EXPECT_STREQ(identity->vendorName, ids::kPreSonusVendorName);
+    EXPECT_STREQ(identity->modelName, ids::kStudioLive1602ModelName);
+
+    const auto profile = AudioProfileRegistry::LookupBestAudioProfile(
+        ByVendorModel(ids::kPreSonusVendorId, ids::kStudioLive1602ModelId));
+    ASSERT_TRUE(profile.has_value());
+    EXPECT_EQ(profile->mode, AudioIntegrationMode::kHardcodedNub);
+    EXPECT_EQ(profile->family, AudioProtocolFamily::DICE);
+}
+
+TEST(AudioProfileRegistryTests, RejectsOtherPreSonusModels) {
+    // PreSonus BeBoB devices (FireBox/FP10/Inspire) and the DICE FireStudio share
+    // the OUI but must not resolve to the StudioLive profile.
+    EXPECT_FALSE(AudioProfileRegistry::LookupIdentity(
+                     ByVendorModel(ids::kPreSonusVendorId, 0x000008))
+                     .has_value());
+    EXPECT_FALSE(AudioProfileRegistry::LookupBestAudioProfile(
+                     ByVendorModel(ids::kPreSonusVendorId, 0x000008))
+                     .has_value());
 }
 
 TEST(AudioProfileRegistryTests, RecognizesMidasVeniceDiceProfile) {

--- a/tests/audio/CMakeLists.txt
+++ b/tests/audio/CMakeLists.txt
@@ -170,6 +170,7 @@ add_audio_test(DiceProfileTests
     "${ASFW_DRIVER_DIR}/Audio/DriverKit/Config/DICE/Isoch/Profiles/GenericDiceProfile.cpp"
     "${ASFW_DRIVER_DIR}/Audio/DriverKit/Config/DICE/Isoch/Profiles/FocusriteSaffireProfile.cpp"
     "${ASFW_DRIVER_DIR}/Audio/DriverKit/Config/DICE/Isoch/Profiles/MidasVeniceProfile.cpp"
+    "${ASFW_DRIVER_DIR}/Audio/DriverKit/Config/DICE/Isoch/Profiles/PreSonusStudioLiveProfile.cpp"
 )
 
 # IT Descriptor Layout Tests

--- a/tests/audio/DiceProfileTests.cpp
+++ b/tests/audio/DiceProfileTests.cpp
@@ -168,11 +168,15 @@ TEST(DiceProfileTests, PreSonusStudioLiveSafetyOffsetsAndLatencies) {
 }
 
 TEST(DiceProfileTests, PreSonusVendorWithWrongModelDoesNotMatchStudioLiveProfile) {
-    // PreSonus also shipped BeBoB-era devices (FireBox/FP10/Inspire) and the DICE
-    // FireStudio (model 0x000008); none of them may match the StudioLive profile.
-    const auto* profile = AudioProfileRegistry::FindProfile(0x000A92, 0x000008, 0x0ULL);
-    if (profile != nullptr) {
-        EXPECT_STRNE(profile->Name(), "PreSonus StudioLive 16.0.2 (DICE)");
+    // PreSonus also shipped BeBoB-era devices (FireBox/FP10/Inspire), the DICE
+    // FireStudio (0x000008), and the StudioLive siblings 16.4.2/24.4.2/32.4.2
+    // (0x000010/0x000012/0x000014) whose channel counts are uncaptured; none of
+    // them may inherit the 16.0.2 stream geometry.
+    for (const uint32_t modelId : {0x000008u, 0x000010u, 0x000012u, 0x000014u}) {
+        const auto* profile = AudioProfileRegistry::FindProfile(0x000A92, modelId, 0x0ULL);
+        if (profile != nullptr) {
+            EXPECT_STRNE(profile->Name(), "PreSonus StudioLive 16.0.2 (DICE)");
+        }
     }
 }
 

--- a/tests/audio/DiceProfileTests.cpp
+++ b/tests/audio/DiceProfileTests.cpp
@@ -12,6 +12,7 @@
 #include "Audio/DriverKit/Config/DICE/Isoch/Profiles/FocusriteSaffireProfile.hpp"
 #include "Audio/DriverKit/Config/DICE/Isoch/Profiles/GenericDiceProfile.hpp"
 #include "Audio/DriverKit/Config/DICE/Isoch/Profiles/MidasVeniceProfile.hpp"
+#include "Audio/DriverKit/Config/DICE/Isoch/Profiles/PreSonusStudioLiveProfile.hpp"
 
 namespace {
 
@@ -124,6 +125,54 @@ TEST(DiceProfileTests, MidasVendorWithWrongModelDoesNotMatchVeniceProfile) {
     // Should fall through to generic profile, not Venice.
     if (profile != nullptr) {
         EXPECT_STRNE(profile->Name(), "Midas Venice F32 (DICE)");
+    }
+}
+
+TEST(DiceProfileTests, ResolvesPreSonusStudioLive1602ProfileByVendorAndModel) {
+    // Identity captured live from the hardware (2026-07-08): GUID 0x000A920404FE2011,
+    // vendor 0x000A92, model 0x000013.
+    const auto* profile = AudioProfileRegistry::FindProfile(0x000A92, 0x000013, 0x000A920404FE2011ULL);
+
+    ASSERT_NE(profile, nullptr);
+    EXPECT_STREQ(profile->Name(), "PreSonus StudioLive 16.0.2 (DICE)");
+    EXPECT_EQ(profile->TxWireFormat(), ASFW::Encoding::AudioWireFormat::kRawPcm24In32);
+    EXPECT_EQ(profile->RxWireFormat(), ASFW::Encoding::AudioWireFormat::kAM824);
+
+    // DICE TX/RX sections at 48 kHz: single stream per direction, NB_AUDIO=16,
+    // NB_MIDI=1, so DBS = 17 both ways.
+    EXPECT_EQ(profile->TxChannelCount(), 16);
+    EXPECT_EQ(profile->RxChannelCount(), 16);
+    EXPECT_EQ(profile->TxMidiSlots(), 1);
+    EXPECT_EQ(profile->RxMidiSlots(), 1);
+    EXPECT_EQ(profile->TxDbs(), 17);
+    EXPECT_EQ(profile->RxDbs(), 17);
+
+    const auto* diceProfile = static_cast<const IDiceDeviceProfile*>(profile);
+    EXPECT_TRUE(diceProfile->Quirks().tx.preserveFdfInNoDataPackets);
+    EXPECT_EQ(diceProfile->Quirks().tx.hostToDevicePcmEncoding,
+              ASFW::Encoding::AudioWireFormat::kRawPcm24In32);
+}
+
+TEST(DiceProfileTests, PreSonusStudioLiveSafetyOffsetsAndLatencies) {
+    const auto* profile = AudioProfileRegistry::FindProfile(0x000A92, 0x000013, 0x000A920404FE2011ULL);
+    ASSERT_NE(profile, nullptr);
+
+    // Device clock caps are 44.1/48 kHz only; both rates sit in the DICE low rate
+    // mode (8 frames per packet). Tx = 6 * 8 = 48, Rx = 16 * 8 = 128.
+    EXPECT_EQ(profile->TxSafetyOffsetFrames(44100.0), 48);
+    EXPECT_EQ(profile->RxSafetyOffsetFrames(44100.0), 128);
+    EXPECT_EQ(profile->TxSafetyOffsetFrames(48000.0), 48);
+    EXPECT_EQ(profile->RxSafetyOffsetFrames(48000.0), 128);
+    EXPECT_EQ(profile->TxReportedLatencyFrames(48000.0), 29);
+    EXPECT_EQ(profile->RxReportedLatencyFrames(48000.0), 29);
+}
+
+TEST(DiceProfileTests, PreSonusVendorWithWrongModelDoesNotMatchStudioLiveProfile) {
+    // PreSonus also shipped BeBoB-era devices (FireBox/FP10/Inspire) and the DICE
+    // FireStudio (model 0x000008); none of them may match the StudioLive profile.
+    const auto* profile = AudioProfileRegistry::FindProfile(0x000A92, 0x000008, 0x0ULL);
+    if (profile != nullptr) {
+        EXPECT_STRNE(profile->Name(), "PreSonus StudioLive 16.0.2 (DICE)");
     }
 }
 

--- a/tests/common/DeviceProtocolFactoryTests.cpp
+++ b/tests/common/DeviceProtocolFactoryTests.cpp
@@ -64,6 +64,11 @@ TEST(DeviceProtocolFactoryTests, SelectsIntegrationModeForKnownDevices) {
                   DeviceProtocolFactory::kMidasVendorId,
                   DeviceProtocolFactory::kMidasVeniceModelId),
               DeviceIntegrationMode::kHardcodedNub);
+
+    EXPECT_EQ(DeviceProtocolFactory::LookupIntegrationMode(
+                  DeviceProtocolFactory::kPreSonusVendorId,
+                  DeviceProtocolFactory::kStudioLive1602ModelId),
+              DeviceIntegrationMode::kHardcodedNub);
 }
 
 TEST(DeviceProtocolFactoryTests, RejectsUnknownDevices) {
@@ -112,6 +117,10 @@ TEST(DeviceProtocolFactoryTests, RecognizesKnownVendorModelPairs) {
     EXPECT_TRUE(DeviceProtocolFactory::IsKnownDevice(
         DeviceProtocolFactory::kMidasVendorId,
         DeviceProtocolFactory::kMidasVeniceModelId));
+
+    EXPECT_TRUE(DeviceProtocolFactory::IsKnownDevice(
+        DeviceProtocolFactory::kPreSonusVendorId,
+        DeviceProtocolFactory::kStudioLive1602ModelId));
 }
 
 TEST(DeviceProtocolFactoryTests, InfersFocusriteIdentityFromGuid) {
@@ -173,6 +182,15 @@ TEST(DeviceProtocolFactoryTests, RecognizesMidasVeniceDiceProfile) {
     EXPECT_EQ(venice->integrationMode, DeviceIntegrationMode::kHardcodedNub);
     EXPECT_STREQ(venice->vendorName, DeviceProtocolFactory::kMidasVendorName);
     EXPECT_STREQ(venice->modelName, DeviceProtocolFactory::kMidasVeniceModelName);
+}
+
+TEST(DeviceProtocolFactoryTests, RecognizesPreSonusStudioLive1602DiceProfile) {
+    const auto studioLive = DeviceProtocolFactory::LookupKnownIdentity(
+        DeviceProtocolFactory::kPreSonusVendorId, DeviceProtocolFactory::kStudioLive1602ModelId);
+    ASSERT_TRUE(studioLive.has_value());
+    EXPECT_EQ(studioLive->integrationMode, DeviceIntegrationMode::kHardcodedNub);
+    EXPECT_STREQ(studioLive->vendorName, DeviceProtocolFactory::kPreSonusVendorName);
+    EXPECT_STREQ(studioLive->modelName, DeviceProtocolFactory::kStudioLive1602ModelName);
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Adds full audio I/O support for the PreSonus StudioLive 16.0.2 mixer at 48KHz rate, following the established Midas/Focusrite hardcoded-nub DICE pattern:

- `DeviceProfiles/Audio/Vendors/PreSonusAudioProfiles.hpp` — identity + `{DICE, kHardcodedNub}` hint for vendor `0x000a92`, model `0x000013` (exact match only; the PreSonus OUI is shared with BeBoB-era devices and the DICE FireStudio, which must not match)
- `Audio/DriverKit/Config/DICE/Isoch/Profiles/PreSonusStudioLiveProfile.{hpp,cpp}` — static stream geometry, registered in `DiceProfileRegistry`
- `DeviceProtocolFactory` case returning the generic `DICETcatProtocol` (same as Alesis/Midas)
- StudioLive siblings 16.4.2 / 24.4.2 / 32.4.2 (model IDs from libffado 2.5.0) are recognized by name but intentionally not audio-enabled: their channel counts differ and have not been captured from hardware, and a wrong DBS means the device never locks. Same recognized-but-disabled pattern as the multistream Focusrite models. README invites owners to contribute a register capture.

## Stream geometry (captured from hardware, not guessed)

Captured live from the device's DICE register space (`0xFFFFE0000000`) via async reads:

- Single isoch stream per direction, `NB_AUDIO=16`, `NB_MIDI=1` → DBS 17, S400
- Clock caps `0x13000006`: 44.1/48 kHz only (no mid/high rate modes), sources internal/ARX1/ARX2
- Config ROM: GUID `0x000A920404FE2011`, unit directory specifier `0x000A92`, version `0x000001`

Cross-checked with Linux `snd-dice` (whole StudioLive series uses the fully generic DICE path, no quirks — only the FireStudio `0x000008` has a PreSonus quirk table) and libffado 2.5.0 device config.

## Hardware verification

Verified end to end on a real StudioLive 16.0.2 (M1 MacBook Air, TB3→TB2→FW800 chain):

- Discovery: `Device upsert … kind=VendorAudio audioCandidate=1`
- `ASFWAudioNub` published; CoreAudio device shows 16 in / 16 out @ 48 kHz
- Wire bringup: `DICE DUPLEX START … inCh=16 outCh=16 inSlots=17 outSlots=17 mode=blocking`
- Sustained full-duplex playback + recording, confirmed audible both directions; telemetry heartbeat-only (`[TxPrep]` margin 136–140 vs min 125, `late1500=0`), zero fault lines

## Tests

- `DiceProfileTests`: profile resolution by vendor+model, safety offsets/latencies at 44.1/48/96 kHz, wrong-model fall-through (FireStudio and all three siblings must not inherit 16.0.2 geometry)
- `AudioProfileRegistryTests`: identity + integration mode, siblings recognized-but-disabled, other PreSonus models rejected
- `DeviceProtocolFactoryTests`: known-identity and integration-mode coverage

`./build.sh --test-only --test-filter 'DiceProfile|AudioProfileRegistry|DeviceProtocolFactory'` → 30/30 pass.