### PR TITLE
FW-67: audio: extract clock request broker

### DIFF
--- a/ASFWDriver/Audio/Protocols/Backends/ClockRequestBroker.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/ClockRequestBroker.hpp
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 ASFireWire Project
+//
+// ClockRequestBroker.hpp
+//
+// FW-67: clock-request token allocation, pending-request coalescing, and
+// completion delivery extracted from DiceDuplexRestartCoordinator. The broker owns the pending
+// and completed per-GUID maps plus the monotonic token allocator; it deliberately BORROWS the
+// coordinator's existing IOLock* rather than creating a lock or queue of its own.
+//
+// That borrowed lock is load-bearing. RequestClockConfig and ClearSession each make one atomic
+// update across this broker, RestartSessionStore, and DuplexOperationGate. Splitting those
+// updates across independently locked components would permit an observer to see a pending
+// request without the corresponding session flag (or vice versa). Like the other extracted
+// helpers, the broker therefore provides both:
+//   * self-locking operations for ordinary producer/consumer/completion paths; and
+//   * *Locked operations for the coordinator's existing multi-domain critical sections.
+//
+// The DICE names are intentional for now; FW-73 performs the mechanical neutral rename after
+// the protocol-neutral coordinator path is complete.
+
+#pragma once
+
+#include "RestartJournal.hpp"
+#include "RestartSessionStore.hpp"
+
+#include <DriverKit/IOLib.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <optional>
+#include <unordered_map>
+
+namespace ASFW::Audio::Backends {
+
+using ASFW::Audio::DICE::DiceClockRequestCompletion;
+using ASFW::Audio::DICE::DiceClockRequestOutcome;
+using ASFW::Audio::DICE::DiceDesiredClockConfig;
+using ASFW::Audio::DICE::DiceRestartReason;
+
+class ClockRequestBroker {
+public:
+    struct PendingClockRequest {
+        DiceDesiredClockConfig desiredClock{};
+        DiceRestartReason reason{DiceRestartReason::kManualReconfigure};
+        uint64_t token{0};
+    };
+
+    // `lock` points at the coordinator's IOLock* member. `sessionStore` is the coordinator's
+    // lock-borrowing session store; both remain valid for the broker's lifetime.
+    ClockRequestBroker(IOLock** lock, RestartSessionStore& sessionStore) noexcept
+        : lockRef_(lock), sessionStore_(sessionStore) {}
+
+    // --- lock-held API: caller already holds *lockRef_. These keep RequestClockConfig and
+    // ClearSession's cross-component state mutations atomic on the coordinator lock.
+
+    [[nodiscard]] uint64_t AllocateTokenLocked() noexcept {
+        return nextClockToken_++;
+    }
+
+    // Replaces the queued request for guid, returns the displaced request when one existed, and
+    // mirrors the new pending state into its restart session. This is the former contiguous
+    // pendingClockRequests_ + sessions_ mutation in RequestClockConfig.
+    [[nodiscard]] std::optional<PendingClockRequest> QueuePendingLocked(
+        uint64_t guid,
+        const PendingClockRequest& request) noexcept {
+        std::optional<PendingClockRequest> superseded{};
+        const auto existingIt = pendingClockRequests_.find(guid);
+        if (existingIt != pendingClockRequests_.end()) {
+            superseded = existingIt->second;
+        }
+        pendingClockRequests_[guid] = request;
+
+        auto* session = sessionStore_.FindSessionLocked(guid);
+        if (session != nullptr) {
+            session->pendingClock = request.desiredClock;
+            session->pendingReason = request.reason;
+            session->hasPendingClockRequest = true;
+        }
+        return superseded;
+    }
+
+    void ClearLocked(uint64_t guid) noexcept {
+        pendingClockRequests_.erase(guid);
+        completedClockRequests_.erase(guid);
+    }
+
+    // --- self-locking API: exact former coordinator helper behaviour.
+
+    [[nodiscard]] bool TryConsumePending(
+        uint64_t guid,
+        PendingClockRequest& outRequest) noexcept {
+        IOLock* const lock = *lockRef_;
+        if (!lock) {
+            return false;
+        }
+
+        IOLockLock(lock);
+        const bool consumed = TryConsumePendingLocked(guid, outRequest);
+        IOLockUnlock(lock);
+        return consumed;
+    }
+
+    [[nodiscard]] bool TryTakeCompleted(
+        uint64_t guid,
+        uint64_t token,
+        DiceClockRequestCompletion& outCompletion) noexcept {
+        IOLock* const lock = *lockRef_;
+        if (!lock) {
+            return false;
+        }
+
+        IOLockLock(lock);
+        auto storeIt = completedClockRequests_.find(guid);
+        if (storeIt == completedClockRequests_.end()) {
+            IOLockUnlock(lock);
+            return false;
+        }
+
+        auto completionIt = storeIt->second.byToken.find(token);
+        if (completionIt == storeIt->second.byToken.end()) {
+            IOLockUnlock(lock);
+            return false;
+        }
+
+        outCompletion = completionIt->second;
+        storeIt->second.byToken.erase(completionIt);
+        auto& order = storeIt->second.insertionOrder;
+        order.erase(std::remove(order.begin(), order.end(), token), order.end());
+        if (storeIt->second.byToken.empty() && order.empty()) {
+            completedClockRequests_.erase(storeIt);
+        }
+        IOLockUnlock(lock);
+        return true;
+    }
+
+    void Complete(const DiceClockRequestCompletion& completion, uint64_t guid) noexcept {
+        IOLock* const lock = *lockRef_;
+        if (!lock) {
+            return;
+        }
+
+        IOLockLock(lock);
+        auto& store = completedClockRequests_[guid];
+        if (store.byToken.find(completion.token) == store.byToken.end()) {
+            store.insertionOrder.push_back(completion.token);
+        }
+        store.byToken[completion.token] = completion;
+        while (store.insertionOrder.size() > kMaxCompletedClockRequestsPerGuid) {
+            const uint64_t evictedToken = store.insertionOrder.front();
+            store.insertionOrder.pop_front();
+            store.byToken.erase(evictedToken);
+        }
+
+        auto* session = sessionStore_.FindSessionLocked(guid);
+        if (session != nullptr) {
+            session->lastClockCompletion = completion;
+        }
+        IOLockUnlock(lock);
+
+        // Preserve the established [FSM] clock-completion trace verbatim; runtime consumers use
+        // these fields to correlate the synchronous clock request with restart progress.
+        ASFW_LOG_V2(DICE,
+                    "[FSM] clock token=%llu outcome=%{public}s status=0x%08x guid=0x%llx restartId=%llu gen=%u",
+                    completion.token,
+                    ToString(completion.outcome),
+                    static_cast<unsigned>(completion.status),
+                    guid,
+                    completion.restartId,
+                    GenerationValue(completion.generation));
+    }
+
+    void FailPending(
+        uint64_t guid,
+        DiceClockRequestOutcome outcome,
+        IOReturn status) noexcept {
+        PendingClockRequest request{};
+        if (!TryConsumePending(guid, request)) {
+            return;
+        }
+
+        // Keep the original lock boundaries: consuming the pending entry, reading the restart
+        // session, and publishing the completion are three separate operations. In particular,
+        // do not fold this into one new critical section; stop/recovery races intentionally see
+        // the same interleavings as before the extraction.
+        const auto session = sessionStore_.LoadSession(guid);
+        Complete(DiceClockRequestCompletion{
+                     .token = request.token,
+                     .desiredClock = request.desiredClock,
+                     .reason = request.reason,
+                     .outcome = outcome,
+                     .status = status,
+                     .restartId = session.restartId,
+                     .generation = session.topologyGeneration,
+                 },
+                 guid);
+    }
+
+private:
+    struct ClockCompletionStore {
+        std::unordered_map<uint64_t, DiceClockRequestCompletion> byToken{};
+        std::deque<uint64_t> insertionOrder{};
+    };
+
+    [[nodiscard]] bool TryConsumePendingLocked(
+        uint64_t guid,
+        PendingClockRequest& outRequest) noexcept {
+        const auto it = pendingClockRequests_.find(guid);
+        if (it == pendingClockRequests_.end()) {
+            return false;
+        }
+
+        outRequest = it->second;
+        pendingClockRequests_.erase(it);
+        auto* session = sessionStore_.FindSessionLocked(guid);
+        if (session != nullptr) {
+            session->pendingClock = {};
+            session->pendingReason = DiceRestartReason::kInitialStart;
+            session->hasPendingClockRequest = false;
+        }
+        return true;
+    }
+
+    IOLock** lockRef_;  // borrowed: &coordinator.lock_ (not owned; never allocated/freed here)
+    RestartSessionStore& sessionStore_;
+    std::unordered_map<uint64_t, PendingClockRequest> pendingClockRequests_{};
+    std::unordered_map<uint64_t, ClockCompletionStore> completedClockRequests_{};
+    uint64_t nextClockToken_{1};
+
+    static constexpr size_t kMaxCompletedClockRequestsPerGuid = 32;
+};
+
+} // namespace ASFW::Audio::Backends

--- a/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
@@ -14,7 +14,6 @@
 
 #include <DriverKit/IOLib.h>
 
-#include <algorithm>
 #include <atomic>
 #include <memory>
 #include <utility>
@@ -311,19 +310,9 @@ IOReturn DiceDuplexRestartCoordinator::RequestClockConfig(
         return kIOReturnAborted;
     }
 
-    request.token = nextClockToken_++;
+    request.token = clockRequests_.AllocateTokenLocked();
     if (gate_.IsActiveLocked(guid)) {
-        const auto existingIt = pendingClockRequests_.find(guid);
-        if (existingIt != pendingClockRequests_.end()) {
-            supersededRequest = existingIt->second;
-        }
-        pendingClockRequests_[guid] = request;
-        auto* sessionPtr = store_.FindSessionLocked(guid);
-        if (sessionPtr != nullptr) {
-            sessionPtr->pendingClock = request.desiredClock;
-            sessionPtr->pendingReason = request.reason;
-            sessionPtr->hasPendingClockRequest = true;
-        }
+        supersededRequest = clockRequests_.QueuePendingLocked(guid, request);
     } else {
         gate_.AcquireLocked(guid);
         shouldLaunchLoop = true;
@@ -429,8 +418,7 @@ void DiceDuplexRestartCoordinator::ClearSession(uint64_t guid) noexcept {
 
     IOLockLock(lock_);
     store_.EraseSessionLocked(guid);
-    pendingClockRequests_.erase(guid);
-    completedClockRequests_.erase(guid);
+    clockRequests_.ClearLocked(guid);
     gate_.ReleaseLocked(guid);
     gate_.ClearStopLocked(guid);
     IOLockUnlock(lock_);
@@ -1671,113 +1659,25 @@ bool DiceDuplexRestartCoordinator::IsRestartEpochCurrent(uint64_t guid,
 
 bool DiceDuplexRestartCoordinator::TryConsumePendingClockRequest(uint64_t guid,
                                                                  PendingClockRequest& outRequest) noexcept {
-    if (!lock_) {
-        return false;
-    }
-
-    IOLockLock(lock_);
-    const auto it = pendingClockRequests_.find(guid);
-    if (it == pendingClockRequests_.end()) {
-        IOLockUnlock(lock_);
-        return false;
-    }
-
-    outRequest = it->second;
-    pendingClockRequests_.erase(it);
-    auto* sessionPtr = store_.FindSessionLocked(guid);
-    if (sessionPtr != nullptr) {
-        sessionPtr->pendingClock = {};
-        sessionPtr->pendingReason = DiceRestartReason::kInitialStart;
-        sessionPtr->hasPendingClockRequest = false;
-    }
-    IOLockUnlock(lock_);
-    return true;
+    return clockRequests_.TryConsumePending(guid, outRequest);
 }
 
 bool DiceDuplexRestartCoordinator::TryTakeCompletedClockRequest(
     uint64_t guid,
     uint64_t token,
     DiceClockRequestCompletion& outCompletion) noexcept {
-    if (!lock_) {
-        return false;
-    }
-
-    IOLockLock(lock_);
-    auto storeIt = completedClockRequests_.find(guid);
-    if (storeIt == completedClockRequests_.end()) {
-        IOLockUnlock(lock_);
-        return false;
-    }
-
-    auto completionIt = storeIt->second.byToken.find(token);
-    if (completionIt == storeIt->second.byToken.end()) {
-        IOLockUnlock(lock_);
-        return false;
-    }
-
-    outCompletion = completionIt->second;
-    storeIt->second.byToken.erase(completionIt);
-    auto& order = storeIt->second.insertionOrder;
-    order.erase(std::remove(order.begin(), order.end(), token), order.end());
-    if (storeIt->second.byToken.empty() && order.empty()) {
-        completedClockRequests_.erase(storeIt);
-    }
-    IOLockUnlock(lock_);
-    return true;
+    return clockRequests_.TryTakeCompleted(guid, token, outCompletion);
 }
 
 void DiceDuplexRestartCoordinator::CompleteClockRequest(const DiceClockRequestCompletion& completion,
                                                         uint64_t guid) noexcept {
-    if (!lock_) {
-        return;
-    }
-
-    IOLockLock(lock_);
-    auto& store = completedClockRequests_[guid];
-    if (store.byToken.find(completion.token) == store.byToken.end()) {
-        store.insertionOrder.push_back(completion.token);
-    }
-    store.byToken[completion.token] = completion;
-    while (store.insertionOrder.size() > kMaxCompletedClockRequestsPerGuid) {
-        const uint64_t evictedToken = store.insertionOrder.front();
-        store.insertionOrder.pop_front();
-        store.byToken.erase(evictedToken);
-    }
-
-    auto* sessionPtr = store_.FindSessionLocked(guid);
-    if (sessionPtr != nullptr) {
-        sessionPtr->lastClockCompletion = completion;
-    }
-    IOLockUnlock(lock_);
-
-    ASFW_LOG_V2(DICE,
-                "[FSM] clock token=%llu outcome=%{public}s status=0x%08x guid=0x%llx restartId=%llu gen=%u",
-                completion.token,
-                ToString(completion.outcome),
-                static_cast<unsigned>(completion.status),
-                guid,
-                completion.restartId,
-                GenerationValue(completion.generation));
+    clockRequests_.Complete(completion, guid);
 }
 
 void DiceDuplexRestartCoordinator::FailPendingClockRequest(uint64_t guid,
                                                            DiceClockRequestOutcome outcome,
                                                            IOReturn status) noexcept {
-    PendingClockRequest request{};
-    if (TryConsumePendingClockRequest(guid, request)) {
-        const DiceRestartSession session = LoadSession(guid);
-        CompleteClockRequest(
-            DiceClockRequestCompletion{
-                .token = request.token,
-                .desiredClock = request.desiredClock,
-                .reason = request.reason,
-                .outcome = outcome,
-                .status = status,
-                .restartId = session.restartId,
-                .generation = session.topologyGeneration,
-            },
-            guid);
-    }
+    clockRequests_.FailPending(guid, outcome, status);
 }
 
 void DiceDuplexRestartCoordinator::RecordTeardownAbort(const char* stage,

--- a/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "ClockRequestBroker.hpp"
 #include "DiceHostTransport.hpp"
 #include "DuplexOperationGate.hpp"
 #include "RestartSessionStore.hpp"
@@ -15,12 +16,9 @@
 #include "../DICE/Core/DICERestartSession.hpp"
 
 #include <atomic>
-#include <deque>
 #include <functional>
 #include <memory>
 #include <optional>
-#include <unordered_map>
-#include <unordered_set>
 
 namespace ASFW::Audio {
 
@@ -63,16 +61,7 @@ public:
     }
 
 private:
-    struct PendingClockRequest {
-        DICE::DiceDesiredClockConfig desiredClock{};
-        DICE::DiceRestartReason reason{DICE::DiceRestartReason::kManualReconfigure};
-        uint64_t token{0};
-    };
-
-    struct ClockCompletionStore {
-        std::unordered_map<uint64_t, DICE::DiceClockRequestCompletion> byToken{};
-        std::deque<uint64_t> insertionOrder{};
-    };
+    using PendingClockRequest = Backends::ClockRequestBroker::PendingClockRequest;
 
     [[nodiscard]] IOReturn RunStartStreaming(uint64_t guid) noexcept;
     [[nodiscard]] IOReturn RunStopStreaming(uint64_t guid) noexcept;
@@ -155,9 +144,9 @@ private:
     // FW-69b: per-GUID session persistence + restart-id allocator. Borrows &lock_ (see
     // RestartSessionStore) so its critical sections share the coordinator's single lock.
     Backends::RestartSessionStore store_{&lock_};
-    std::unordered_map<uint64_t, PendingClockRequest> pendingClockRequests_{};
-    std::unordered_map<uint64_t, ClockCompletionStore> completedClockRequests_{};
-    uint64_t nextClockToken_{1};
+    // FW-67: clock token + pending/completion delivery. Borrows &lock_ and shares the store so
+    // pending/completion state remains atomic with the restart-session snapshot.
+    Backends::ClockRequestBroker clockRequests_{&lock_, store_};
     std::atomic<uint64_t> teardownAbortCount_{0};
 
     static constexpr uint32_t kSyncBridgeTimeoutMs = 12000;
@@ -165,7 +154,6 @@ private:
     static constexpr uint32_t kGlobalClockLockTimeoutMs = 1000;
     static constexpr uint32_t kGlobalClockLockPollMs = 10;
     static constexpr uint32_t kGlobalClockStableReads = 3;
-    static constexpr size_t kMaxCompletedClockRequestsPerGuid = 32;
 };
 
 } // namespace ASFW::Audio

--- a/tests/devices/CMakeLists.txt
+++ b/tests/devices/CMakeLists.txt
@@ -80,6 +80,11 @@ add_device_test(RestartSessionStoreTests
     RestartSessionStoreTests.cpp
 )
 
+# DICE clock-request broker tests (FW-67, header-only lock-borrowing broker)
+add_device_test(ClockRequestBrokerTests
+    ClockRequestBrokerTests.cpp
+)
+
 # Apogee protocol boolean control mapping tests
 add_device_test(ApogeeBooleanControlMappingTests
     ApogeeBooleanControlMappingTests.cpp
@@ -90,5 +95,4 @@ add_device_test(ApogeeDuetVendorCmdTests
     ApogeeDuetVendorCmdTests.cpp
     "${ASFW_DRIVER_DIR}/Audio/Protocols/Oxford/Apogee/ApogeeDuetProtocol.cpp"
 )
-
 

--- a/tests/devices/ClockRequestBrokerTests.cpp
+++ b/tests/devices/ClockRequestBrokerTests.cpp
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 ASFireWire Project
+//
+// FW-67 characterization tests for ClockRequestBroker. These pin the clock-token, latest-wins
+// pending queue, completion mailbox, eviction, and restart-session mirror behaviour extracted
+// from DiceDuplexRestartCoordinator. Host tests, no hardware.
+
+#include <gtest/gtest.h>
+
+#include <DriverKit/IOLib.h>
+
+#include "Audio/Protocols/Backends/ClockRequestBroker.hpp"
+
+namespace {
+
+using ASFW::Audio::Backends::ClockRequestBroker;
+using ASFW::Audio::Backends::RestartSessionStore;
+using ASFW::Audio::DICE::DiceClockRequestCompletion;
+using ASFW::Audio::DICE::DiceClockRequestOutcome;
+using ASFW::Audio::DICE::DiceRestartReason;
+using ASFW::Audio::DICE::DiceRestartSession;
+
+constexpr uint64_t kGuid = 0x0011223344556677ULL;
+
+class ClockRequestBrokerTest : public ::testing::Test {
+protected:
+    void SetUp() override { ASSERT_NE(lock_, nullptr); }
+    void TearDown() override {
+        if (lock_) {
+            IOLockFree(lock_);
+        }
+    }
+
+    ClockRequestBroker::PendingClockRequest QueueLocked(
+        uint32_t sampleRateHz,
+        DiceRestartReason reason = DiceRestartReason::kManualReconfigure) {
+        IOLockLock(lock_);
+        ClockRequestBroker::PendingClockRequest request{
+            .desiredClock = {.sampleRateHz = sampleRateHz, .clockSelect = sampleRateHz / 1000U},
+            .reason = reason,
+            .token = broker_.AllocateTokenLocked(),
+        };
+        EXPECT_FALSE(broker_.QueuePendingLocked(kGuid, request).has_value());
+        IOLockUnlock(lock_);
+        return request;
+    }
+
+    IOLock* lock_ = IOLockAlloc();
+    RestartSessionStore store_{&lock_};
+    ClockRequestBroker broker_{&lock_, store_};
+};
+
+TEST_F(ClockRequestBrokerTest, TokenAllocationStartsAtOneAndIsMonotonic) {
+    IOLockLock(lock_);
+    EXPECT_EQ(broker_.AllocateTokenLocked(), 1u);
+    EXPECT_EQ(broker_.AllocateTokenLocked(), 2u);
+    EXPECT_EQ(broker_.AllocateTokenLocked(), 3u);
+    IOLockUnlock(lock_);
+}
+
+// RequestClockConfig holds the coordinator lock across queue insertion and session mutation.
+// The broker must preserve that atomic latest-wins update, including its session mirror.
+TEST_F(ClockRequestBrokerTest, QueuePendingLatestWinsAndMirrorsRestartSession) {
+    DiceRestartSession session{};
+    session.guid = kGuid;
+    store_.StoreSession(session);
+
+    IOLockLock(lock_);
+    const ClockRequestBroker::PendingClockRequest first{
+        .desiredClock = {.sampleRateHz = 44100, .clockSelect = 44},
+        .reason = DiceRestartReason::kSampleRateChange,
+        .token = broker_.AllocateTokenLocked(),
+    };
+    EXPECT_FALSE(broker_.QueuePendingLocked(kGuid, first).has_value());
+
+    const ClockRequestBroker::PendingClockRequest replacement{
+        .desiredClock = {.sampleRateHz = 48000, .clockSelect = 48},
+        .reason = DiceRestartReason::kClockSourceChange,
+        .token = broker_.AllocateTokenLocked(),
+    };
+    const auto superseded = broker_.QueuePendingLocked(kGuid, replacement);
+    ASSERT_TRUE(superseded.has_value());
+    EXPECT_EQ(superseded->token, first.token);
+    EXPECT_EQ(superseded->desiredClock.sampleRateHz, 44100u);
+    IOLockUnlock(lock_);
+
+    const auto mirrored = store_.GetSession(kGuid);
+    ASSERT_TRUE(mirrored.has_value());
+    EXPECT_TRUE(mirrored->hasPendingClockRequest);
+    EXPECT_EQ(mirrored->pendingClock.sampleRateHz, 48000u);
+    EXPECT_EQ(mirrored->pendingReason, DiceRestartReason::kClockSourceChange);
+
+    ClockRequestBroker::PendingClockRequest consumed{};
+    ASSERT_TRUE(broker_.TryConsumePending(kGuid, consumed));
+    EXPECT_EQ(consumed.token, replacement.token);
+    EXPECT_EQ(consumed.desiredClock.sampleRateHz, 48000u);
+}
+
+TEST_F(ClockRequestBrokerTest, ConsumeClearsPendingMirrorAndOnlyConsumesOnce) {
+    DiceRestartSession session{};
+    session.guid = kGuid;
+    store_.StoreSession(session);
+    const auto request = QueueLocked(48000);
+
+    ClockRequestBroker::PendingClockRequest consumed{};
+    ASSERT_TRUE(broker_.TryConsumePending(kGuid, consumed));
+    EXPECT_EQ(consumed.token, request.token);
+    EXPECT_EQ(consumed.desiredClock.sampleRateHz, request.desiredClock.sampleRateHz);
+    EXPECT_FALSE(broker_.TryConsumePending(kGuid, consumed));
+
+    const auto mirrored = store_.GetSession(kGuid);
+    ASSERT_TRUE(mirrored.has_value());
+    EXPECT_FALSE(mirrored->hasPendingClockRequest);
+    EXPECT_EQ(mirrored->pendingClock.sampleRateHz, 0u);
+    EXPECT_EQ(mirrored->pendingReason, DiceRestartReason::kInitialStart);
+}
+
+TEST_F(ClockRequestBrokerTest, CompleteDeliversOnceAndUpdatesLastClockCompletion) {
+    DiceRestartSession session{};
+    session.guid = kGuid;
+    store_.StoreSession(session);
+
+    const DiceClockRequestCompletion completion{
+        .token = 17,
+        .desiredClock = {.sampleRateHz = 96000, .clockSelect = 96},
+        .reason = DiceRestartReason::kManualReconfigure,
+        .outcome = DiceClockRequestOutcome::kApplied,
+        .status = kIOReturnSuccess,
+        .restartId = 9,
+        .generation = ASFW::FW::Generation{3},
+    };
+    broker_.Complete(completion, kGuid);
+
+    const auto afterComplete = store_.GetSession(kGuid);
+    ASSERT_TRUE(afterComplete.has_value());
+    ASSERT_TRUE(afterComplete->lastClockCompletion.has_value());
+    EXPECT_EQ(afterComplete->lastClockCompletion->token, completion.token);
+    EXPECT_EQ(afterComplete->lastClockCompletion->outcome, DiceClockRequestOutcome::kApplied);
+
+    DiceClockRequestCompletion taken{};
+    ASSERT_TRUE(broker_.TryTakeCompleted(kGuid, completion.token, taken));
+    EXPECT_EQ(taken.token, completion.token);
+    EXPECT_EQ(taken.status, kIOReturnSuccess);
+    EXPECT_FALSE(broker_.TryTakeCompleted(kGuid, completion.token, taken));
+}
+
+TEST_F(ClockRequestBrokerTest, FailPendingPublishesFailureWithCurrentSessionEpoch) {
+    DiceRestartSession session{};
+    session.guid = kGuid;
+    session.restartId = 11;
+    session.topologyGeneration = ASFW::FW::Generation{7};
+    store_.StoreSession(session);
+    const auto request = QueueLocked(88200, DiceRestartReason::kClockSourceChange);
+
+    broker_.FailPending(kGuid, DiceClockRequestOutcome::kAbortedByStop, kIOReturnAborted);
+
+    DiceClockRequestCompletion completion{};
+    ASSERT_TRUE(broker_.TryTakeCompleted(kGuid, request.token, completion));
+    EXPECT_EQ(completion.desiredClock.sampleRateHz, 88200u);
+    EXPECT_EQ(completion.reason, DiceRestartReason::kClockSourceChange);
+    EXPECT_EQ(completion.outcome, DiceClockRequestOutcome::kAbortedByStop);
+    EXPECT_EQ(completion.status, kIOReturnAborted);
+    EXPECT_EQ(completion.restartId, 11u);
+    EXPECT_EQ(completion.generation.value, 7u);
+}
+
+// The original coordinator bounded each GUID's completion mailbox at 32 tokens. This avoids a
+// waiter that never returns allowing an unbounded per-device accumulation.
+TEST_F(ClockRequestBrokerTest, CompletionMailboxEvictsOldestAfterThirtyTwoTokens) {
+    for (uint64_t token = 1; token <= 33; ++token) {
+        broker_.Complete(DiceClockRequestCompletion{.token = token}, kGuid);
+    }
+
+    DiceClockRequestCompletion completion{};
+    EXPECT_FALSE(broker_.TryTakeCompleted(kGuid, 1, completion));
+    ASSERT_TRUE(broker_.TryTakeCompleted(kGuid, 2, completion));
+    EXPECT_EQ(completion.token, 2u);
+    ASSERT_TRUE(broker_.TryTakeCompleted(kGuid, 33, completion));
+    EXPECT_EQ(completion.token, 33u);
+}
+
+TEST_F(ClockRequestBrokerTest, ClearLockedDropsPendingAndCompletedRequests) {
+    const auto request = QueueLocked(48000);
+    broker_.Complete(DiceClockRequestCompletion{.token = 44}, kGuid);
+
+    IOLockLock(lock_);
+    broker_.ClearLocked(kGuid);
+    IOLockUnlock(lock_);
+
+    ClockRequestBroker::PendingClockRequest pending{};
+    DiceClockRequestCompletion completion{};
+    EXPECT_FALSE(broker_.TryConsumePending(kGuid, pending));
+    EXPECT_FALSE(broker_.TryTakeCompleted(kGuid, 44, completion));
+    EXPECT_NE(request.token, 0u);
+}
+
+// The broker follows the same borrowed-lock lifecycle as the gate/store: self-locking paths
+// short-circuit until the coordinator has allocated its IOLock.
+TEST(ClockRequestBrokerNullLock, SelfLockingOperationsShortCircuitWithoutBorrowedLock) {
+    IOLock* lock = nullptr;
+    RestartSessionStore store{&lock};
+    ClockRequestBroker broker{&lock, store};
+    ClockRequestBroker::PendingClockRequest pending{};
+    DiceClockRequestCompletion completion{};
+
+    EXPECT_FALSE(broker.TryConsumePending(kGuid, pending));
+    EXPECT_FALSE(broker.TryTakeCompleted(kGuid, 1, completion));
+    broker.Complete(DiceClockRequestCompletion{.token = 1}, kGuid);
+    broker.FailPending(kGuid, DiceClockRequestOutcome::kFailed, kIOReturnError);
+    EXPECT_FALSE(broker.TryTakeCompleted(kGuid, 1, completion));
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Extracts the DICE coordinator's clock-request state into a lock-borrowing `ClockRequestBroker`.

- Preserves token allocation, latest-wins superseding, completion delivery, and 32-token mailbox eviction.
- Keeps the coordinator's single `IOLock` atomicity across the broker, restart-session store, and duplex operation gate.
- Adds host characterization coverage for tokens, pending/session mirroring, completions, failure propagation, eviction, clearing, and null-lock behavior.

## Behavior

No intentional cadence, SYT, packet-geometry, DICE start-order, IRM-order, rollback, or logging behavior change.

## Validation

- `./build.sh --no-bump --test-only` — 1,251 passed; six existing reference-fixture tests skipped.
- Focused broker and coordinator regression tests passed.