### PR TITLE
docs: 44.1 kHz cadence notes (RME/Fireface), PR #41 review, device-backend design note

### DIFF
--- a/documentation/44100.md
+++ b/documentation/44100.md
@@ -7,8 +7,13 @@ AppleFWAudio Mach-O loaded in IDA, not an implementation specification.
 embedded diagnostics from the AppleFWAudio binary. The local `references/`
 directory was absent when this work began. Later comparison sections use the
 user-supplied, read-only Linux and FFADO trees; the Apple binary findings
-remain unverified against an Apple source release. Do not copy binary-derived,
-GPL, or LGPL source code; use behavioral observations only.
+remain unverified against an Apple source release. §12 adds a comparison
+against RME's own macOS kext (`FirefaceAudioDriver`, `com_RME_driver_*`, a
+2009-era x86 IOAudioFamily/IOFireWireFamily driver that cannot run on modern
+macOS — studied purely for its cadence algorithm). Do not copy binary-derived,
+GPL, LGPL, or proprietary source code; use behavioral observations only. The
+RME binary is proprietary, so the bar is stricter than for the GPL/LGPL
+references: observed algorithm and constants only, never a code fragment.
 
 > [!IMPORTANT]
 > **ASFW implementation boundary:** ASFW does not use Apple's DCL or NuDCL
@@ -815,39 +820,243 @@ DriverKit OHCI and packetization architecture.
 
 ---
 
-## 12. Open questions
+## 12. RME Fireface driver comparison (proprietary macOS kext)
 
-1. Recover the actual names and ownership of the object/parameter fields used
-   for `payloadQuadletsPerFrame`, transmit-buffer stride, group count, and
-   packets per group.
-2. Confirm the DCL-ring length is a multiple of the accumulator period before
-   its final branch repeats the static descriptor schedule.
-3. Recover the hardware semantics of the legacy DCL update-list operation and
-   DCL types `1` and `3`; the observed list construction is clear, but its
-   low-level execution contract is not yet decoded.
-4. Trace CIP-header creation in the legacy DCL path to establish how its
-   variable 5/6-frame packet count interacts with DBC and SYT values.
-5. Determine selection conditions between `AM824DCLWrite` and
-   `AM824NuDCLWrite` across device generations and synchronization modes.
-6. Cross-check this behavioral model against a local read-only reference stack
-   before implementing any wire-visible 44.1-family behavior in ASFW.
-7. Capture a target DICE device at 44.1 kHz to verify the blocking seed,
-   no-data placement, SYT phase, and transfer delay before enabling ASFW
-   support.
-8. Trace the Apple NuDCL resynchronization path and relate each bus-time phase
-   correction to ASFW's RX cadence recovery and CoreAudio ZTS anchor, without
-   feeding host-time jitter into the transmit packet cadence.
-9. Determine which Saffire stream and clock-source modes enable its
-   received-SYT phase recovery, and compare its warm-up, lead, and loss-of-SYT
-   behavior with target-device captures before treating it as an ASFW device
-   profile.
-10. Capture the same 44.1 kHz source as Saffire and FFADO use for clock
-    recovery, then compare its SYT deltas, ASFW ZTS anchor, and actual output
-    packet placement without adopting either legacy runtime architecture.
+This section analyses RME's own macOS driver, `FirefaceAudioDriver`
+(`com_RME_driver_FireWireAudioDevice` / `…AudioEngine` / `…FireWireUserClient`).
+It is a small (284 functions, ~52 KB, x86-64) 2009-era kext built on the
+**legacy IOAudioFamily + IOFireWireFamily DCL** stack — the same `IOFWDCL`,
+`IOFWSendDCL`, `IOFWDCLPool`, and `IOFWRemoteIsochPort` machinery Apple's
+AppleFWAudio used, wrapped in RME's own `IsochTransmitter`/`IsochReceiver`
+classes. It predates DriverKit entirely and cannot load on modern macOS; it is
+studied here only because it is a third fully independent 44.1-family cadence
+implementation, and the first that is **closed-loop by construction**.
+
+> [!IMPORTANT]
+> This is a **proprietary** binary. Everything below is a behavioral/algorithm
+> observation with IDA addresses as provenance — no code was or may be copied.
+> RME's on-wire format is proprietary and is **not** standard AM824/CIP; only
+> the rate-cadence *machinery* is portable as a lesson, not the framing.
+
+### 12.1 Rate handling is register programming, not cadence
+
+Three helpers own the rate as a device concern, entirely separate from packet
+timing:
+
+- `xRate(rateHz)` (`0x638c`) is a **rate classifier**: a threshold ladder that
+  snaps a measured/approximate rate onto the standard grid it supports —
+  `{32000, 44100, 48000, 64000, 88200, 96000, 128000, 176400, 192000}`. Note
+  the inclusion of 64 kHz and 128 kHz, which DICE and Apple do not carry.
+- `hwSetSampleRate(unit, dev, rateHz, bool)` (`0x63fa`) maps the rate to an RME
+  rate-code (`{44100→2, 48000→4, 64000→8, 88200→0xA, 96000→0xC, …}` with a
+  1x/2x family index `{44.1-family→1, 48-family→2}`) and writes it to a device
+  register via `FWWriteQuad`. This is DICE-`CLOCK_SELECT`-like clock
+  programming; it produces no packet schedule.
+- `IsochReceiver::Multiplier()` (`0x46ca`) returns the family multiplier
+  `1/2/4` from a stored rate code (`≤10→1`, `11–20→2`, `>20→4`).
+
+RME also enumerates **varispeed / pull-up-pull-down** rates the other stacks do
+not: `42336`, `44056`, `45937` around 44.1 kHz and `47952`, `48048` around
+48 kHz appear as first-class cases in `hwStart`. Because the cadence engine
+(§12.2) is a rate-agnostic Bresenham, these arbitrary near-nominal rates need
+no special packet math — only a startup-latency entry (§12.4).
+
+### 12.2 Transmit cadence: two-variant DCL ring + Bresenham branch selection
+
+RME builds the fractional 44.1 cadence at **DCL-branch granularity**, not by
+varying a per-packet transfer length. `IsochTransmitter::initBranches`
+(`0x4a70`) holds two parallel arrays of DCL pointers — a "primary" array at
+object slot `+45` and an "alternate" array at slot `+1069` — and wires each
+packet's branch to one or the other with a Bresenham/DDA accumulator:
+
+```text
+increment per cycle  v8 = (rateHz << 26) / 125      // magic 0x20C49BA5E353F7D = round(2^64/125)
+threshold            v2 = framesPerStep << 32       // object slot +71
+per cycle i in [0, packetCount):
+    if (v2 >= acc + v8)  acc += 2*v8 - v2;  branch i -> alternate[i]
+    else                 acc +=   v8 - v2;  branch i -> primary[(i+1) % n]
+```
+
+The scale is exact: `v8 / 2^32 = rateHz / 8000`, i.e. **frames per FireWire
+cycle** (5.5125 at 44.1 kHz, verified numerically). The accumulator carries the
+fractional 0.5125 frame and steers to the alternate DCL on carry — the identical
+mathematics to Apple's legacy `AM824DCLWrite` 5/6 accumulator (§4), just
+expressed as a choice between two prebuilt descriptor chains rather than a
+per-descriptor byte count. The accumulator spans the whole ring, so ring length
+must preserve its phase, exactly as in §5.
+
+### 12.3 Runtime retune and closed-loop clock recovery (the novel part)
+
+Where Apple's NuDCL is open-loop (synthesize a nominal fractional deadline) and
+Saffire replays a measured delta ring 1:1, **RME closes the loop with a smoothed
+estimate and re-tunes the Bresenham every interrupt group.**
+
+`IsochTransmitter::DCLCallback` (`0x4c7e`) fires once per buffer group. For the
+group it is about to refill it reads a **per-group target packet count** from a
+16-entry table at object offset `+276` and calls:
+
+```text
+adjustBranches(this, groupBase, targetCount)   // 0x4cb7
+```
+
+`IsochTransmitter::adjustBranches` (`0x49a2`) redistributes `targetCount − base`
+"extra" data cycles evenly across the `base` cycles of that group using a
+**16.16 fixed-point Bresenham** (`step = (base << 16) / extra`), forward-only so
+scheduled presentation times stay monotonic. It first resets the group to a
+plain sequential chain, then redirects exactly `extra` descriptors to the
+alternate array at the Bresenham positions. So the cadence is not baked in at
+start — each group's data/no-data split is retuned at runtime.
+
+The target table at `+276` is the **RX→TX handoff**. Cross-references confirm
+`+276` is written by `IsochReceiver::DCLCallback` / `IsochReceiver::Start` and
+read only by `IsochTransmitter::DCLCallback`. `IsochReceiver::DCLCallback`
+(`0x43d0`) is the recovery source:
+
+1. It extracts a per-packet timestamp (`(hdr[16]<<8) + hdr[4]`, `0x4461`) and a
+   DBC-like counter (`hdr[24]`, `0x444f`) from each received isoch packet.
+2. It computes the **wrapped timestamp delta** (`0x4478`–`0x44a7`) with a
+   rate-family wrap modulus (`2048 / 4096 / 6144` for 1x/2x/4x) and the
+   **DBC delta = frames in packet** (`v9 − prev` mod 256, `0x453c`–`0x4562`),
+   storing the per-group frame count at `+276 + 4*group`.
+3. It validates the measured delta against the nominal `rate × multiplier`; on
+   mismatch it raises a discontinuity flag at engine `+368` (`0x44ef`) that
+   `hwStart` reads to count consecutive glitches.
+4. It runs a **leaky-integrator (α = 1/16) IIR** over the min/max of a header
+   field (`result = v24 − (v24>>4) + ((max+min)>>1)`, `0x45d1`) to keep a
+   smoothed rate/phase estimate, clamping each group's count into
+   `[rate+1, 2·rate]`.
+
+So RME's answer to 44.1 kHz is: **measured device clock (RX DBC/timestamp
+deltas) → smoothed per-group frame counts → per-group Bresenham redistribution
+of two DCL variants on TX.** It is conceptually the Saffire "learn the device
+clock, don't synthesize it" lesson, but implemented as an averaging servo plus
+a fractional branch DDA rather than an exact 512-entry replay ring. This is
+strong independent corroboration of the project's replay-first / device-clock
+decision in [`SAMPLE_RATE_EXPANSION.md`](SAMPLE_RATE_EXPANSION.md) §1 and
+§3 — three unrelated 44.1 stacks (Saffire, FFADO, RME) all drive TX cadence
+from the received clock rather than from nominal rate arithmetic alone.
+
+### 12.4 Per-rate startup latency anchors
+
+`com_RME_driver_FireWireAudioEngine::hwStart` (`0x2b88`), after starting both
+isoch channels, seeds the initial CoreAudio timestamp by adding a **per-rate
+latency offset** (nanoseconds) before the first `takeTimeStamp`:
+
+| Rate (Hz) | Startup offset | | Rate (Hz) | Startup offset |
+|---:|---:|---|---:|---:|
+| 32000 | 1,832 µs | | 88200 | 1,162 µs |
+| 44100 (+ 42336/44056/45937) | 1,516 µs | | 96000 | 1,126 µs |
+| 48000 / 48048 (default) | 1,000 µs | | 128000 | 1,109 µs |
+| 64000 | 1,382 µs | | 176400 | 1,025 µs |
+| | | | 192000 | 1,020 µs |
+
+These are device-measured buffer latencies, not a `1/rate` formula: they shrink
+as the rate rises (more headroom is needed at lower rates) and the whole
+44.1-varispeed family shares 1,516 µs. This is the RME analogue of Apple's SYT
+presentation lead (§7) and FFADO's transfer delay (§10.2): a rate-specific
+constant added once at start to anchor the presentation clock. ASFW's
+equivalent is the ZTS/`HostClockAnchor` seed, and this table is evidence that
+the seed should be **per-rate**, not a single 48 kHz constant.
+
+### 12.5 Five-way comparison
+
+| Concern | Apple NuDCL | Saffire | FFADO active AMDTP | **RME Fireface** |
+|---|---|---|---|---|
+| Cadence source | Synthesized fixed-point next-SYT deadline | Replayed RX-SYT delta ring (1:1) | RX SYT → DLL → future presentation TS | **RX DBC/timestamp deltas → 1/16 IIR estimate** |
+| Loop type | Open-loop nominal + resync | Closed-loop, exact replay | Closed-loop DLL | **Closed-loop, smoothed/averaged** |
+| Fractional 44.1 carry | Apple phase remainder | In the measured deltas | In DLL ticks-per-frame | **Bresenham over two DCL variants (rate/8000)** |
+| Runtime retune unit | Per cycle | Per SYT | Per transmit period | **Per interrupt group (16.16 Bresenham)** |
+| Startup anchor | SYT presentation lead | Queue lead | Transfer delay | **Per-rate ns latency table (§12.4)** |
+| On-wire framing | AM824/CIP | AM824/CIP (DICE) | AM824/CIP | **Proprietary (not portable)** |
+
+The architectural lesson RME adds on top of Saffire/FFADO: a full **exact**
+delta-replay ring is not required to track a device clock well — an averaging
+servo plus a rate-agnostic fractional DDA is sufficient and simpler, provided
+(a) the estimate is clamped to a sane band, (b) discontinuities raise an
+explicit resync flag, and (c) the startup anchor is per-rate. That maps cleanly
+onto ASFW's intended split (`Audio/Wire` cadence/recovery + ZTS anchor), and
+the DDA itself is the same one already validated in
+`tools/amdtp_blocking_cadence_sim.py`. As with every other section: behavior
+only — RME's proprietary framing and DCL layout must not enter ASFW.
+
+The distilled consequence of §9–§12 for the device-clocked case — that the
+per-cycle TX contract reduces to {data/no-data, SYT}, that DBC and cadence
+generation fall out for free under replay, and precisely what device-as-master
+does *not* remove (bring-up, framing, per-rate anchor, the fallback engine) — is
+recorded in [`SAMPLE_RATE_EXPANSION.md`](SAMPLE_RATE_EXPANSION.md) §3 as the
+minimal TX cadence contract.
 
 ---
 
-## 13. IDA and Reference Evidence Index
+## 13. Open questions
+
+Status legend: **[OPEN]** unresolved; **[RESOLVED]** answered with evidence;
+**[RESOLVED — by decision]** closed as not-needed rather than investigated;
+**[CAPTURE-GATED]** blocked only on a hardware capture. Items 1–5 concern the
+Apple *legacy DCL* internals and are archaeology, not blockers — ASFW uses
+neither DCL nor NuDCL (see the boundary note at the top of this document).
+
+The **[CAPTURE-GATED]** items (#7, #9, #10, #11, #12-value) are **not five
+separate captures**: they reduce to one measurement — the per-rate presentation
+lead the target device expects plus its tolerance of ASFW's startup no-data
+prefix — in one gated session, partly self-instrumented via ASFW's own
+`[TxSyt]`/`[Zts]` traces rather than a bus analyzer. #9/#10 are moot under
+replay. See [`SAMPLE_RATE_EXPANSION.md`](SAMPLE_RATE_EXPANSION.md) §8 for the
+consolidated capture plan and sequencing.
+
+1. **[OPEN]** Recover the actual names and ownership of the object/parameter fields used
+   for `payloadQuadletsPerFrame`, transmit-buffer stride, group count, and
+   packets per group.
+2. **[OPEN]** Confirm the DCL-ring length is a multiple of the accumulator period before
+   its final branch repeats the static descriptor schedule.
+3. **[OPEN]** Recover the hardware semantics of the legacy DCL update-list operation and
+   DCL types `1` and `3`; the observed list construction is clear, but its
+   low-level execution contract is not yet decoded.
+4. **[OPEN]** Trace CIP-header creation in the legacy DCL path to establish how its
+   variable 5/6-frame packet count interacts with DBC and SYT values.
+5. **[OPEN]** Determine selection conditions between `AM824DCLWrite` and
+   `AM824NuDCLWrite` across device generations and synchronization modes.
+6. **[RESOLVED]** Cross-check this behavioral model against a local read-only reference stack
+   before implementing any wire-visible 44.1-family behavior in ASFW.
+   *Done:* the Linux ALSA FireWire tree is in-tree and the model survives the
+   check in full — Apple NuDCL ≡ Linux ideal blocking (4458.23-tick step,
+   147-event 1386/1387 sequence, 441/640 D/N, 8/16/32 intervals). See
+   [`SAMPLE_RATE_EXPANSION.md`](SAMPLE_RATE_EXPANSION.md) §4.
+7. **[CAPTURE-GATED]** Capture a target DICE device at 44.1 kHz to verify the blocking seed,
+   no-data placement, SYT phase, and transfer delay before enabling ASFW
+   support.
+8. **[RESOLVED — by decision]** Trace the Apple NuDCL resynchronization path and relate each bus-time phase
+   correction to ASFW's RX cadence recovery and CoreAudio ZTS anchor, without
+   feeding host-time jitter into the transmit packet cadence.
+   *Closed as not-needed:* in a replay architecture the resync branch's job is
+   done by replay re-anchoring plus the existing half-ring utilities
+   (`extOffsetDiff`); it is deliberately not ported. A synthesized-mode drift
+   servo, if ever needed, is a separate capture-driven design
+   ([`SAMPLE_RATE_EXPANSION.md`](SAMPLE_RATE_EXPANSION.md) §8 item 4). The
+   literal trace of Apple's branch was not performed and is deemed unnecessary.
+9. **[CAPTURE-GATED]** Determine which Saffire stream and clock-source modes enable its
+   received-SYT phase recovery, and compare its warm-up, lead, and loss-of-SYT
+   behavior with target-device captures before treating it as an ASFW device
+   profile.
+10. **[CAPTURE-GATED]** Capture the same 44.1 kHz source as Saffire and FFADO use for clock
+    recovery, then compare its SYT deltas, ASFW ZTS anchor, and actual output
+    packet placement without adopting either legacy runtime architecture.
+11. **[CAPTURE-GATED]** Confirm whether RME's `+276` per-group target counts and the 1/16 IIR
+    estimate (§12.3) track a real 44.1 device oscillator as tightly as
+    Saffire's exact delta replay, or whether the averaging visibly lags at
+    the pull-up/pull-down varispeed rates. This decides whether ASFW's
+    device-clock path needs exact replay or an averaging servo suffices.
+12. **[RESOLVED (design) / CAPTURE-GATED (value)]** Cross-check the RME per-rate startup latency table (§12.4) against ASFW's
+    ZTS/`HostClockAnchor` seed to confirm the seed must be per-rate.
+    *Design half done:* the RME per-rate table (§12.4), plus the ZTS audit
+    (`hostNanosPerSampleQ8` is already live-per-rate while the `RxSytCadence`
+    bootstrap is still a 48 k constant), confirm the seed **must** be per-rate
+    ([`SAMPLE_RATE_EXPANSION.md`](SAMPLE_RATE_EXPANSION.md) §6 item 3, §8 item 3).
+    The exact per-rate lead the device wants folds into the capture in #7.
+
+---
+
+## 14. IDA and Reference Evidence Index
 
 | Topic | IDA locations |
 |---|---|
@@ -873,3 +1082,8 @@ DriverKit OHCI and packetization architecture.
 | FFADO generic rational CIP helper | `src/libstreaming/util/cip.c:81-206` |
 | FFADO active SYT/DLL/timestamp path | `src/libstreaming/amdtp/Amdtp{Receive,Transmit}StreamProcessor.cpp`, `src/libutil/TimestampedBuffer.cpp:1025-1102`, `src/libstreaming/StreamProcessorManager.cpp:1488-1511` |
 | Secondary Linux `sound/firewire` comparison | `sound/firewire/amdtp-stream.h:13-20`, `sound/firewire/amdtp-stream.c:365-423` |
+| RME rate classifier / register program | `xRate 0x638c`, `hwSetSampleRate 0x63fa`, `IsochReceiver::Multiplier 0x46ca` |
+| RME TX Bresenham branch init (rate/8000, magic 0x20C49BA5E353F7D) | `IsochTransmitter::initBranches 0x4a70` (div-by-125 at `0x4a99`), `IsochTransmitter::Start 0x4b1e` |
+| RME runtime 16.16 Bresenham retune | `IsochTransmitter::adjustBranches 0x49a2` (step at `0x49ed`), `IsochTransmitter::DCLCallback 0x4c7e` (target read `0x4cb7`) |
+| RME closed-loop RX clock recovery (`+276` table, 1/16 IIR, resync flag) | `IsochReceiver::DCLCallback 0x43d0` (TS delta `0x4461`–`0x44a7`, DBC delta `0x453c`–`0x4562`, IIR `0x45d1`, resync flag `0x44ef`) |
+| RME per-rate startup latency anchors | `com_RME_driver_FireWireAudioEngine::hwStart 0x2b88` |

--- a/documentation/DEVICE_BACKEND_UNIFICATION.md
+++ b/documentation/DEVICE_BACKEND_UNIFICATION.md
@@ -1,0 +1,163 @@
+# Design Note: Unified Device-Backend Interface
+
+**Status:** design note / proposal (2026-07-11). Not an accepted decision like
+[`SAMPLE_RATE_EXPANSION.md`](SAMPLE_RATE_EXPANSION.md); it records a direction
+and the decisions it forces. No code implied by this note.
+
+## The idea in one sentence
+
+A caller should be able to ask a device a **protocol-neutral question** — *"what
+is your current sample rate?"*, *"set 44.1 kHz"*, *"how many input channels?"* —
+and the device answers. The caller must **not** know whether the answer came from
+a DICE register read, an AV/C plug/stream-format query, an RME vendor register, or
+a future Oxford/BeBoB path. Protocol is an implementation detail behind one
+interface, not a branch in the caller.
+
+This is the opposite of the 2000s model where each vendor shipped a full custom
+driver and chose its own way end-to-end. Here there is **one shared audio engine**
+(cadence → AMDTP/CIP → OHCI) and **thin protocol adapters** that only translate
+neutral requests into device-specific transactions.
+
+### Motivating example: "what's the current sample rate?"
+
+One neutral call, three unrelated implementations, caller unaware:
+
+```
+GetCurrentSampleRate() -> Result<uint32_t>
+```
+
+- **DICE** reads the GLOBAL section clock/status registers (`GlobalOffset::kSampleRate`
+  `0x5C` / nominal-rate bits in `kStatus` `0x54`, `DICETypes.hpp`).
+- **AV/C** issues a plug-signal-format / stream-format query on the Music subunit.
+- **RME** reads its vendor status register (the legacy kext's `hwGetRate` — see
+  [`44100.md`](44100.md) §12.1).
+
+The caller gets a `uint32_t` Hz and never sees any of that. `SetSampleRate(hz)`,
+`GetSupportedRates()`, `GetChannelCounts()`, `GetClockSource()` follow the same
+shape.
+
+## This is a convergence, not a greenfield
+
+The universal-engine + protocol-adapter architecture **already exists in ASFW** —
+it is partly built and needs unifying, not inventing. Today's seams:
+
+| Concern | Existing seam | State |
+|---|---|---|
+| Control plane (start/stop streaming) | `IAudioBackend` (`Name`, `StartStreaming(guid)`, `StopStreaming(guid)`) | DICE + AV/C backends implement it |
+| Per-device business logic (bring-up, DSP, controls, caps) | `IDeviceProtocol` | DICE, Focusrite-DICE, Oxford/Apogee behind it |
+| Capability / timing data (formats, channels, DBS, per-rate latency) | `IAudioDeviceProfile` | protocol-agnostic; already rate-parameterized (`double sampleRate`) |
+| Identity → which protocol | `DeviceProtocolFactory` + `AudioIntegrationMode` + `DeviceProfiles/Audio/` | registry of Focusrite/Apogee/Alesis/Midas/PreSonus |
+
+So the vision is mostly realized structurally. The work is to make the interface
+**honest and neutral**, then add RME as one more adapter.
+
+## Why it is not unified yet
+
+The generic interfaces have accreted DICE-specific shape — the interface leaks the
+very protocol it is supposed to hide:
+
+- `IDeviceProtocol` hardcodes DICE and 48 kHz in its bring-up hooks:
+  `PrepareDuplex48k`, `ProgramRxForDuplex48k`, `ProgramTxAndEnableDuplex48k`,
+  `ConfirmDuplex48kStart`, plus an `AsDiceDuplexProtocol()` downcast. A neutral
+  interface cannot contain `...48k` or `AsDice...`.
+- The "universal" `IAudioBackend` is thin (start/stop by GUID); the real surface —
+  `RequestClockConfig`, `HandleRecoveryEvent`, `BeginTeardown` — lives as
+  DICE-specific public methods on the concrete `DiceAudioBackend` and is reached by
+  downcasting. So the neutral contract today is essentially just start/stop, and
+  everything interesting is protocol-specific.
+
+**ASFW's real risk is not per-vendor forks (that is already avoided) — it is the
+generic interface slowly becoming "DICE with a vtable" so AV/C and RME never
+genuinely fit.** The `...48k` hooks are that drift already in progress.
+
+## The unified surface (neutral query/command model)
+
+Collapse the leaks into one protocol-neutral device interface whose operations are
+all phrased as questions and commands, never as protocol mechanics. Illustrative
+shape only:
+
+```
+Probe()                 -> Result<DeviceCapabilities>   // rates, channels, clock sources, quirks
+GetCurrentSampleRate()  -> Result<uint32_t>
+SetSampleRate(hz)       -> Status                        // async under the hood; see boundaries
+GetClockSource()        -> Result<ClockSource>
+SetClockSource(src)     -> Status
+ConfigureStreams(req)   -> Result<ActiveStreamProfile>   // the neutral profile the engine consumes
+StartStreaming() / StopStreaming() -> Status
+```
+
+The device answers `ActiveStreamProfile` — a **value type** (no pointers into
+either service's memory; FW-60 rule) that the shared engine consumes to pick the
+cadence source and drive AMDTP/OHCI. The engine downstream of the profile is 100%
+protocol-agnostic.
+
+## Design rules the unification must hold
+
+1. **Two-protocol rule.** A method may live on the neutral interface only if at
+   least two *unrelated* protocols implement it meaningfully. Force DICE **and**
+   AV/C through every neutral method; anything only DICE can answer belongs on the
+   concrete adapter, not the shared interface.
+2. **No protocol names in the neutral surface.** `...48k`, `AsDice...`, register
+   offsets, plug numbers, and vendor opcodes are leaks. Neutral requests are
+   rate-generic and mechanism-free (`PrepareDuplex(profile)`, not
+   `PrepareDuplex48k`). De-leaking `IDeviceProtocol` is the same task as
+   rate-genericizing DICE — [`SAMPLE_RATE_EXPANSION.md`](SAMPLE_RATE_EXPANSION.md)
+   gap #5.
+3. **Async is part of the contract, not hidden.** DICE clock/rate changes are async
+   FireWire transactions that can take seconds to lock (`DiceDuplexRestartCoordinator`).
+   Neutral setters must be modeled as async (completion/continuation), or a
+   synchronous signature re-imports the multi-second work-queue stall flagged in
+   the PR #41 review. "Answer the question" may mean "answer later."
+4. **The profile owns per-rate device timing.** `IAudioDeviceProfile` already
+   carries per-rate transfer delay (`TxTransferDelayTicks(sampleRate)`, default flat
+   `12800`). The device-specific presentation lead — the capture-gated value from
+   the cadence work ([`44100.md`](44100.md) §12.4, `SAMPLE_RATE_EXPANSION.md` §8) —
+   lives here, per protocol, per rate. It is a profile override, not a new
+   interface.
+
+## Layer boundary (what the backend must not do)
+
+The backend **configures the physical device and answers questions about it. It
+does not touch the stream.** Keep out of every adapter:
+
+- AMDTP/CIP framing, DBC state, SYT arithmetic
+- RX replay and the rational cadence engine
+- OHCI descriptors / DMA layout / isoch scheduling
+- CoreAudio timing anchors (ZTS / `HostClockAnchor`)
+- bus-reset recovery state machine
+
+Keep inside the adapter: DICE register transactions, AV/C + CMP/PCR, RME vendor
+protocol, clock-source selection, capability discovery, and the firmware quirks
+needed only to start/stop. This is the existing layer-boundary rule (CLAUDE.md),
+restated for backends.
+
+## Where new protocols slot in
+
+RME (and any future class) is one more adapter, not a new architecture: a
+`AudioIntegrationMode` value, an `RmeAudioBackend : IAudioBackend`, an
+`RmeProtocol : IDeviceProtocol`, and profiles under `DeviceProfiles/Audio/Vendors/`.
+This is only clean **after** the de-leak (rules 1–2); adding RME against today's
+DICE-shaped interface would fight the `48k`/`AsDice` accretion.
+
+## DICE-first, and a simulated DICE backend
+
+- **Generalize from DICE.** It is the most complete adapter and TCAT spans many
+  vendors, so shape the neutral surface around what DICE needs, then validate it by
+  forcing AV/C through the same methods (rule 1).
+- **Add a simulated DICE backend behind the neutral interface.** It implements the
+  two interfaces and feeds canned RX sequences, letting the whole
+  `profile → cadence → AMDTP → OHCI` chain (including 44.1 replay) be host-tested
+  with no hardware — the transport-side analogue of `ADKVirtualAudioLab` and the
+  `Testing/` DMA stubs. Cheap because the seams already exist, and it makes the
+  de-leak refactor verifiable off-hardware. Likely the highest-leverage first step.
+
+## Open decisions
+
+1. Does the neutral contract live on one interface, or stay split as control-plane
+   (`IAudioBackend`) + device-logic (`IDeviceProtocol`)? Today the split is
+   ambiguous and the real surface leaks through concrete backends.
+2. Exact neutral vocabulary for clock source, multi-stream devices (a profile is a
+   *set* of streams per direction, e.g. Venice F32 = 2×16 — the single
+   `rxChannel`/`txChannel` shape is insufficient), and async completion.
+3. Whether `AudioIntegrationMode` stays an enum or becomes a capability set as the
+   protocol count grows.

--- a/documentation/PR_41_CODE_REVIEW.md
+++ b/documentation/PR_41_CODE_REVIEW.md
@@ -1,0 +1,144 @@
+# PR #41 Code Review — Rate-Generic DICE Sample-Rate Support (Phase 0: 44.1 kHz)
+
+**PR:** [#41 — (DICE-4) 44k Sample Rate Implementation Switcher](https://github.com/mrmidi/ASFireWire/pull/41)
+
+**Reviewed commit:** `3285b13378d3db721d1b98557d02defa0688d9b4`
+
+**Goal:** build normal, multi-sample-rate support across the audio stack. This
+PR's Phase 0 scope is DICE 44.1 kHz enablement; it must establish the
+rate-generic configuration and ownership model that later enables 32/48,
+88.2/96, and 176.4/192 kHz without another architecture fork.
+
+**Verdict:** **Request changes.** The Phase 0 44.1 kHz cadence math is sound,
+but the CoreAudio/device-clock transaction is incomplete and can leave the HAL,
+direct binding, and DICE clock in different states. That prevents this PR from
+being a safe foundation for normal multi-rate support.
+
+## Requirement cross-check
+
+| Requirement | PR status |
+|---|---|
+| Rate-generic blocking/replay arithmetic | Pass for Phase 0 (44.1 kHz) |
+| Per-device supported-rate set derived from DICE capabilities | Missing |
+| Host-coordinated ADK configuration transaction | Missing |
+| Atomic HAL + stream-format + transport publish | Missing |
+| Rate-tier geometry and capture-gated wire policy | Incomplete / stale |
+
+## Findings
+
+### P0 — The new rate switch bypasses the required AudioDriverKit configuration transaction
+
+[`HandleChangeSampleRate`](https://github.com/mrmidi/ASFireWire/blob/3285b13378d3db721d1b98557d02defa0688d9b4/ASFWDriver/Audio/DriverKit/ASFWAudioDevice.cpp#L616)
+immediately calls the cross-service DICE RPC, mutates the endpoint binding, then
+calls `SetSampleRate`. The PR adds no `RequestDeviceConfigurationChange`,
+`PerformDeviceConfigurationChange`, or `AbortDeviceConfigurationChange`
+implementation; the IIG declares only `StartIO`, `StopIO`, and
+`HandleChangeSampleRate`.
+
+This violates the required stop → hardware commit → publish → resume barrier
+in [SAMPLE_RATE_EXPANSION.md](SAMPLE_RATE_EXPANSION.md#L225). When I/O is
+active it merely returns `kIOReturnBusy`; it never asks the host to quiesce I/O
+and perform the change safely.
+
+Implement the pending-change state machine specified in the design: validate
+and queue a request, call `RequestDeviceConfigurationChange`, commit DICE only
+from `PerformDeviceConfigurationChange` after `StopIO`, publish all ADK
+state, and discard the pending record in `AbortDeviceConfigurationChange`.
+
+### P1 — A successful rate request does not update stream formats, and a failed ADK publish leaves the device already changed
+
+The graph initially selects a stream format once at
+[input](https://github.com/mrmidi/ASFireWire/blob/3285b13378d3db721d1b98557d02defa0688d9b4/ASFWDriver/Audio/DriverKit/ASFWAudioDriverGraph.cpp#L495)
+and [output](https://github.com/mrmidi/ASFireWire/blob/3285b13378d3db721d1b98557d02defa0688d9b4/ASFWDriver/Audio/DriverKit/ASFWAudioDriverGraph.cpp#L530).
+The new handler only calls `SetSampleRate`; it never calls
+`DeviceSampleRateChanged` for either stream.
+
+DICE and the direct binding have already been updated before `SetSampleRate`
+can fail. The design requires device rate, both stream formats, direct-memory
+metadata, replay/DBC state, and transport state to publish as one successful
+commit; on failure, hardware must remain at or recover to the previous committed
+state. See [the required contract](SAMPLE_RATE_EXPANSION.md#L240).
+
+The `audioNub` null branch is also unsafe: it skips hardware programming but
+still calls `SetSampleRate`, allowing CoreAudio to accept a rate change that
+never reached the device.
+
+### P1 — The PR does not establish a per-device, rate-generic capability contract
+
+DICE profiles unconditionally publish `{44100, 48000}` at
+[DiceDeviceProfile.hpp:51](https://github.com/mrmidi/ASFireWire/blob/3285b13378d3db721d1b98557d02defa0688d9b4/ASFWDriver/Audio/DriverKit/Config/DICE/DiceDeviceProfile.hpp#L51).
+The graph overwrites nub-provided rates with that profile list at
+[ASFWAudioDriverGraph.cpp:165](https://github.com/mrmidi/ASFireWire/blob/3285b13378d3db721d1b98557d02defa0688d9b4/ASFWDriver/Audio/DriverKit/ASFWAudioDriverGraph.cpp#L165).
+
+The code reads `GLOBAL_CLOCK_CAPABILITIES`, and even defines
+`DiceClockCapsSupportRate`, but never uses it to advertise or validate a
+selection. `HandleChangeSampleRate` also casts any `double` to `uint32_t`
+with no exact-membership check. Consequently, 32 kHz can pass the DICE selector
+and restart validation even though CoreAudio was advertised only 44.1/48 kHz,
+producing a device/format mismatch.
+
+For the broader goal, the supported-rate list must be the intersection of
+device caps, validated stream-geometry tiers, and profile quirks; Phase 0 can
+limit that intersection to 44.1/48 kHz, but it must not hardcode a universal
+two-rate list. This conflicts with the design's requirement to validate the
+exact requested rate against nub-advertised rates and current device caps
+([SAMPLE_RATE_EXPANSION.md](SAMPLE_RATE_EXPANSION.md#L240)). The local Linux
+DICE reference uses clock capabilities to gate usable rates:
+[dice.c](../references/linux-upstream/sound/firewire/dice/dice.c#L74) and
+[dice-stream.c](../references/linux-upstream/sound/firewire/dice/dice-stream.c#L32).
+
+### P1 — A failed DICE clock change poisons the next start
+
+[`DICETcatProtocol::ApplyClockConfig`](https://github.com/mrmidi/ASFireWire/blob/3285b13378d3db721d1b98557d02defa0688d9b4/ASFWDriver/Audio/Protocols/DICE/TCAT/DICETcatProtocol.cpp#L190)
+stores `selectedClock_` before the asynchronous hardware operation succeeds,
+with no rollback on the failure callback. A subsequent `StartIO` uses that
+stored value through
+[`PrepareDuplex48k`](https://github.com/mrmidi/ASFireWire/blob/3285b13378d3db721d1b98557d02defa0688d9b4/ASFWDriver/Audio/Protocols/DICE/TCAT/DICETcatProtocol.cpp#L253).
+
+A rejected 44.1 kHz request can therefore leave CoreAudio at 48 kHz while the
+next start retries 44.1 kHz. Set `selectedClock_` only after confirmed success,
+or restore the previous applied clock on every error path.
+
+### P2 — The simulator and design note do not describe the multi-rate roadmap accurately
+
+The simulator passes but still prints that production rejects 44.1 kHz, has a
+48 kHz ZTS conversion, lacks rate-aware timing geometry, lacks HAL wiring, and
+needs the ZTS-period assertion. Those statements are no longer accurate for
+the code changed by this PR.
+
+Likewise, [SAMPLE_RATE_EXPANSION.md](SAMPLE_RATE_EXPANSION.md#L1) still says
+implementation has not started. Update the documents to distinguish Phase 0
+(44.1 kHz on DICE) from the rate-generic endpoint, including the 2x/4x geometry
+and capture gates. Do not describe the accumulator seed as hardware-verified
+without the capture required by [44100.md](44100.md#L834).
+
+## Verification performed
+
+- Reviewed PR head `3285b13378d3db721d1b98557d02defa0688d9b4` against base
+  `3b7bbb68e4b9409a4de48c3bcdf89f39b8ba31a0`.
+- `git diff --check` completed without whitespace errors.
+- Ran `python3 tools/amdtp_blocking_cadence_sim.py`: **119/119 checks passed**.
+- Verified that `tests/audio/generated/AmdtpBlockingCadence441Golden.hpp`
+  matches the current generator output.
+
+The simulator validates the arithmetic/model, not the missing AudioDriverKit
+transaction, capability filtering, or hardware capture gates.
+
+### Simulator results confirmed
+
+- Phase 0: 441 data packets per 640 cycles, carrying 3528 frames per period.
+- SYT deltas are 4458/4459 ticks, with 34 long deltas in every 147 events and
+  a 655360-tick period sum.
+- DBC advances by 8 on data packets and remains unchanged on no-data packets.
+- One isochronous packet is sent per FireWire cycle at every tested rate.
+- The model also verifies family-invariant blocking sequences for
+  88.2/176.4 and 96/192 kHz; this is evidence for the rate-generic engine, not
+  proof that those DICE rate tiers are ready to advertise.
+- 44.1 kHz has 32/40 frames in every six-cycle timing group.
+- Replay round-trips preserve the presentation lag at tested clock offsets from
+  -500 ppm through +500 ppm.
+
+## Scope note
+
+No implementation code, tests, GitHub review comments, or PR state were
+modified during this review.

--- a/documentation/PR_41_REVIEW_ASSESSMENT.md
+++ b/documentation/PR_41_REVIEW_ASSESSMENT.md
@@ -1,0 +1,151 @@
+# Assessment of PR #41 Code Review
+
+**Subject:** [`PR_41_CODE_REVIEW.md`](PR_41_CODE_REVIEW.md) — review of
+[PR #41 — (DICE-4) 44k Sample Rate Implementation Switcher](https://github.com/mrmidi/ASFireWire/pull/41)
+
+**Assessed:** 2026-07-11. Every load-bearing claim in the review was verified
+against the PR head (`3285b13378d3db721d1b98557d02defa0688d9b4`), the
+AudioDriverKit SDK headers (DriverKit 27.0 SDK), and `ADKVirtualAudioLab`
+(the project's designated runtime-truth source for ADK behavior). Analysis
+only — no implementation code, tests, or PR state were modified.
+
+## Overall verdict: mostly agree, with two meaningful corrections
+
+The review's findings are real and well-anchored — nearly every factual claim
+was confirmed in code. But its severity framing is off in both directions:
+
+1. **The P0 overstates what AudioDriverKit itself requires.** The SDK's own
+   default `HandleChangeSampleRate` does exactly what the PR does.
+2. **The P1 failure-ordering finding understates one mitigating fact** (the
+   clock RPC is synchronous, so hardware failures propagate before the HAL
+   publish) **and misses a nastier defect** (a 15-second blocking poll inside
+   the ADK callback).
+
+## Finding-by-finding
+
+### P0 — "Bypasses the required ADK configuration transaction": agree with the gap, disagree with the framing
+
+- The SDK header states the **default** implementation of
+  `HandleChangeSampleRate` "will call SetSampleRate() and return
+  kIOReturnSuccess" (`IOUserAudioClockDevice.iig:316`, DriverKit 27.0 SDK).
+  The ADK lab does literally that (`ADKVirtualAudioLab/Driver/VirtualAudioDevice.cpp:819`).
+  So "bypasses the required AudioDriverKit transaction" is **wrong as an
+  API-contract claim** — Apple's own default does what the PR does.
+  `RequestDeviceConfigurationChange` is the mechanism for **driver-initiated**
+  configuration changes, not HAL-initiated rate changes.
+- What **is** true: the functional gap. Rejecting with `kIOReturnBusy`
+  whenever IO runs means no rate change while any client holds IO, and the
+  project's own design doc (`SAMPLE_RATE_EXPANSION.md`, audit item 6, ~L210 at
+  the PR head — the review's `#L225`/`#L240` anchors are drifted) explicitly
+  calls for wiring `PerformDeviceConfigurationChange` → duplex restart via
+  `DiceDuplexRestartCoordinator`.
+- The PR's busy-rejection is a **deliberate, safe interim policy** — its code
+  comment describes the empirically observed failure mode of hot
+  reconfiguration (device PLL flaps 44.1k↔48k, audio starves until replug).
+  This is a scope narrowing, not an unsafe transaction.
+- Caveat on the PR side: the code comment citing "the validated ADK contract
+  (ADKVirtualAudioLab)" **overclaims**. The lab advertises exactly one sample
+  rate (`SetAvailableSampleRates(&sampleRate, 1)`,
+  `VirtualAudioDevice.cpp:267`), so it has never exercised a real multi-rate
+  switch. The single-rate lab cannot validate rate-change format
+  follow-through either way.
+
+### P1 — "Formats not updated / failed publish leaves device changed": agree on formats, half-agree on ordering
+
+- **Formats: confirmed.** `IOUserAudioStream::DeviceSampleRateChanged` is a
+  driver-called helper — "Call to update stream formats when the owning audio
+  device changes sample rate. Goes through all the available stream formats
+  and selects the closest format with the matching sample rate"
+  (`IOUserAudioStream.iig:254-266`). The PR never calls it (nor
+  `SetCurrentStreamFormat`), so ADK stream formats stay at the old rate's
+  descriptor after a switch. Legitimate finding.
+- **Ordering: overdrawn.** `DiceDuplexRestartCoordinator::RequestClockConfig`
+  **blocks up to 15 s** polling `TryTakeCompletedClockRequest` and returns the
+  real hardware completion status (`DiceDuplexRestartCoordinator.cpp`,
+  `kClockRequestWaitTimeoutMs = 15000`). `AudioCoordinator` and the nub only
+  mutate binding state (`endpoint->SetCurrentSampleRate`,
+  `ivars->currentSampleRateHz`) **on success**. So a failed DICE commit
+  propagates cleanly and `SetSampleRate` is never reached; the review's "DICE
+  and the direct binding have already been updated before `SetSampleRate` can
+  fail" is only accurate for the success path.
+- **Residual real defects (confirmed, narrow):**
+  - A `SetSampleRate` failure *after* a successful hardware commit has no
+    unwind (device + binding at new rate, HAL at old).
+  - The `audioNub == nullptr` branch calls `SetSampleRate` without touching
+    hardware (`ASFWAudioDevice.cpp`, `HandleChangeSampleRate`).
+- **Missed by the review:** the 15-second `IOSleep` poll runs *inside*
+  `HandleChangeSampleRate` on the ADK work queue. A wedged device stalls the
+  audio device's queue for 15 s. Arguably worse than anything listed under
+  this finding.
+
+### P1 — "No per-device capability contract": fully agree
+
+All confirmed at the PR head:
+
+- `DiceDeviceProfile::SupportedSampleRates()` unconditionally returns
+  `{44100, 48000}` (`DiceDeviceProfile.hpp:51`).
+- The graph overwrites nub-provided rates with the profile list
+  (`ASFWAudioDriverGraph.cpp:~165`).
+- `DiceClockCapsSupportRate` is defined (`DICETypes.hpp:518`) and **never
+  called anywhere** (git grep over the PR head: one hit, the definition).
+- `HandleChangeSampleRate` does a bare `static_cast<uint32_t>` with no
+  membership check against advertised rates.
+- `IsSupportedClockConfig` explicitly accepts 32 kHz — "Internal clock at a
+  validated 1x rate (32 / 44.1 / 48 kHz)" (`DICERestartSession.hpp:250-268`) —
+  while CoreAudio is advertised only two rates, so an unadvertised 32 kHz
+  request would reach `CLOCK_SELECT`.
+- This matches the project's own design doc (audit item 5): read
+  `GLOBAL_CLOCK_CAPS` (0x64) "to populate the nub's supported-rate list
+  instead of assuming."
+
+Severity caveat: the HAL should not request unadvertised rates, and
+essentially all DICE devices support both 1x rates — so this is
+defense-in-depth plus roadmap hygiene rather than a live bug.
+
+### P1 — "`selectedClock_` poisons the next start": fully agree
+
+Confirmed: `DICETcatProtocol::ApplyClockConfig` stores
+`selectedClock_ = desiredClock` **before** dispatching to the duplex
+controller, the completion lambda has no rollback on failure, and
+`PrepareDuplex48k` feeds the stored value into the next `StartIO`
+(`DICETcatProtocol.cpp:~190` and `~253`). A rejected 44.1 kHz request leaves
+CoreAudio at 48 kHz while the next bring-up programs 44.1 kHz — exactly the
+clock-mismatch starvation scenario the PR's own comments warn about elsewhere.
+**This is the strongest correctness finding in the review.**
+
+### P2 — "Stale docs/simulator": fully agree
+
+- `print_wiring_status()` in `tools/amdtp_blocking_cadence_sim.py` still
+  lists as TODO things this PR did:
+  - "`AmdtpTxPacketizer.cpp:43` Configure() still rejects
+    sampleRate != 48000" — at the PR head the packetizer accepts the 44.1
+    family in blocking mode (rejects only non-blocking ≠ 48 k).
+  - The ZTS-period static assert — now present:
+    `zeroTimestampPeriodFrames % kMaxBlockingFramesPerDataPacket == 0`
+    inside `IsValidAudioHalBufferProfile`, statically asserted for all three
+    profiles (`AudioHalBufferProfiles.hpp:60-69`).
+- `SAMPLE_RATE_EXPANSION.md` still opens with "Implementation not started."
+- Trivial to fix, genuinely misleading if left.
+
+## Bottom line
+
+The **"Request changes" verdict is defensible** — the `selectedClock_`
+rollback, the capability intersection, and the stream-format sync are real
+pre-merge items, and they align with the project's own design doc rather than
+reviewer taste. But the severity should be re-weighted:
+
+- **Downgrade P0:** not an ADK-correctness violation (Apple's default does the
+  same thing). Idle-only switching is a legitimate Phase 0 policy — track the
+  `PerformDeviceConfigurationChange` wiring as a follow-up, not a blocker.
+- **Add the missed finding:** the 15 s blocking poll inside
+  `HandleChangeSampleRate` on the ADK work queue ranks above most of what the
+  review flagged.
+- **Keep as blockers:** `selectedClock_` rollback on failed clock apply;
+  stream-format sync (`DeviceSampleRateChanged`) or an empirical demonstration
+  it is unnecessary on the HAL-initiated path; the capability-set
+  intersection (or at minimum an exact-membership check in
+  `HandleChangeSampleRate`).
+- **Nits on the review itself:** `SAMPLE_RATE_EXPANSION.md#L225/#L240` anchors
+  don't land on the contract text at the PR head (it's ~L210), and the
+  failure-ordering narrative is only accurate for the success path.
+]

--- a/documentation/SAMPLE_RATE_EXPANSION.md
+++ b/documentation/SAMPLE_RATE_EXPANSION.md
@@ -96,6 +96,60 @@ drift) is strictly stronger than regenerating a nominal pattern — this is the
 Saffire lesson of `44100.md` §9, and it is why the fractional-cadence problem
 largely disappears for the duplex case.
 
+### The minimal TX cadence contract
+
+Distilled, the per-cycle TX cadence output is only two things: the
+**data/no-data decision** and, on data packets, the **SYT**. Everything else
+follows from those or sits beside them:
+
+- **DBC is not a third axis.** In blocking mode it advances by `sytInterval` on
+  a data packet and is unchanged on a no-data packet, so it is the running sum
+  of the data/no-data sequence — fully determined once that sequence is fixed.
+  It must still be emitted and seeded correctly (a DBC that disagrees with the
+  block count is a classic reason a device drops the stream — capture gate §8
+  item 2), but it is bookkeeping, not an independent decision.
+- **SYT is a delta replay plus a phase re-anchor, not a copy.** The device's SYT
+  *deltas* carry the fractional-rate structure and are replayed 1:1; the
+  *absolute* phase is re-anchored to the outgoing packet's bus time plus a
+  per-rate presentation lead (`ComputeReplaySytFromTicks` + `txTransferDelayTicks`,
+  §2). The rate can be perfect while a wrong lead still walks the device's
+  receive buffer into under/overflow — the lead is the part that must be
+  validated per device (§8 item 3; RME uses a per-rate startup-latency table,
+  `44100.md` §12.4).
+- **Payload is a separate axis.** The cadence only *sizes* each packet (how many
+  frames, and when); sourcing those frames from the CoreAudio buffer and
+  AM824-encoding them is the `PrepareTransmitSlots`/payload path, unaffected by
+  which rate produced the cadence.
+- **RX carries no cadence obligation at all** — it decodes `dataBlocks` from the
+  CIP header and stores what arrives (restated from the transaction section, §6).
+
+### What "device-as-master" removes — and what it does not
+
+The duplex clock-master case (the normal DICE-at-internal-clock topology)
+removes the cadence *generator*, not cadence as a concern. It removes computing
+the 441/640 D/N pattern and 4458/4459-tick SYT deltas yourself — the device's RX
+stream carries them and replay reproduces them (§2–§3). It does **not** remove:
+
+1. **Bring-up.** Before replay warms there is nothing to replay, and the device
+   will not lock its receive stream until it sees a paced host stream. TX must
+   emit valid no-data packets during that window, and the startup seed / lead /
+   reset policy is a distinct, capture-gated deliverable (§6 item 7, §8 item 1) —
+   not covered by "the device dictates cadence."
+2. **Framing correctness** (the contract above): DBC continuity, SYT encoding,
+   no-data format. Replay supplies timing, not framing.
+3. **The per-rate host-clock anchor.** ZTS seed and transfer delay are per-rate,
+   not a 48 kHz constant (§4 notes, §6 items 2–3, §8 item 3).
+4. **The synthesized fallback engine.** Playback-only devices, an unusable RX
+   SYT stream, and the AVC/Oxford path have no replay source and still need the
+   ideal engine (§5, Phase 4). This is why the design keeps both models rather
+   than declaring cadence "solved" by device-as-master.
+
+Three unrelated device-clocked stacks confirm the split: Saffire, FFADO, and RME
+are each clock-slaved to the device yet all keep a startup bootstrap, an explicit
+resync/discontinuity guard, and a per-rate startup anchor (`44100.md` §9, §10.2,
+§12.3–§12.4). A driver that had truly stopped caring about cadence would need
+none of those.
+
 ## 4. Cross-validation results (44100.md open question #6 — resolved)
 
 The Apple-derived model survives the Linux check in full:
@@ -379,7 +433,46 @@ and both copies plus their pinning tests go away with the rational form.)
 
 ## 8. Open risks / capture gates
 
-Wire enablement of 44.1 remains gated on `44100.md` open questions 7–9:
+Wire enablement of 44.1 reduces to **one measurement in one gated session**, not
+several separate captures. The capture-gated items in `44100.md` §13 (#7, #9,
+#10, #11, and the value-half of #12) collapse once *observing the device* is
+separated from *emitting our own stream*:
+
+- **Genuinely needs hardware — the presentation lead / transfer delay the target
+  device expects at 44.1, plus tolerance of ASFW's startup no-data prefix.** This
+  is the union of #7, #11, and #12-value, and it is a single number per rate
+  family. It needs hardware because it is *not* derivable from spec: Linux (`+1`
+  SYT interval on the `0x2e00` base), Apple (15-cycle lead + startup seed), and
+  RME (per-rate table, 1516 µs at 44.1, `44100.md` §12.4) each use a different
+  convention, so the value must be matched to the target empirically. Reachable
+  only after the §6 plumbing lets ASFW emit 44.1.
+- **Moot under replay — `44100.md` #9/#10** ("learn the device cadence / compare
+  SYT deltas"). The replay ring copies the device's stream verbatim, so it needs
+  no prior knowledge of the blocking pattern or delta sequence. A capture here
+  matters only when the *synthesized* engine must drive that specific device (the
+  fallback path), not for the normal duplex path.
+- **Needs no hardware — already cross-validated.** The 441/640 blocking pattern,
+  the 4458/4459-tick SYT deltas (34-long-per-147), and the DBC convention are
+  proven four ways (Apple/Linux/FFADO/RME, §4 and `44100.md` §9–§12) and
+  reproduced by `tools/amdtp_blocking_cadence_sim.py`. A capture only *confirms*
+  the target does not deviate — nice-to-have under the wire-compat doctrine, not
+  a discovery task.
+
+### What the gated session must contain, and how to sequence it
+
+- **Early / cheap (before the plumbing):** passively observe the device's own
+  stream while it runs at 44.1 (any known-good stack, or ASFW just setting
+  `CLOCK_SELECT` and receiving). This validates the replay source and retires the
+  device-observation half of #7 without ASFW transmitting anything.
+- **The real gate (after §6 plumbing):** ASFW emits 44.1 and we measure whether
+  the device locks and how receive-buffer occupancy trends over minutes — a wrong
+  lead shows up as a slow buffer walk even at a perfect rate. **This does not
+  require a FireWire bus analyzer:** ASFW's own `[TxSyt]`/`[Zts]` traces plus
+  `tools/zts_sim.py` (once it takes `--rate`, §6 ZTS residual 3) settle it
+  functionally. Hand the `log stream … | grep [TxSyt]` command to the user to run
+  — the dext trace is not readable from the agent sandbox.
+
+The detailed risk register (unchanged):
 
 1. Device tolerance of ASFW's warmup no-data prefix at 44.1 (blocking seed and
    no-data placement). **The engine's startup seed is not a wire contract**:


### PR DESCRIPTION
## Summary

Documentation-only branch — no driver or app code changes.

- **`documentation/44100.md`** — extends the 44.1 kHz family analysis: RME Fireface RE findings, the minimal TX contract, and consolidation of capture notes.
- **`documentation/SAMPLE_RATE_EXPANSION.md`** — updated alongside the cadence notes.
- **`documentation/PR_41_CODE_REVIEW.md`** — code review of [PR #41](https://github.com/mrmidi/ASFireWire/pull/41) (DICE 44.1 kHz sample-rate switcher), verdict: request changes (CoreAudio/device-clock transaction incompleteness).
- **`documentation/PR_41_REVIEW_ASSESSMENT.md`** — verification of that review against the PR head, DriverKit 27.0 SDK headers, and `ADKVirtualAudioLab`; agrees overall with two severity corrections.
- **`documentation/DEVICE_BACKEND_UNIFICATION.md`** — design note (proposal, not accepted decision) for a protocol-neutral device-backend interface across DICE / AV/C / RME vendor registers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)