### PR TITLE
Remove stale fw-tests submodule

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-          submodules: recursive
 
       - name: Install Dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ ADKVirtualAudioLab/ADKVirtualAudioLab.xcodeproj/
 # Local scratch / tool artifacts
 /Testing/
 /tmp/
+/fw-tests/am-config-roms/
 /CMakeLists.txt.bak
 /validation_data.json
 __pycache__/


### PR DESCRIPTION
## Summary
- remove the stale `fw-tests/am-config-roms` submodule gitlink
- stop CI checkout from recursively initializing submodules
- ignore the local `fw-tests/am-config-roms` checkout so it can remain on disk without entering repo state

## Root cause
GitHub Actions was running `actions/checkout` with `submodules: recursive`, but the repository tracked `fw-tests/am-config-roms` as a submodule without a matching `.gitmodules` URL. Checkout failed before the build began.

## Validation
- `git diff HEAD --check`
- verified no `160000` gitlink entries remain in the index
- `git submodule update --init --force --recursive`