### PR TITLE
License the project under Apache 2.0

### DIFF
--- a/ASFWDriver/ASFWDriver.cpp
+++ b/ASFWDriver/ASFWDriver.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 //
 //  ASFWDriver.cpp
 //  ASFWDriver

--- a/ASFWDriver/Async/AsyncSubsystem.cpp
+++ b/ASFWDriver/Async/AsyncSubsystem.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 #include "AsyncSubsystem.hpp"
 
 #include "Commands/LockCommand.hpp"

--- a/ASFWDriver/Async/AsyncSubsystem.hpp
+++ b/ASFWDriver/Async/AsyncSubsystem.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 #pragma once
 
 #include <atomic>

--- a/ASFWDriver/Async/AsyncSubsystemBusReset.cpp
+++ b/ASFWDriver/Async/AsyncSubsystemBusReset.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 #include "AsyncSubsystem.hpp"
 
 #include "Tx/Submitter.hpp"

--- a/ASFWDriver/Async/AsyncSubsystemCommandQueue.cpp
+++ b/ASFWDriver/Async/AsyncSubsystemCommandQueue.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 #include "AsyncSubsystem.hpp"
 
 #include "../Logging/Logging.hpp"

--- a/ASFWDriver/Async/AsyncSubsystemDiagnostics.cpp
+++ b/ASFWDriver/Async/AsyncSubsystemDiagnostics.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 #include "AsyncSubsystem.hpp"
 
 #include "../Hardware/OHCIDescriptors.hpp"

--- a/ASFWDriver/Async/AsyncSubsystemInterrupts.cpp
+++ b/ASFWDriver/Async/AsyncSubsystemInterrupts.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 #include "AsyncSubsystem.hpp"
 
 #include "Contexts/ATRequestContext.hpp"

--- a/ASFWDriver/Async/AsyncSubsystemLifecycle.cpp
+++ b/ASFWDriver/Async/AsyncSubsystemLifecycle.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 #include "AsyncSubsystem.hpp"
 #include "Engine/ContextManager.hpp"
 

--- a/ASFWDriver/Async/AsyncTypes.hpp
+++ b/ASFWDriver/Async/AsyncTypes.hpp
@@ -150,6 +150,8 @@ enum class AsyncStatus : uint8_t {
 /**
  * FWAddress - Standard FireWire 48-bit address structure
  * Ported from IOFireWireFamily/IOFireWireFamilyCommon.h for API compatibility.
+ * Source: Apple IOFireWireFamily (APSL-2.0) — API layout only, no
+ * implementation code reproduced. See NOTICE.
  *
  * Format: nodeID[15:0] + addressHi[15:0] + addressLo[31:0] = 64 bits total
  *   - nodeID: bus[15:10] | node[5:0]

--- a/ASFWDriver/Async/Rx/LocalRequestDispatch.cpp
+++ b/ASFWDriver/Async/Rx/LocalRequestDispatch.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // LocalRequestDispatch.cpp — see LocalRequestDispatch.hpp.

--- a/ASFWDriver/Async/Rx/LocalRequestDispatch.hpp
+++ b/ASFWDriver/Async/Rx/LocalRequestDispatch.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // LocalRequestDispatch.hpp — single owner of inbound AR *request* routing to the

--- a/ASFWDriver/Audio/Core/AudioCoordinator.cpp
+++ b/ASFWDriver/Audio/Core/AudioCoordinator.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 
 #include "AudioCoordinator.hpp"

--- a/ASFWDriver/Audio/Core/AudioCoordinator.hpp
+++ b/ASFWDriver/Audio/Core/AudioCoordinator.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // AudioCoordinator.hpp

--- a/ASFWDriver/Audio/Core/AudioEndpointRuntime.hpp
+++ b/ASFWDriver/Audio/Core/AudioEndpointRuntime.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 
 #pragma once

--- a/ASFWDriver/Audio/Core/AudioNubPublisher.cpp
+++ b/ASFWDriver/Audio/Core/AudioNubPublisher.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 
 #include "AudioNubPublisher.hpp"

--- a/ASFWDriver/Audio/Core/AudioNubPublisher.hpp
+++ b/ASFWDriver/Audio/Core/AudioNubPublisher.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // AudioNubPublisher.hpp

--- a/ASFWDriver/Audio/Core/AudioRuntimeRegistry.cpp
+++ b/ASFWDriver/Audio/Core/AudioRuntimeRegistry.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 
 #include "AudioRuntimeRegistry.hpp"

--- a/ASFWDriver/Audio/Core/AudioRuntimeRegistry.hpp
+++ b/ASFWDriver/Audio/Core/AudioRuntimeRegistry.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // AudioRuntimeRegistry.hpp

--- a/ASFWDriver/Audio/Core/IAVCAudioConfigListener.hpp
+++ b/ASFWDriver/Audio/Core/IAVCAudioConfigListener.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // IAVCAudioConfigListener.hpp

--- a/ASFWDriver/Audio/DriverKit/Config/AudioProfileRegistry.cpp
+++ b/ASFWDriver/Audio/DriverKit/Config/AudioProfileRegistry.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // AudioProfileRegistry.cpp

--- a/ASFWDriver/Audio/DriverKit/Config/AudioProfileRegistry.hpp
+++ b/ASFWDriver/Audio/DriverKit/Config/AudioProfileRegistry.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // AudioProfileRegistry.hpp

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/Async/DiceQuirks.hpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/Async/DiceQuirks.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // DiceQuirks.hpp

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/DiceDeviceProfile.hpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/DiceDeviceProfile.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // DiceDeviceProfile.hpp

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/DiceProfileRegistry.cpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/DiceProfileRegistry.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // DiceProfileRegistry.cpp

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/DiceProfileRegistry.hpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/DiceProfileRegistry.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // DiceProfileRegistry.hpp

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/DiceStreamConfig.hpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/DiceStreamConfig.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // DiceStreamConfig.hpp

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/FocusriteSaffireProfile.cpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/FocusriteSaffireProfile.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // FocusriteSaffireProfile.cpp

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/FocusriteSaffireProfile.hpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/FocusriteSaffireProfile.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // FocusriteSaffireProfile.hpp

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/GenericDiceProfile.cpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/GenericDiceProfile.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // GenericDiceProfile.cpp

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/GenericDiceProfile.hpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/GenericDiceProfile.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // GenericDiceProfile.hpp

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/MidasVeniceProfile.cpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/MidasVeniceProfile.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // MidasVeniceProfile.cpp

--- a/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/MidasVeniceProfile.hpp
+++ b/ASFWDriver/Audio/DriverKit/Config/DICE/Isoch/Profiles/MidasVeniceProfile.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // MidasVeniceProfile.hpp

--- a/ASFWDriver/Audio/DriverKit/Config/IAudioDeviceProfile.hpp
+++ b/ASFWDriver/Audio/DriverKit/Config/IAudioDeviceProfile.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // IAudioDeviceProfile.hpp

--- a/ASFWDriver/Audio/Model/AudioPropertyKeys.hpp
+++ b/ASFWDriver/Audio/Model/AudioPropertyKeys.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 
 #pragma once

--- a/ASFWDriver/Audio/Protocols/AudioTypes.hpp
+++ b/ASFWDriver/Audio/Protocols/AudioTypes.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // AudioTypes.hpp - Shared protocol-facing audio topology/runtime types

--- a/ASFWDriver/Audio/Protocols/Backends/AVCAudioBackend.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/AVCAudioBackend.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 
 #include "AVCAudioBackend.hpp"

--- a/ASFWDriver/Audio/Protocols/Backends/AVCAudioBackend.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/AVCAudioBackend.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // AVCAudioBackend.hpp

--- a/ASFWDriver/Audio/Protocols/Backends/DiceAudioBackend.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceAudioBackend.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 
 #include "DiceAudioBackend.hpp"

--- a/ASFWDriver/Audio/Protocols/Backends/DiceAudioBackend.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceAudioBackend.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // DiceAudioBackend.hpp

--- a/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 
 #include "DiceDuplexRestartCoordinator.hpp"

--- a/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // DiceDuplexRestartCoordinator.hpp - Top-level DICE restart FSM owner

--- a/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 
 #include "DiceHostTransport.hpp"

--- a/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // DiceHostTransport.hpp - Host-side isoch orchestration seam for DICE restart FSM

--- a/ASFWDriver/Audio/Protocols/Backends/DiceRecoveryPolicy.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceRecoveryPolicy.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // DiceRecoveryPolicy.hpp

--- a/ASFWDriver/Audio/Protocols/Backends/DuplexOperationGate.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DuplexOperationGate.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // DuplexOperationGate.hpp

--- a/ASFWDriver/Audio/Protocols/Backends/IAudioBackend.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/IAudioBackend.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // IAudioBackend.hpp

--- a/ASFWDriver/Audio/Protocols/Backends/RestartJournal.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/RestartJournal.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // RestartJournal.hpp

--- a/ASFWDriver/Audio/Protocols/Backends/RestartSessionStore.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/RestartSessionStore.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // RestartSessionStore.hpp

--- a/ASFWDriver/Audio/Protocols/Backends/SyncAsyncBridge.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/SyncAsyncBridge.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // SyncAsyncBridge.hpp

--- a/ASFWDriver/Audio/Protocols/DICE/Core/DICEDuplexBringupController.cpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Core/DICEDuplexBringupController.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // DICEDuplexBringupController.cpp - Raw-reference duplex startup for generic DICE devices

--- a/ASFWDriver/Audio/Protocols/DICE/Core/DICEDuplexBringupController.hpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Core/DICEDuplexBringupController.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // DICEDuplexBringupController.hpp - Generic async duplex startup state machine for DICE devices

--- a/ASFWDriver/Audio/Protocols/DICE/Core/DICENotificationMailbox.hpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Core/DICENotificationMailbox.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // DICENotificationMailbox.hpp - Shared mailbox for DICE async notifications

--- a/ASFWDriver/Audio/Protocols/DICE/Core/DICERestartSession.hpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Core/DICERestartSession.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // DICERestartSession.hpp - Explicit restart/session state for DICE duplex control

--- a/ASFWDriver/Audio/Protocols/DICE/Core/DICETransaction.cpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Core/DICETransaction.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // DICETransaction.cpp - DICE section/capability reader

--- a/ASFWDriver/Audio/Protocols/DICE/Core/DICETransaction.hpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Core/DICETransaction.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // DICETransaction.hpp - DICE section/capability reader

--- a/ASFWDriver/Audio/Protocols/DICE/Core/DICETypes.hpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Core/DICETypes.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // DICETypes.hpp - Core DICE protocol types

--- a/ASFWDriver/Audio/Protocols/DICE/Core/IDICEDuplexProtocol.hpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Core/IDICEDuplexProtocol.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // IDICEDuplexProtocol.hpp - Typed DICE duplex restart/control surface

--- a/ASFWDriver/Audio/Protocols/DICE/Focusrite/SPro24DspProtocol.cpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Focusrite/SPro24DspProtocol.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // SPro24DspProtocol.cpp - Focusrite Saffire Pro 24 DSP protocol implementation

--- a/ASFWDriver/Audio/Protocols/DICE/Focusrite/SPro24DspProtocol.hpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Focusrite/SPro24DspProtocol.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // SPro24DspProtocol.hpp - Focusrite Saffire Pro 24 DSP protocol implementation

--- a/ASFWDriver/Audio/Protocols/DICE/Focusrite/SPro24DspRouting.hpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Focusrite/SPro24DspRouting.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // SPro24DspRouting.hpp - Pure routing helpers for Saffire Pro 24 DSP

--- a/ASFWDriver/Audio/Protocols/DICE/Focusrite/SPro24DspTypes.cpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Focusrite/SPro24DspTypes.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // SPro24DspTypes.cpp - Wire serialization for Saffire Pro 24 DSP-only types

--- a/ASFWDriver/Audio/Protocols/DICE/Focusrite/SPro24DspTypes.hpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Focusrite/SPro24DspTypes.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // SPro24DspTypes.hpp - Wire types exclusive to the Saffire Pro 24 DSP

--- a/ASFWDriver/Audio/Protocols/DICE/Focusrite/SaffireproCommon.cpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Focusrite/SaffireproCommon.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // SaffireproCommon.cpp - Common Saffire Pro implementations

--- a/ASFWDriver/Audio/Protocols/DICE/Focusrite/SaffireproCommon.hpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Focusrite/SaffireproCommon.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // SaffireproCommon.hpp - Common definitions for Focusrite Saffire Pro family

--- a/ASFWDriver/Audio/Protocols/DICE/TCAT/DICETcatProtocol.cpp
+++ b/ASFWDriver/Audio/Protocols/DICE/TCAT/DICETcatProtocol.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // DICETcatProtocol.cpp - Generic DICE/TCAT protocol state and duplex control

--- a/ASFWDriver/Audio/Protocols/DICE/TCAT/DICETcatProtocol.hpp
+++ b/ASFWDriver/Audio/Protocols/DICE/TCAT/DICETcatProtocol.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // DICETcatProtocol.hpp - Generic DICE/TCAT protocol state and duplex control

--- a/ASFWDriver/Audio/Protocols/DeviceProtocolFactory.cpp
+++ b/ASFWDriver/Audio/Protocols/DeviceProtocolFactory.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // DeviceProtocolFactory.cpp - Factory for creating device-specific protocol handlers

--- a/ASFWDriver/Audio/Protocols/DeviceProtocolFactory.hpp
+++ b/ASFWDriver/Audio/Protocols/DeviceProtocolFactory.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // DeviceProtocolFactory.hpp - Factory for creating device-specific protocol handlers

--- a/ASFWDriver/Audio/Protocols/DeviceStreamModeQuirks.cpp
+++ b/ASFWDriver/Audio/Protocols/DeviceStreamModeQuirks.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // DeviceStreamModeQuirks.cpp - Vendor/model stream mode overrides

--- a/ASFWDriver/Audio/Protocols/DeviceStreamModeQuirks.hpp
+++ b/ASFWDriver/Audio/Protocols/DeviceStreamModeQuirks.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // DeviceStreamModeQuirks.hpp - Vendor/model stream mode overrides

--- a/ASFWDriver/Audio/Protocols/IDeviceProtocol.hpp
+++ b/ASFWDriver/Audio/Protocols/IDeviceProtocol.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // IDeviceProtocol.hpp - Interface for device-specific protocol handlers

--- a/ASFWDriver/Audio/Protocols/Oxford/Apogee/ApogeeDuetProtocol.cpp
+++ b/ASFWDriver/Audio/Protocols/Oxford/Apogee/ApogeeDuetProtocol.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // ApogeeDuetProtocol.cpp - Protocol implementation for Apogee Duet FireWire

--- a/ASFWDriver/Audio/Protocols/Oxford/Apogee/ApogeeDuetProtocol.hpp
+++ b/ASFWDriver/Audio/Protocols/Oxford/Apogee/ApogeeDuetProtocol.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // ApogeeDuetProtocol.hpp - Protocol implementation for Apogee Duet FireWire

--- a/ASFWDriver/Audio/Protocols/Oxford/Apogee/ApogeeTypes.hpp
+++ b/ASFWDriver/Audio/Protocols/Oxford/Apogee/ApogeeTypes.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // ApogeeTypes.hpp - Apogee Duet FireWire protocol types

--- a/ASFWDriver/Audio/Wire/AMDTP/AmdtpTiming.hpp
+++ b/ASFWDriver/Audio/Wire/AMDTP/AmdtpTiming.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // AmdtpTiming.hpp

--- a/ASFWDriver/Audio/Wire/RawPcm24In32/RawPcm24In32Decoder.hpp
+++ b/ASFWDriver/Audio/Wire/RawPcm24In32/RawPcm24In32Decoder.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 
 #pragma once

--- a/ASFWDriver/Audio/Wire/RawPcm24In32/RawPcm24In32Encoder.hpp
+++ b/ASFWDriver/Audio/Wire/RawPcm24In32/RawPcm24In32Encoder.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 
 #pragma once

--- a/ASFWDriver/Bus/BusManager/BusManagerElection.cpp
+++ b/ASFWDriver/Bus/BusManager/BusManagerElection.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // BusManagerElection.cpp — see BusManagerElection.hpp

--- a/ASFWDriver/Bus/BusManager/BusManagerElection.hpp
+++ b/ASFWDriver/Bus/BusManager/BusManagerElection.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // BusManagerElection.hpp — IEEE 1394 Bus Manager election FSM (FW-18).

--- a/ASFWDriver/Bus/BusManager/BusManagerElectionDriver.cpp
+++ b/ASFWDriver/Bus/BusManager/BusManagerElectionDriver.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // BusManagerElectionDriver.cpp — see BusManagerElectionDriver.hpp

--- a/ASFWDriver/Bus/BusManager/BusManagerElectionDriver.hpp
+++ b/ASFWDriver/Bus/BusManager/BusManagerElectionDriver.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // BusManagerElectionDriver.hpp — Coordinates IEEE 1394 Bus Manager election (FW-18).

--- a/ASFWDriver/Bus/BusManager/BusManagerPolicyCoordinator.cpp
+++ b/ASFWDriver/Bus/BusManager/BusManagerPolicyCoordinator.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // BusManagerPolicyCoordinator.cpp — see BusManagerPolicyCoordinator.hpp

--- a/ASFWDriver/Bus/BusManager/BusManagerPolicyCoordinator.hpp
+++ b/ASFWDriver/Bus/BusManager/BusManagerPolicyCoordinator.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // BusManagerPolicyCoordinator.hpp — Coordinates Bus Manager policy decisions (FW-14).

--- a/ASFWDriver/Bus/BusManager/CyclePolicyCoordinator.cpp
+++ b/ASFWDriver/Bus/BusManager/CyclePolicyCoordinator.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // CyclePolicyCoordinator.cpp — see CyclePolicyCoordinator.hpp

--- a/ASFWDriver/Bus/BusManager/CyclePolicyCoordinator.hpp
+++ b/ASFWDriver/Bus/BusManager/CyclePolicyCoordinator.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // CyclePolicyCoordinator.hpp — Cycle start generation policy and repair planner (Milestone 5).

--- a/ASFWDriver/Bus/BusManager/GapPolicyCoordinator.cpp
+++ b/ASFWDriver/Bus/BusManager/GapPolicyCoordinator.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // GapPolicyCoordinator.cpp — see GapPolicyCoordinator.hpp

--- a/ASFWDriver/Bus/BusManager/GapPolicyCoordinator.hpp
+++ b/ASFWDriver/Bus/BusManager/GapPolicyCoordinator.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // GapPolicyCoordinator.hpp — Gap count optimization policy and planner (Milestone 7).

--- a/ASFWDriver/Bus/BusManager/PowerLinkPolicyCoordinator.cpp
+++ b/ASFWDriver/Bus/BusManager/PowerLinkPolicyCoordinator.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // PowerLinkPolicyCoordinator.cpp — see PowerLinkPolicyCoordinator.hpp

--- a/ASFWDriver/Bus/BusManager/PowerLinkPolicyCoordinator.hpp
+++ b/ASFWDriver/Bus/BusManager/PowerLinkPolicyCoordinator.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // PowerLinkPolicyCoordinator.hpp — Power management and Link-On policy (Milestone 8).

--- a/ASFWDriver/Bus/BusManager/RootSelectionCoordinator.cpp
+++ b/ASFWDriver/Bus/BusManager/RootSelectionCoordinator.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // RootSelectionCoordinator.cpp — see RootSelectionCoordinator.hpp

--- a/ASFWDriver/Bus/BusManager/RootSelectionCoordinator.hpp
+++ b/ASFWDriver/Bus/BusManager/RootSelectionCoordinator.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // RootSelectionCoordinator.hpp — Root selection and force-root policy (Milestone 6).

--- a/ASFWDriver/Bus/CSR/BroadcastChannelCSR.hpp
+++ b/ASFWDriver/Bus/CSR/BroadcastChannelCSR.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // BroadcastChannelCSR.hpp — Local software-owned BROADCAST_CHANNEL register (FW-19).

--- a/ASFWDriver/Bus/CSR/CSRContract.hpp
+++ b/ASFWDriver/Bus/CSR/CSRContract.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // CSRContract.hpp — IEEE 1212 / IEEE 1394 Bus Manager CSR ownership contract.

--- a/ASFWDriver/Bus/CSR/CSRContractVerifier.cpp
+++ b/ASFWDriver/Bus/CSR/CSRContractVerifier.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // CSRContractVerifier.cpp — see CSRContractVerifier.hpp

--- a/ASFWDriver/Bus/CSR/CSRContractVerifier.hpp
+++ b/ASFWDriver/Bus/CSR/CSRContractVerifier.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // CSRContractVerifier.hpp — Diagnostic verifier for CSR ownership (Milestone 9).

--- a/ASFWDriver/Bus/CSR/CSRHardwareAdapters.hpp
+++ b/ASFWDriver/Bus/CSR/CSRHardwareAdapters.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // CSRHardwareAdapters.hpp — production adapters binding CSRResponder's injected

--- a/ASFWDriver/Bus/CSR/CSRResponder.cpp
+++ b/ASFWDriver/Bus/CSR/CSRResponder.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // CSRResponder.cpp — see CSRResponder.hpp. Semantics ported from in-tree Linux

--- a/ASFWDriver/Bus/CSR/CSRResponder.hpp
+++ b/ASFWDriver/Bus/CSR/CSRResponder.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // CSRResponder.hpp — local software-owned CSR responder surface (FW-19).

--- a/ASFWDriver/Bus/CSR/SpeedMapService.cpp
+++ b/ASFWDriver/Bus/CSR/SpeedMapService.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // SpeedMapService.cpp — see SpeedMapService.hpp

--- a/ASFWDriver/Bus/CSR/SpeedMapService.hpp
+++ b/ASFWDriver/Bus/CSR/SpeedMapService.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // SpeedMapService.hpp — Local software-owned SPEED_MAP CSR register (FW-20/M9).

--- a/ASFWDriver/Bus/CSR/TopologyMapBuilder.cpp
+++ b/ASFWDriver/Bus/CSR/TopologyMapBuilder.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // TopologyMapBuilder.cpp — see TopologyMapBuilder.hpp

--- a/ASFWDriver/Bus/CSR/TopologyMapBuilder.hpp
+++ b/ASFWDriver/Bus/CSR/TopologyMapBuilder.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // TopologyMapBuilder.hpp — pure helper to construct IEEE 1394 topology map (FW-20).

--- a/ASFWDriver/Bus/CSR/TopologyMapService.cpp
+++ b/ASFWDriver/Bus/CSR/TopologyMapService.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // TopologyMapService.cpp — see TopologyMapService.hpp

--- a/ASFWDriver/Bus/CSR/TopologyMapService.hpp
+++ b/ASFWDriver/Bus/CSR/TopologyMapService.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // TopologyMapService.hpp — serves the IEEE 1394 topology map region (FW-20).

--- a/ASFWDriver/Bus/GapCountOptimizer.cpp
+++ b/ASFWDriver/Bus/GapCountOptimizer.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 ASFW Project
 
 #include "GapCountOptimizer.hpp"

--- a/ASFWDriver/Bus/GapCountOptimizer.hpp
+++ b/ASFWDriver/Bus/GapCountOptimizer.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 ASFW Project
 
 #pragma once

--- a/ASFWDriver/Bus/IRM/IRMCSRConstants.hpp
+++ b/ASFWDriver/Bus/IRM/IRMCSRConstants.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // IRMCSRConstants.hpp — IEEE 1394 IRM CSR addresses and spec values.

--- a/ASFWDriver/Bus/IRM/IRMFallbackCoordinator.cpp
+++ b/ASFWDriver/Bus/IRM/IRMFallbackCoordinator.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // IRMFallbackCoordinator.cpp — see IRMFallbackCoordinator.hpp

--- a/ASFWDriver/Bus/IRM/IRMFallbackCoordinator.hpp
+++ b/ASFWDriver/Bus/IRM/IRMFallbackCoordinator.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // IRMFallbackCoordinator.hpp — IRM fallback detector and cycle policy planner (Milestone 4).

--- a/ASFWDriver/Bus/IRM/LocalCSRAccessor.cpp
+++ b/ASFWDriver/Bus/IRM/LocalCSRAccessor.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // LocalCSRAccessor.cpp — see LocalCSRAccessor.hpp

--- a/ASFWDriver/Bus/IRM/LocalCSRAccessor.hpp
+++ b/ASFWDriver/Bus/IRM/LocalCSRAccessor.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // LocalCSRAccessor.hpp — Thin wrapper for local autonomous CSR access.

--- a/ASFWDriver/Bus/IRM/LocalIRMResourceCSRHandler.cpp
+++ b/ASFWDriver/Bus/IRM/LocalIRMResourceCSRHandler.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // LocalIRMResourceCSRHandler.cpp — see LocalIRMResourceCSRHandler.hpp

--- a/ASFWDriver/Bus/IRM/LocalIRMResourceCSRHandler.hpp
+++ b/ASFWDriver/Bus/IRM/LocalIRMResourceCSRHandler.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // LocalIRMResourceCSRHandler.hpp — inbound local CSR adapter for OHCI IRM resources.

--- a/ASFWDriver/Bus/IRM/LocalIRMResourceController.cpp
+++ b/ASFWDriver/Bus/IRM/LocalIRMResourceController.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // LocalIRMResourceController.cpp — see LocalIRMResourceController.hpp

--- a/ASFWDriver/Bus/IRM/LocalIRMResourceController.hpp
+++ b/ASFWDriver/Bus/IRM/LocalIRMResourceController.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // LocalIRMResourceController.hpp — Manages local IRM CSR registers (FW-13/19).

--- a/ASFWDriver/Common/CSRSpace.hpp
+++ b/ASFWDriver/Common/CSRSpace.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // CSRSpace.hpp — CSR address space: register constants, Config ROM structure, bus options

--- a/ASFWDriver/Common/FWTypes.hpp
+++ b/ASFWDriver/Common/FWTypes.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // FWTypes.hpp — FireWire protocol enums, strong types, and transport constants

--- a/ASFWDriver/Common/TimingUtils.hpp
+++ b/ASFWDriver/Common/TimingUtils.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // TimingUtils.hpp

--- a/ASFWDriver/Common/WireFormat.hpp
+++ b/ASFWDriver/Common/WireFormat.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // WireFormat.hpp — Bit manipulation and byte-order utilities (no FireWire-specific concepts)

--- a/ASFWDriver/DeviceProfiles/Audio/AudioDeviceIds.hpp
+++ b/ASFWDriver/DeviceProfiles/Audio/AudioDeviceIds.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // AudioDeviceIds.hpp - Canonical IEEE OUI vendor IDs, model IDs and display names for

--- a/ASFWDriver/DeviceProfiles/Audio/AudioProfileRegistry.hpp
+++ b/ASFWDriver/DeviceProfiles/Audio/AudioProfileRegistry.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // AudioProfileRegistry.hpp - Aggregates the per-vendor audio profile providers into one

--- a/ASFWDriver/DeviceProfiles/Audio/AudioProfileTypes.hpp
+++ b/ASFWDriver/DeviceProfiles/Audio/AudioProfileTypes.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // AudioProfileTypes.hpp - Metadata hints describing which audio family/profile a

--- a/ASFWDriver/DeviceProfiles/Audio/Vendors/AlesisAudioProfiles.hpp
+++ b/ASFWDriver/DeviceProfiles/Audio/Vendors/AlesisAudioProfiles.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // AlesisAudioProfiles.hpp - Alesis FireWire audio device knowledge (DICE/TCAT).

--- a/ASFWDriver/DeviceProfiles/Audio/Vendors/ApogeeAudioProfiles.hpp
+++ b/ASFWDriver/DeviceProfiles/Audio/Vendors/ApogeeAudioProfiles.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // ApogeeAudioProfiles.hpp - Apogee FireWire audio device knowledge (Oxford / AV/C).

--- a/ASFWDriver/DeviceProfiles/Audio/Vendors/FocusriteAudioProfiles.hpp
+++ b/ASFWDriver/DeviceProfiles/Audio/Vendors/FocusriteAudioProfiles.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // FocusriteAudioProfiles.hpp - Focusrite FireWire audio device knowledge (DICE/TCAT).

--- a/ASFWDriver/DeviceProfiles/Audio/Vendors/MidasAudioProfiles.hpp
+++ b/ASFWDriver/DeviceProfiles/Audio/Vendors/MidasAudioProfiles.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // MidasAudioProfiles.hpp - Midas FireWire audio device knowledge (DICE/TCAT).

--- a/ASFWDriver/DeviceProfiles/Common/DeviceProfileTypes.hpp
+++ b/ASFWDriver/DeviceProfiles/Common/DeviceProfileTypes.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // DeviceProfileTypes.hpp - Neutral, metadata-only inputs for device profile matching.

--- a/ASFWDriver/Service/LocalRequestWiring.cpp
+++ b/ASFWDriver/Service/LocalRequestWiring.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // LocalRequestWiring.cpp — see LocalRequestWiring.hpp. The single home for the

--- a/ASFWDriver/Service/LocalRequestWiring.hpp
+++ b/ASFWDriver/Service/LocalRequestWiring.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // LocalRequestWiring.hpp — single entry point that builds the LocalRequestDispatch,

--- a/ASFWDriver/Testing/HostDriverKitStubs.hpp
+++ b/ASFWDriver/Testing/HostDriverKitStubs.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // HostDriverKitStubs.hpp — Minimal stubs for DriverKit types to allow unit testing on host.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,20 @@
+ASFireWire
+Copyright 2024-2026 ASFireWire Project Contributors
+
+This product includes software developed as part of the ASFireWire
+project (https://github.com/mrmidi/ASFireWire).
+
+---
+
+The FWAddress structure in ASFWDriver/Async/AsyncTypes.hpp reproduces the
+public API layout of the FWAddress structure from Apple's IOFireWireFamily
+(IOFireWireFamilyCommon.h), published under the Apple Public Source
+License 2.0 (https://opensource.org/license/apsl-2-0), for API
+compatibility. No implementation code from IOFireWireFamily is included.
+
+Wire and bus behavior in this project has been validated against the
+following works, used strictly as behavioral references (no code copied):
+  - Linux kernel drivers/firewire and sound/firewire (GPL-2.0)
+  - Apple IOFireWireFamily, IOFireWireAVC, IOFireWireSBP2 (APSL-2.0)
+  - libffado (GPL-2.0/GPL-3.0)
+  - snd-firewire-ctl-services (GPL-3.0)

--- a/README.md
+++ b/README.md
@@ -361,6 +361,19 @@ Contributions are VERY welcome! If you want to contribute to the project, please
 
 Literally any help is appreciated, from fixing typos in documentation to implementing new features or fixing bugs. Writing tests, improving code quality, testing on hardware, and reporting regressions are all valuable. Hardware reports for supported Saffire devices are especially useful right now. If you have any experience with FireWire protocol, just opening an issue or emailing me is invaluable. If you have any experience with Swift, the ASFW app could use some love too.
 
+## License
+
+ASFireWire is licensed under the [Apache License, Version 2.0](LICENSE).
+
+The in-tree reference stacks used for behavioral validation (Linux
+`drivers/firewire`, Apple IOFireWireFamily, libffado, and others) are **not**
+part of this repository and are never distributed with it; they are consulted
+as read-only behavioral references and no code from them is copied. See
+[NOTICE](NOTICE) for attribution details.
+
+Contributions are accepted under the terms of the Apache License 2.0
+(inbound = outbound, per section 5 of the license).
+
 ## Contacts
 
 You can reach me via:

--- a/tests/audio/AudioProfileRegistryTests.cpp
+++ b/tests/audio/AudioProfileRegistryTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 //
 // Pins the metadata behavior of the DeviceProfiles audio layer: identity enrichment,
 // Focusrite GUID inference (including the Pro 40 / TCD3070 quirk), and the integration

--- a/tests/audio/DiceProfileTests.cpp
+++ b/tests/audio/DiceProfileTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // DiceProfileTests.cpp

--- a/tests/audio/TxRefillCoverageTests.cpp
+++ b/tests/audio/TxRefillCoverageTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // TxRefillCoverageTests.cpp

--- a/tests/common/CSRContractVerifierTests.cpp
+++ b/tests/common/CSRContractVerifierTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // CSRContractVerifierTests.cpp — Unit tests for CSRContractVerifier (Milestone 9).

--- a/tests/common/CSRResponderContractTests.cpp
+++ b/tests/common/CSRResponderContractTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // CSRResponderContractTests.cpp — Verifies CSR ownership split (Milestone 9).

--- a/tests/common/CSRResponderTests.cpp
+++ b/tests/common/CSRResponderTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // CSRResponderTests.cpp — FW-19 software CSR responder surface.

--- a/tests/common/CapabilityModeTests.cpp
+++ b/tests/common/CapabilityModeTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // CapabilityModeTests.cpp — FW-22 role-mode capability advertisement.

--- a/tests/common/DeviceProtocolFactoryTests.cpp
+++ b/tests/common/DeviceProtocolFactoryTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
 

--- a/tests/common/LocalRequestDispatchTests.cpp
+++ b/tests/common/LocalRequestDispatchTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // LocalRequestDispatchTests.cpp — FW-19 central inbound-request routing.

--- a/tests/common/SpeedMapServiceTests.cpp
+++ b/tests/common/SpeedMapServiceTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // SpeedMapServiceTests.cpp — Unit tests for SpeedMapService (Milestone 9).

--- a/tests/core/BusManagerElectionTests.cpp
+++ b/tests/core/BusManagerElectionTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // BusManagerElectionTests.cpp — Unit tests for Bus Manager election (FW-18).

--- a/tests/core/CyclePolicyCoordinatorTests.cpp
+++ b/tests/core/CyclePolicyCoordinatorTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // CyclePolicyCoordinatorTests.cpp — Unit tests for CyclePolicyCoordinator.

--- a/tests/core/CyclePolicyExecutorTests.cpp
+++ b/tests/core/CyclePolicyExecutorTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // CyclePolicyExecutorTests.cpp — Unit tests for CyclePolicyCoordinator executor logic.

--- a/tests/core/GapCountOptimizerTests.cpp
+++ b/tests/core/GapCountOptimizerTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 ASFW Project
 
 #include <gtest/gtest.h>

--- a/tests/core/GapPolicyCoordinatorTests.cpp
+++ b/tests/core/GapPolicyCoordinatorTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // GapPolicyCoordinatorTests.cpp — Unit tests for GapPolicyCoordinator (Milestone 7).

--- a/tests/core/HardwareInterfaceOrderTests.cpp
+++ b/tests/core/HardwareInterfaceOrderTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // HardwareInterfaceOrderTests.cpp — Regression tests for CSRControl write order and cycle master.

--- a/tests/core/PostResetTimingTests.cpp
+++ b/tests/core/PostResetTimingTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 ASFW Project
 //
 // Host tests for the Milestone 2 post-reset timing core. Pure logic: the clock

--- a/tests/core/PowerLinkPolicyCoordinatorTests.cpp
+++ b/tests/core/PowerLinkPolicyCoordinatorTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // PowerLinkPolicyCoordinatorTests.cpp — Unit tests for PowerLinkPolicyCoordinator (Milestone 8).

--- a/tests/core/RootSelectionCoordinatorTests.cpp
+++ b/tests/core/RootSelectionCoordinatorTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // RootSelectionCoordinatorTests.cpp — Unit tests for RootSelectionCoordinator (Milestone 6).

--- a/tests/core/SelfIDStreamParserTests.cpp
+++ b/tests/core/SelfIDStreamParserTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 ASFW Project
 
 #include <gtest/gtest.h>

--- a/tests/core/SelfIDTopologyNormalizerTests.cpp
+++ b/tests/core/SelfIDTopologyNormalizerTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 ASFW Project
 
 #include <gtest/gtest.h>

--- a/tests/core/TopologyGapExtractionTests.cpp
+++ b/tests/core/TopologyGapExtractionTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2025 ASFW Project
 
 #include <gtest/gtest.h>

--- a/tests/core/TopologyMapBuilderTests.cpp
+++ b/tests/core/TopologyMapBuilderTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // TopologyMapBuilderTests.cpp — unit tests for BuildTopologyMap (FW-20).

--- a/tests/devices/ApogeeDuetVendorCmdTests.cpp
+++ b/tests/devices/ApogeeDuetVendorCmdTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // ApogeeDuetVendorCmdTests.cpp - Unit tests for Apogee Duet vendor command encoding/decoding

--- a/tests/devices/DiceRecoveryPolicyTests.cpp
+++ b/tests/devices/DiceRecoveryPolicyTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // FW-66 characterization tests for the recovery-policy decision kernel extracted from

--- a/tests/devices/DuplexOperationGateTests.cpp
+++ b/tests/devices/DuplexOperationGateTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // FW-68 characterization tests for DuplexOperationGate, the per-GUID duplex operation gate

--- a/tests/devices/RestartJournalTests.cpp
+++ b/tests/devices/RestartJournalTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // FW-69a characterization tests for RestartJournal — the FSM-journal state mutators extracted

--- a/tests/devices/RestartSessionStoreTests.cpp
+++ b/tests/devices/RestartSessionStoreTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // FW-69b characterization tests for RestartSessionStore — the per-GUID session store + restart-id

--- a/tests/devices/WaitForAsyncResultTests.cpp
+++ b/tests/devices/WaitForAsyncResultTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
 // FW-65 characterization tests for the WaitForAsyncResult sync/async bridge.

--- a/tests/irm/BroadcastChannelCSRTests.cpp
+++ b/tests/irm/BroadcastChannelCSRTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // BroadcastChannelCSRTests.cpp — Unit tests for BroadcastChannelCSR.

--- a/tests/irm/IRMFallbackCoordinatorTests.cpp
+++ b/tests/irm/IRMFallbackCoordinatorTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // IRMFallbackCoordinatorTests.cpp — Unit tests for IRMFallbackCoordinator (Milestone 4).

--- a/tests/irm/LocalIRMResourceCSRHandlerTests.cpp
+++ b/tests/irm/LocalIRMResourceCSRHandlerTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // LocalIRMResourceCSRHandlerTests.cpp — local OHCI-backed IRM CSR routing.

--- a/tests/irm/LocalIRMResourceControllerTests.cpp
+++ b/tests/irm/LocalIRMResourceControllerTests.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 ASFireWire Project
 //
 // LocalIRMResourceControllerTests.cpp — Unit tests for LocalIRMResourceController.


### PR DESCRIPTION
## Summary

The repository currently has **no LICENSE file**, which under default copyright law means "all rights reserved" — forks and users have no legal right to use, modify, or redistribute the code. Meanwhile the source files carry contradictory SPDX headers: **145 files** say `LGPL-3.0-or-later`, **17 files** say `MIT`, and ~670 files have no header. All copyright lines say "ASFireWire Project", so these appear self-authored and inconsistently generated rather than imported.

This PR proposes formalizing the project under the **Apache License 2.0**:

- Adds top-level `LICENSE` (verbatim Apache 2.0 text) and `NOTICE`
- Normalizes all 162 existing SPDX headers to `Apache-2.0`
- Adds APSL-2.0 attribution to the `FWAddress` API-compatibility port from Apple IOFireWireFamily (`ASFWDriver/Async/AsyncTypes.hpp`)
- Adds a License section to the README, clarifying that the gitignored `references/` stacks (Linux, Apple, libffado) are read-only behavioral references, never distributed, and that no code is copied from them

## Why Apache 2.0

A tree audit (grep for ported/copied/verbatim markers and license identifiers) found nothing that forces copyleft:

- No verbatim GPL copying — Linux/Apple mentions are behavioral citations ("cross-validated with…")
- `FWAddress` reproduces an API layout from IOFireWireFamily (APSL-2.0) — interface-level, now attributed
- `CSRResponder.cpp` ports *semantics* from Linux, not code
- Swift app dependencies are all Apache-2.0/MIT

Apache 2.0 over MIT because of the explicit patent grant (§3), which is meaningful for driver code. LGPL-3.0 (the majority header today) is an awkward fit for a statically linked dext — the library-swap mechanism it's built around doesn't apply.

## ⚠️ Contributor consent required before merge

The 145 files currently marked `LGPL-3.0-or-later` carry an explicit license grant. Changing that grant requires consent from everyone with copyrightable contributions to those files. This PR is a **draft** until the contributors below have acked (a simple "I consent to relicensing my contributions under Apache-2.0" comment suffices):

- [x] @mrmidi (Aleksandr Shabelnikov)
- [x] @gly11
- [x] Chris Izatt (@boggspa)
- [x] Brian Hoffman
- [x] Mathias Hellevang — consented (PR author)
- [x] @alicankaralar

(Only those with non-trivial changes in the LGPL-marked files strictly need to consent; listing everyone for completeness.)

**Consent window:** if no objection is raised within **14 days** of this PR (2026-07-23), we treat silence from the remaining contributors as no objection and proceed. Their footprint in the relicensed files is small (git log: gly11 11 commits, Brian Hoffman 2, vs. 826 for @mrmidi). If anyone objects later, their contributions will be rewritten or their files reverted to LGPL — no one's grant is changed over their objection.

## Notes

- Going forward, contributions are inbound = outbound per Apache-2.0 §5 — no CLA needed.
- Follow-up (optional, separate PR): add SPDX headers to the ~670 files that have none.

