### PR TITLE
FW-71 Promote neutral duplex seams

### DIFF
--- a/ASFWDriver/Audio/Core/AudioCoordinator.cpp
+++ b/ASFWDriver/Audio/Core/AudioCoordinator.cpp
@@ -280,10 +280,10 @@ IOReturn AudioCoordinator::StopStreaming(uint64_t guid) noexcept {
     return kIOReturnSuccess;
 }
 
-IOReturn AudioCoordinator::RequestDiceClockConfig(
+IOReturn AudioCoordinator::RequestClockConfig(
     uint64_t guid,
-    const DICE::DiceDesiredClockConfig& desiredClock,
-    DICE::DiceRestartReason reason) noexcept {
+    const AudioClockConfig& desiredClock,
+    DuplexRestartReason reason) noexcept {
     if (guid == 0) {
         return kIOReturnBadArgument;
     }
@@ -294,7 +294,7 @@ IOReturn AudioCoordinator::RequestDiceClockConfig(
             const uint64_t active = activeGuid_;
             IOLockUnlock(lock_);
             ASFW_LOG_WARNING(Audio,
-                             "AudioCoordinator: RequestDiceClockConfig busy requested=0x%016llx active=0x%016llx",
+                             "AudioCoordinator: RequestClockConfig busy requested=0x%016llx active=0x%016llx",
                              guid,
                              active);
             return kIOReturnBusy;
@@ -315,17 +315,16 @@ IOReturn AudioCoordinator::RequestDiceClockConfig(
     const IOReturn kr = dice_.RequestClockConfig(guid, desiredClock, reason);
     if (kr != kIOReturnSuccess) {
         ASFW_LOG_ERROR(Audio,
-                       "AudioCoordinator: RequestDiceClockConfig failed GUID=0x%016llx kr=0x%x",
+                       "AudioCoordinator: RequestClockConfig failed GUID=0x%016llx kr=0x%x",
                        guid,
                        kr);
         return kr;
     }
 
     ASFW_LOG(Audio,
-             "AudioCoordinator: RequestDiceClockConfig ok GUID=0x%016llx rate=%uHz clock=0x%08x reason=%u",
+             "AudioCoordinator: RequestClockConfig ok GUID=0x%016llx rate=%uHz reason=%u",
              guid,
              desiredClock.sampleRateHz,
-             desiredClock.clockSelect,
              static_cast<unsigned>(reason));
     return kIOReturnSuccess;
 }

--- a/ASFWDriver/Audio/Core/AudioCoordinator.hpp
+++ b/ASFWDriver/Audio/Core/AudioCoordinator.hpp
@@ -56,10 +56,10 @@ public:
 
     [[nodiscard]] IOReturn StartStreaming(uint64_t guid) noexcept;
     [[nodiscard]] IOReturn StopStreaming(uint64_t guid) noexcept;
-    [[nodiscard]] IOReturn RequestDiceClockConfig(
+    [[nodiscard]] IOReturn RequestClockConfig(
         uint64_t guid,
-        const DICE::DiceDesiredClockConfig& desiredClock,
-        DICE::DiceRestartReason reason) noexcept;
+        const AudioClockConfig& desiredClock,
+        DuplexRestartReason reason) noexcept;
     void BeginTeardown() noexcept;
 
     [[nodiscard]] ASFWAudioNub* GetNub(uint64_t guid) const noexcept { return publisher_.GetNub(guid); }

--- a/ASFWDriver/Audio/Protocols/Backends/ClockRequestBroker.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/ClockRequestBroker.hpp
@@ -23,6 +23,7 @@
 
 #include "RestartJournal.hpp"
 #include "RestartSessionStore.hpp"
+#include "../Duplex/DuplexControlTypes.hpp"
 
 #include <DriverKit/IOLib.h>
 
@@ -35,16 +36,16 @@
 
 namespace ASFW::Audio::Backends {
 
-using ASFW::Audio::DICE::DiceClockRequestCompletion;
-using ASFW::Audio::DICE::DiceClockRequestOutcome;
-using ASFW::Audio::DICE::DiceDesiredClockConfig;
-using ASFW::Audio::DICE::DiceRestartReason;
+using ASFW::Audio::AudioClockConfig;
+using ASFW::Audio::DuplexClockRequestCompletion;
+using ASFW::Audio::DuplexClockRequestOutcome;
+using ASFW::Audio::DuplexRestartReason;
 
 class ClockRequestBroker {
 public:
     struct PendingClockRequest {
-        DiceDesiredClockConfig desiredClock{};
-        DiceRestartReason reason{DiceRestartReason::kManualReconfigure};
+        AudioClockConfig desiredClock{};
+        DuplexRestartReason reason{DuplexRestartReason::kManualReconfigure};
         uint64_t token{0};
     };
 
@@ -106,7 +107,7 @@ public:
     [[nodiscard]] bool TryTakeCompleted(
         uint64_t guid,
         uint64_t token,
-        DiceClockRequestCompletion& outCompletion) noexcept {
+        DuplexClockRequestCompletion& outCompletion) noexcept {
         IOLock* const lock = *lockRef_;
         if (!lock) {
             return false;
@@ -136,7 +137,7 @@ public:
         return true;
     }
 
-    void Complete(const DiceClockRequestCompletion& completion, uint64_t guid) noexcept {
+    void Complete(const DuplexClockRequestCompletion& completion, uint64_t guid) noexcept {
         IOLock* const lock = *lockRef_;
         if (!lock) {
             return;
@@ -174,7 +175,7 @@ public:
 
     void FailPending(
         uint64_t guid,
-        DiceClockRequestOutcome outcome,
+        DuplexClockRequestOutcome outcome,
         IOReturn status) noexcept {
         PendingClockRequest request{};
         if (!TryConsumePending(guid, request)) {
@@ -186,7 +187,7 @@ public:
         // do not fold this into one new critical section; stop/recovery races intentionally see
         // the same interleavings as before the extraction.
         const auto session = sessionStore_.LoadSession(guid);
-        Complete(DiceClockRequestCompletion{
+        Complete(DuplexClockRequestCompletion{
                      .token = request.token,
                      .desiredClock = request.desiredClock,
                      .reason = request.reason,
@@ -200,7 +201,7 @@ public:
 
 private:
     struct ClockCompletionStore {
-        std::unordered_map<uint64_t, DiceClockRequestCompletion> byToken{};
+        std::unordered_map<uint64_t, DuplexClockRequestCompletion> byToken{};
         std::deque<uint64_t> insertionOrder{};
     };
 
@@ -217,7 +218,7 @@ private:
         auto* session = sessionStore_.FindSessionLocked(guid);
         if (session != nullptr) {
             session->pendingClock = {};
-            session->pendingReason = DiceRestartReason::kInitialStart;
+            session->pendingReason = DuplexRestartReason::kInitialStart;
             session->hasPendingClockRequest = false;
         }
         return true;

--- a/ASFWDriver/Audio/Protocols/Backends/DiceAudioBackend.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceAudioBackend.cpp
@@ -7,7 +7,8 @@
 #include "../../../Audio/Core/AudioRuntimeRegistry.hpp"
 #include "../../../Logging/Logging.hpp"
 #include "../DICE/Core/DICENotificationMailbox.hpp"
-#include "../DICE/Core/IDICEDuplexProtocol.hpp"
+#include "../DICE/Core/DICETypes.hpp"
+#include "../Duplex/IDuplexDeviceControl.hpp"
 #include "../IDeviceProtocol.hpp"
 #include "../DeviceProtocolFactory.hpp"
 #include "../../DriverKit/Config/DICE/DiceProfileRegistry.hpp"
@@ -263,7 +264,7 @@ void DiceAudioBackend::ProbeDuplexHealth(uint64_t guid, uint32_t notificationBit
     // Hold a shared_ptr for the duration of the (blocking) health probe so the
     // protocol cannot be torn down underneath us by a concurrent device removal.
     auto protocol = runtime_.FindShared(guid);
-    auto* diceProtocol = protocol ? protocol->AsDiceDuplexProtocol() : nullptr;
+    auto* diceProtocol = protocol ? protocol->AsDuplexDeviceControl() : nullptr;
     if (!diceProtocol) {
         return;
     }
@@ -322,14 +323,8 @@ void DiceAudioBackend::ProbeDuplexHealth(uint64_t guid, uint32_t notificationBit
         return;
     }
 
-    const bool sourceLocked = DICE::IsSourceLocked(waitState->result.status);
-    bool extClockHealthy = true;
-    const uint32_t clockSource = waitState->result.appliedClock.clockSelect & DICE::ClockSelect::kSourceMask;
-    if (clockSource == static_cast<uint32_t>(DICE::ClockSource::ARX1)) {
-        extClockHealthy =
-            DICE::IsArx1Locked(waitState->result.extStatus) &&
-            !DICE::HasArx1Slip(waitState->result.extStatus);
-    }
+    const bool sourceLocked = waitState->result.sourceLocked;
+    const bool extClockHealthy = waitState->result.clockReferenceHealthy;
 
     char notifyStr[96];
     char clockStr[40];
@@ -468,7 +463,7 @@ void DiceAudioBackend::EnsureNubForGuid(uint64_t guid) noexcept {
     // once before the first publish so CoreAudio shows the real names from the
     // start. The load early-returns if caps are already cached; publish happens
     // regardless of outcome (names fall back to synthesized "<plug> N").
-    if (auto* dice = protocol ? protocol->AsDiceDuplexProtocol() : nullptr) {
+    if (auto* dice = protocol ? protocol->AsDuplexDeviceControl() : nullptr) {
         dice->EnsureRuntimeStreamGeometry(
             [finish, dev, protocol](IOReturn /*status*/) mutable {
                 finish(std::move(dev), protocol);
@@ -544,8 +539,8 @@ IOReturn DiceAudioBackend::StopStreaming(uint64_t guid) noexcept {
 }
 
 IOReturn DiceAudioBackend::RequestClockConfig(uint64_t guid,
-                                              const DICE::DiceDesiredClockConfig& desiredClock,
-                                              DICE::DiceRestartReason reason) noexcept {
+                                              const AudioClockConfig& desiredClock,
+                                              DuplexRestartReason reason) noexcept {
     if (stopping_.load(std::memory_order_acquire)) {
         ASFW_LOG(Audio,
                  "DiceAudioBackend: RequestClockConfig refused by teardown GUID=0x%016llx",

--- a/ASFWDriver/Audio/Protocols/Backends/DiceAudioBackend.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceAudioBackend.hpp
@@ -48,8 +48,8 @@ public:
     [[nodiscard]] IOReturn StartStreaming(uint64_t guid) noexcept override;
     [[nodiscard]] IOReturn StopStreaming(uint64_t guid) noexcept override;
     [[nodiscard]] IOReturn RequestClockConfig(uint64_t guid,
-                                              const DICE::DiceDesiredClockConfig& desiredClock,
-                                              DICE::DiceRestartReason reason) noexcept;
+                                              const AudioClockConfig& desiredClock,
+                                              DuplexRestartReason reason) noexcept;
 
     // FW-61: quiesce the dice queue before the core detaches hardware. Sets the stop flag,
     // cancels in-flight recovery (coordinator), then drains the work queue (synchronous
@@ -72,7 +72,7 @@ private:
     Driver::HardwareInterface& hardware_;
     DiceIsochHostTransport hostTransport_;
     std::atomic<bool> stopping_{false}; // FW-61 teardown latch
-    DiceDuplexRestartCoordinator restartCoordinator_;
+    AudioDuplexCoordinator restartCoordinator_;
 
     IOLock* lock_{nullptr};
     OSSharedPtr<IODispatchQueue> workQueue_{};

--- a/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
@@ -10,7 +10,6 @@
 #include "../../../Logging/Logging.hpp"
 #include "../../Core/AudioRuntimeRegistry.hpp"
 #include "../../Model/ASFWAudioDevice.hpp"
-#include "../DICE/Core/IDICEDuplexProtocol.hpp"
 
 #include <DriverKit/IOLib.h>
 
@@ -26,26 +25,11 @@ using namespace ASFW::Audio::Backends;
 namespace {
 
 using ASFW::Audio::DICE::ClearRestartProgress;
-using ASFW::Audio::DICE::DiceClockRequestCompletion;
-using ASFW::Audio::DICE::DiceClockRequestOutcome;
-using ASFW::Audio::DICE::DiceDesiredClockConfig;
-using ASFW::Audio::DICE::DiceDuplexConfirmResult;
-using ASFW::Audio::DICE::DiceDuplexHealthResult;
-using ASFW::Audio::DICE::DiceDuplexPrepareResult;
-using ASFW::Audio::DICE::DiceDuplexStageResult;
-using ASFW::Audio::DICE::DiceRestartErrorClass;
-using ASFW::Audio::DICE::DiceRestartFailureCause;
-using ASFW::Audio::DICE::DiceRestartIssueInfo;
-using ASFW::Audio::DICE::DiceRestartPhase;
-using ASFW::Audio::DICE::DiceRestartReason;
-using ASFW::Audio::DICE::DiceRestartSession;
-using ASFW::Audio::DICE::DiceRestartState;
+using ASFW::Audio::AudioClockConfig;
 using ASFW::Audio::DICE::HasAnyRestartState;
 using ASFW::Audio::DICE::HasDeviceRestartState;
 using ASFW::Audio::DICE::HasHostRestartState;
 using ASFW::Audio::DICE::HasRestartIntent;
-using ASFW::Audio::DICE::IsSupportedClockConfig;
-using ASFW::Audio::DICE::kDiceClockSelect48kInternal;
 
 constexpr uint32_t kClockRequestWaitTimeoutMs = 15000;
 
@@ -67,8 +51,8 @@ inline uint8_t ReadLocalSid(Driver::HardwareInterface& hw) noexcept {
 
 // FW-70: the execution body of a duplex start/stop/idle-clock transaction.  The
 // coordinator remains the FSM entry-point and owns the gate/store, while this
-// runner owns the ordered stage sequence.  FW-71 will replace the temporary
-// DICE-named dependency types with their protocol-neutral seams.
+// runner owns the ordered stage sequence through protocol-neutral dependency
+// seams. FW-73 will perform the remaining mechanical file/type rename.
 // Device stream programming before GLOBAL_ENABLE is cross-validated with Linux
 // dice-stream.c:326-374 and dice-interface.h:120-125; no source code is copied.
 class DuplexStartTransaction final {
@@ -76,10 +60,10 @@ public:
     struct Dependencies {
         Discovery::DeviceRegistry& registry;
         AudioRuntimeRegistry& runtime;
-        IDiceHostTransport& hostTransport;
+        IIsochDuplexHostTransport& hostTransport;
         Driver::HardwareInterface& hardware;
         const std::atomic<bool>* cancel;
-        const DiceDuplexRestartCoordinator::DirectAudioBindingSourceProvider& bindingSourceProvider;
+        const AudioDuplexCoordinator::DirectAudioBindingSourceProvider& bindingSourceProvider;
         Backends::DuplexOperationGate& gate;
         Backends::RestartSessionStore& sessionStore;
         std::atomic<uint64_t>& teardownAbortCount;
@@ -92,26 +76,26 @@ public:
     struct StartRequest {
         uint64_t guid;
         Discovery::DeviceRecord& record;
-        DICE::IDICEDuplexProtocol& deviceControl;
-        DiceRestartSession& session;
-        const DiceDesiredClockConfig& desiredClock;
-        DiceRestartReason reason;
+        IDuplexDeviceControl& deviceControl;
+        DuplexRestartSession& session;
+        const AudioClockConfig& desiredClock;
+        DuplexRestartReason reason;
     };
 
     struct StopRequest {
         uint64_t guid;
         Discovery::DeviceRecord& record;
-        DICE::IDICEDuplexProtocol& deviceControl;
-        DiceRestartSession& session;
+        IDuplexDeviceControl& deviceControl;
+        DuplexRestartSession& session;
     };
 
     struct IdleClockApplyRequest {
         uint64_t guid;
-        DICE::IDICEDuplexProtocol& deviceControl;
-        DiceRestartSession& session;
+        IDuplexDeviceControl& deviceControl;
+        DuplexRestartSession& session;
         FW::Generation topologyGeneration;
-        const DiceDesiredClockConfig& desiredClock;
-        DiceRestartReason reason;
+        const AudioClockConfig& desiredClock;
+        DuplexRestartReason reason;
     };
 
     explicit DuplexStartTransaction(Dependencies dependencies) noexcept : dependencies_(dependencies) {}
@@ -130,9 +114,9 @@ private:
         uint64_t guid) const noexcept;
     [[nodiscard]] IOReturn WaitForStableGlobalClock(
         uint64_t guid,
-        DICE::IDICEDuplexProtocol& deviceControl,
+        IDuplexDeviceControl& deviceControl,
         FW::Generation topologyGeneration,
-        const DiceDesiredClockConfig& desiredClock) noexcept;
+        const AudioClockConfig& desiredClock) noexcept;
 
     Dependencies dependencies_;
 };
@@ -145,7 +129,7 @@ bool DuplexStartTransaction::TeardownRequested() const noexcept {
 void DuplexStartTransaction::RecordTeardownAbort(const char* stage, uint64_t guid) noexcept {
     dependencies_.teardownAbortCount.fetch_add(1, std::memory_order_acq_rel);
     ASFW_LOG(Audio,
-             "DiceDuplexRestartCoordinator: recovery aborted by teardown stage=%{public}s "
+             "AudioDuplexCoordinator: recovery aborted by teardown stage=%{public}s "
              "GUID=%llx kr=0x%x",
              stage ? stage : "unknown", guid, kIOReturnAborted);
 }
@@ -160,7 +144,7 @@ bool DuplexStartTransaction::IsRestartEpochCurrent(
         return false;
     }
 
-    const DiceRestartSession session = dependencies_.sessionStore.LoadSession(guid);
+    const DuplexRestartSession session = dependencies_.sessionStore.LoadSession(guid);
     if (session.restartId != restartId || session.topologyGeneration != topologyGeneration) {
         return false;
     }
@@ -174,39 +158,39 @@ Runtime::IDirectAudioBindingSource* DuplexStartTransaction::GetDirectAudioBindin
     return dependencies_.bindingSourceProvider ? dependencies_.bindingSourceProvider(guid) : nullptr;
 }
 
-DiceDuplexRestartCoordinator::DiceDuplexRestartCoordinator(
+AudioDuplexCoordinator::AudioDuplexCoordinator(
     Discovery::DeviceRegistry& registry, AudioRuntimeRegistry& runtime,
-    IDiceHostTransport& hostTransport, Driver::HardwareInterface& hardware,
+    IIsochDuplexHostTransport& hostTransport, Driver::HardwareInterface& hardware,
     const std::atomic<bool>* cancel,
     DirectAudioBindingSourceProvider bindingSourceProvider) noexcept
     : registry_(registry), runtime_(runtime), hostTransport_(hostTransport), hardware_(hardware),
       cancel_(cancel), bindingSourceProvider_(std::move(bindingSourceProvider)) {
     lock_ = IOLockAlloc();
     if (!lock_) {
-        ASFW_LOG_ERROR(Audio, "DiceDuplexRestartCoordinator: failed to allocate lock");
+        ASFW_LOG_ERROR(Audio, "AudioDuplexCoordinator: failed to allocate lock");
         return;
     }
 }
 
-DiceDuplexRestartCoordinator::~DiceDuplexRestartCoordinator() noexcept {
+AudioDuplexCoordinator::~AudioDuplexCoordinator() noexcept {
     if (lock_) {
         IOLockFree(lock_);
         lock_ = nullptr;
     }
 }
 
-IOReturn DiceDuplexRestartCoordinator::StartStreaming(uint64_t guid) noexcept {
+IOReturn AudioDuplexCoordinator::StartStreaming(uint64_t guid) noexcept {
     if (guid == 0) {
         return kIOReturnBadArgument;
     }
     if (TeardownRequested()) {
         ASFW_LOG(Audio,
-                 "DiceDuplexRestartCoordinator: StartStreaming refused by teardown GUID=%llx",
+                 "AudioDuplexCoordinator: StartStreaming refused by teardown GUID=%llx",
                  guid);
         return kIOReturnAborted;
     }
 
-    const DiceRestartSession session = LoadSession(guid);
+    const DuplexRestartSession session = LoadSession(guid);
     LogFsmEvent("start", guid, session.restartId, session.topologyGeneration, session.state,
                 session.phase, session.reason);
 
@@ -223,7 +207,7 @@ IOReturn DiceDuplexRestartCoordinator::StartStreaming(uint64_t guid) noexcept {
     }
     if (!acquired) {
         ASFW_LOG_ERROR(Audio,
-                       "DiceDuplexRestartCoordinator: StartStreaming timed out waiting for GUID "
+                       "AudioDuplexCoordinator: StartStreaming timed out waiting for GUID "
                        "claim GUID=%llx timeoutMs=%u",
                        guid, kSyncBridgeTimeoutMs);
         return kIOReturnTimeout;
@@ -234,22 +218,22 @@ IOReturn DiceDuplexRestartCoordinator::StartStreaming(uint64_t guid) noexcept {
     return status;
 }
 
-IOReturn DiceDuplexRestartCoordinator::StopStreaming(uint64_t guid) noexcept {
+IOReturn AudioDuplexCoordinator::StopStreaming(uint64_t guid) noexcept {
     if (guid == 0) {
         return kIOReturnBadArgument;
     }
     if (TeardownRequested()) {
-        ASFW_LOG(Audio, "DiceDuplexRestartCoordinator: StopStreaming refused by teardown GUID=%llx",
+        ASFW_LOG(Audio, "AudioDuplexCoordinator: StopStreaming refused by teardown GUID=%llx",
                  guid);
         return kIOReturnAborted;
     }
 
-    const DiceRestartSession session = LoadSession(guid);
+    const DuplexRestartSession session = LoadSession(guid);
     LogFsmEvent("stop", guid, session.restartId, session.topologyGeneration, session.state,
                 session.phase, session.reason);
 
     RequestStopIntent(guid);
-    FailPendingClockRequest(guid, DiceClockRequestOutcome::kAbortedByStop, kIOReturnAborted);
+    FailPendingClockRequest(guid, DuplexClockRequestOutcome::kAbortedByStop, kIOReturnAborted);
 
     bool acquired = false;
     for (uint32_t waited = 0; waited < kSyncBridgeTimeoutMs; waited += kSyncBridgePollMs) {
@@ -265,7 +249,7 @@ IOReturn DiceDuplexRestartCoordinator::StopStreaming(uint64_t guid) noexcept {
     }
     if (!acquired) {
         ASFW_LOG_ERROR(Audio,
-                       "DiceDuplexRestartCoordinator: StopStreaming timed out waiting for GUID "
+                       "AudioDuplexCoordinator: StopStreaming timed out waiting for GUID "
                        "claim GUID=%llx timeoutMs=%u",
                        guid, kSyncBridgeTimeoutMs);
         ClearStopIntent(guid);
@@ -273,24 +257,24 @@ IOReturn DiceDuplexRestartCoordinator::StopStreaming(uint64_t guid) noexcept {
     }
 
     const IOReturn status = RunStopStreaming(guid);
-    FailPendingClockRequest(guid, DiceClockRequestOutcome::kAbortedByStop, kIOReturnAborted);
+    FailPendingClockRequest(guid, DuplexClockRequestOutcome::kAbortedByStop, kIOReturnAborted);
     ClearStopIntent(guid);
     ReleaseGuid(guid);
     return status;
 }
 
-IOReturn DiceDuplexRestartCoordinator::RequestClockConfig(
-    uint64_t guid, const DiceDesiredClockConfig& desiredClock, DiceRestartReason reason) noexcept {
+IOReturn AudioDuplexCoordinator::RequestClockConfig(
+    uint64_t guid, const AudioClockConfig& desiredClock, DuplexRestartReason reason) noexcept {
     if (guid == 0) {
         return kIOReturnBadArgument;
     }
     if (TeardownRequested()) {
         ASFW_LOG(Audio,
-                 "DiceDuplexRestartCoordinator: RequestClockConfig refused by teardown GUID=%llx",
+                 "AudioDuplexCoordinator: RequestClockConfig refused by teardown GUID=%llx",
                  guid);
         return kIOReturnAborted;
     }
-    if (!IsSupportedClockConfig(desiredClock)) {
+    if (!IsSupportedAudioClockConfig(desiredClock)) {
         return kIOReturnUnsupported;
     }
 
@@ -301,7 +285,7 @@ IOReturn DiceDuplexRestartCoordinator::RequestClockConfig(
 
     bool shouldLaunchLoop = false;
     std::optional<PendingClockRequest> supersededRequest{};
-    DiceRestartSession session = LoadSession(guid);
+    DuplexRestartSession session = LoadSession(guid);
     if (!lock_) {
         return kIOReturnNoResources;
     }
@@ -328,11 +312,11 @@ IOReturn DiceDuplexRestartCoordinator::RequestClockConfig(
 
     if (supersededRequest.has_value()) {
         CompleteClockRequest(
-            DiceClockRequestCompletion{
+            DuplexClockRequestCompletion{
                 .token = supersededRequest->token,
                 .desiredClock = supersededRequest->desiredClock,
                 .reason = supersededRequest->reason,
-                .outcome = DiceClockRequestOutcome::kSuperseded,
+                .outcome = DuplexClockRequestOutcome::kSuperseded,
                 .status = kIOReturnAborted,
                 .restartId = session.restartId,
                 .generation = session.topologyGeneration,
@@ -346,7 +330,7 @@ IOReturn DiceDuplexRestartCoordinator::RequestClockConfig(
     }
 
     for (uint32_t waited = 0; waited < kClockRequestWaitTimeoutMs; waited += kSyncBridgePollMs) {
-        DiceClockRequestCompletion completion{};
+        DuplexClockRequestCompletion completion{};
         if (TryTakeCompletedClockRequest(guid, request.token, completion)) {
             return completion.status;
         }
@@ -360,23 +344,23 @@ IOReturn DiceDuplexRestartCoordinator::RequestClockConfig(
     return kIOReturnTimeout;
 }
 
-IOReturn DiceDuplexRestartCoordinator::RecoverStreaming(uint64_t guid,
-                                                        DiceRestartReason reason) noexcept {
+IOReturn AudioDuplexCoordinator::RecoverStreaming(uint64_t guid,
+                                                        DuplexRestartReason reason) noexcept {
     if (guid == 0) {
         return kIOReturnBadArgument;
     }
     if (TeardownRequested()) {
         ASFW_LOG(Audio,
-                 "DiceDuplexRestartCoordinator: RecoverStreaming refused by teardown GUID=%llx",
+                 "AudioDuplexCoordinator: RecoverStreaming refused by teardown GUID=%llx",
                  guid);
         return kIOReturnAborted;
     }
 
-    const DiceRestartSession session = LoadSession(guid);
+    const DuplexRestartSession session = LoadSession(guid);
     LogFsmEvent("recover", guid, session.restartId, session.topologyGeneration, session.state,
                 session.phase, reason);
 
-    FailPendingClockRequest(guid, DiceClockRequestOutcome::kAbortedByStop, kIOReturnAborted);
+    FailPendingClockRequest(guid, DuplexClockRequestOutcome::kAbortedByStop, kIOReturnAborted);
 
     bool acquired = false;
     for (uint32_t waited = 0; waited < kSyncBridgeTimeoutMs; waited += kSyncBridgePollMs) {
@@ -391,7 +375,7 @@ IOReturn DiceDuplexRestartCoordinator::RecoverStreaming(uint64_t guid,
     }
     if (!acquired) {
         ASFW_LOG_ERROR(Audio,
-                       "DiceDuplexRestartCoordinator: RecoverStreaming timed out waiting for GUID "
+                       "AudioDuplexCoordinator: RecoverStreaming timed out waiting for GUID "
                        "claim GUID=%llx timeoutMs=%u",
                        guid, kSyncBridgeTimeoutMs);
         return kIOReturnTimeout;
@@ -402,7 +386,7 @@ IOReturn DiceDuplexRestartCoordinator::RecoverStreaming(uint64_t guid,
     return status;
 }
 
-void DiceDuplexRestartCoordinator::ClearSession(uint64_t guid) noexcept {
+void AudioDuplexCoordinator::ClearSession(uint64_t guid) noexcept {
     if (!lock_ || guid == 0) {
         return;
     }
@@ -415,92 +399,91 @@ void DiceDuplexRestartCoordinator::ClearSession(uint64_t guid) noexcept {
     IOLockUnlock(lock_);
 }
 
-std::optional<DiceRestartSession>
-DiceDuplexRestartCoordinator::GetSession(uint64_t guid) const noexcept {
+std::optional<DuplexRestartSession>
+AudioDuplexCoordinator::GetSession(uint64_t guid) const noexcept {
     return store_.GetSession(guid);
 }
 
-IOReturn DiceDuplexRestartCoordinator::RunStartStreaming(uint64_t guid) noexcept {
+IOReturn AudioDuplexCoordinator::RunStartStreaming(uint64_t guid) noexcept {
     if (TeardownRequested()) {
         return kIOReturnAborted;
     }
 
-    DICE::IDICEDuplexProtocol* diceProtocol = nullptr;
+    IDuplexDeviceControl* deviceControl = nullptr;
     std::shared_ptr<IDeviceProtocol> protoHold; // keeps the protocol alive for this op
-    auto* record = RequireDiceRecord(guid, diceProtocol, protoHold);
-    if (!record || !diceProtocol) {
-        FailPendingClockRequest(guid, DiceClockRequestOutcome::kFailed, kIOReturnNotReady);
+    auto* record = RequireDuplexRecord(guid, deviceControl, protoHold);
+    if (!record || !deviceControl) {
+        FailPendingClockRequest(guid, DuplexClockRequestOutcome::kFailed, kIOReturnNotReady);
         return kIOReturnNotReady;
     }
 
-    DiceRestartSession session = LoadSession(guid);
-    const DiceDesiredClockConfig desiredClock{
+    DuplexRestartSession session = LoadSession(guid);
+    const AudioClockConfig desiredClock{
         .sampleRateHz = 48000U,
-        .clockSelect = kDiceClockSelect48kInternal,
     };
-    const DiceRestartReason reason = DICE::HasRestartIntent(session)
+    const DuplexRestartReason reason = HasRestartIntent(session)
                                          ? DICE::ClassifyRestartReason(&session, desiredClock)
-                                         : DiceRestartReason::kInitialStart;
+                                         : DuplexRestartReason::kInitialStart;
 
     const IOReturn status =
-        RunDuplexStart(guid, *record, *diceProtocol, session, desiredClock, reason);
+        RunDuplexStart(guid, *record, *deviceControl, session, desiredClock, reason);
     if (status != kIOReturnSuccess) {
-        FailPendingClockRequest(guid, DiceClockRequestOutcome::kFailed, status);
+        FailPendingClockRequest(guid, DuplexClockRequestOutcome::kFailed, status);
         return status;
     }
 
     if (IsStopRequested(guid)) {
-        FailPendingClockRequest(guid, DiceClockRequestOutcome::kAbortedByStop, kIOReturnAborted);
+        FailPendingClockRequest(guid, DuplexClockRequestOutcome::kAbortedByStop, kIOReturnAborted);
         return kIOReturnSuccess;
     }
 
     PendingClockRequest pending{};
     while (TryConsumePendingClockRequest(guid, pending)) {
         if (IsStopRequested(guid)) {
-            const DiceRestartSession completionSession = LoadSession(guid);
+            const DuplexRestartSession completionSession = LoadSession(guid);
             CompleteClockRequest(
-                DiceClockRequestCompletion{
+                DuplexClockRequestCompletion{
                     .token = pending.token,
                     .desiredClock = pending.desiredClock,
                     .reason = pending.reason,
-                    .outcome = DiceClockRequestOutcome::kAbortedByStop,
+                    .outcome = DuplexClockRequestOutcome::kAbortedByStop,
                     .status = kIOReturnAborted,
                     .restartId = completionSession.restartId,
                     .generation = completionSession.topologyGeneration,
                 },
                 guid);
-            FailPendingClockRequest(guid, DiceClockRequestOutcome::kAbortedByStop,
+            FailPendingClockRequest(guid, DuplexClockRequestOutcome::kAbortedByStop,
                                     kIOReturnAborted);
             break;
         }
 
         const IOReturn pendingStatus = ApplyClockRequest(guid, pending);
         if (IsStopRequested(guid)) {
-            const DiceRestartSession completionSession = LoadSession(guid);
+            const DuplexRestartSession completionSession = LoadSession(guid);
             CompleteClockRequest(
-                DiceClockRequestCompletion{
+                DuplexClockRequestCompletion{
                     .token = pending.token,
                     .desiredClock = pending.desiredClock,
                     .reason = pending.reason,
-                    .outcome = DiceClockRequestOutcome::kAbortedByStop,
+                    .outcome = DuplexClockRequestOutcome::kAbortedByStop,
                     .status = kIOReturnAborted,
                     .restartId = completionSession.restartId,
                     .generation = completionSession.topologyGeneration,
                 },
                 guid);
-            FailPendingClockRequest(guid, DiceClockRequestOutcome::kAbortedByStop,
+            FailPendingClockRequest(guid, DuplexClockRequestOutcome::kAbortedByStop,
                                     kIOReturnAborted);
             break;
         }
 
-        const DiceRestartSession completionSession = LoadSession(guid);
+        const DuplexRestartSession completionSession = LoadSession(guid);
         CompleteClockRequest(
-            DiceClockRequestCompletion{
+            DuplexClockRequestCompletion{
                 .token = pending.token,
                 .desiredClock = pending.desiredClock,
                 .reason = pending.reason,
-                .outcome = (pendingStatus == kIOReturnSuccess) ? DiceClockRequestOutcome::kApplied
-                                                               : DiceClockRequestOutcome::kFailed,
+                .outcome = (pendingStatus == kIOReturnSuccess) ? DuplexClockRequestOutcome::kApplied
+                                                               : DuplexClockRequestOutcome::kFailed,
                 .status = pendingStatus,
                 .restartId = completionSession.restartId,
                 .generation = completionSession.topologyGeneration,
@@ -511,16 +494,16 @@ IOReturn DiceDuplexRestartCoordinator::RunStartStreaming(uint64_t guid) noexcept
     return kIOReturnSuccess;
 }
 
-IOReturn DiceDuplexRestartCoordinator::RunStopStreaming(uint64_t guid) noexcept {
+IOReturn AudioDuplexCoordinator::RunStopStreaming(uint64_t guid) noexcept {
     if (TeardownRequested()) {
         return kIOReturnAborted;
     }
 
-    DICE::IDICEDuplexProtocol* diceProtocol = nullptr;
+    IDuplexDeviceControl* deviceControl = nullptr;
     std::shared_ptr<IDeviceProtocol> protoHold; // keeps the protocol alive for this op
-    auto* record = RequireDiceRecord(guid, diceProtocol, protoHold);
-    if (!record || !diceProtocol) {
-        DiceRestartSession session = LoadSession(guid);
+    auto* record = RequireDuplexRecord(guid, deviceControl, protoHold);
+    if (!record || !deviceControl) {
+        DuplexRestartSession session = LoadSession(guid);
         ClearFailureSnapshot(session);
         ClearRestartProgress(session);
         StoreSession(session);
@@ -528,24 +511,24 @@ IOReturn DiceDuplexRestartCoordinator::RunStopStreaming(uint64_t guid) noexcept 
         return kIOReturnNotReady;
     }
 
-    DiceRestartSession session = LoadSession(guid);
-    return RunDuplexStop(guid, *record, *diceProtocol, session);
+    DuplexRestartSession session = LoadSession(guid);
+    return RunDuplexStop(guid, *record, *deviceControl, session);
 }
 
-IOReturn DiceDuplexRestartCoordinator::RunRecoveryStreaming(uint64_t guid,
-                                                            DiceRestartReason reason) noexcept {
+IOReturn AudioDuplexCoordinator::RunRecoveryStreaming(uint64_t guid,
+                                                            DuplexRestartReason reason) noexcept {
     if (TeardownRequested()) {
         return kIOReturnAborted;
     }
 
-    DICE::IDICEDuplexProtocol* diceProtocol = nullptr;
+    IDuplexDeviceControl* deviceControl = nullptr;
     std::shared_ptr<IDeviceProtocol> protoHold; // keeps the protocol alive for this op
-    auto* record = RequireDiceRecord(guid, diceProtocol, protoHold);
-    DiceRestartSession session = LoadSession(guid);
+    auto* record = RequireDuplexRecord(guid, deviceControl, protoHold);
+    DuplexRestartSession session = LoadSession(guid);
     session.guid = guid;
     if (IsRecoveryReason(reason)) {
         RecordIssue(session, session.lastInvalidation, session.phase,
-                    DiceRestartErrorClass::kEpochInvalidated, FailureCauseForReason(reason),
+                    DuplexRestartErrorClass::kEpochInvalidated, FailureCauseForReason(reason),
                     kIOReturnAborted, true, false, kIOReturnSuccess, true, true);
         StoreSession(session);
         LogInvalidation(session);
@@ -560,7 +543,7 @@ IOReturn DiceDuplexRestartCoordinator::RunRecoveryStreaming(uint64_t guid,
         .hasHostFootprint = HasHostRestartState(session),
         .hasDeviceFootprint = HasDeviceRestartState(session),
         .hasDiceRecord = (record != nullptr),
-        .hasProtocol = (diceProtocol != nullptr),
+        .hasProtocol = (deviceControl != nullptr),
         .lastFailureRetryable = session.lastFailure.has_value() && session.lastFailure->retryable,
     };
     const DiceRecoveryDecision decision = EvaluateRecoveryPolicy(context);
@@ -574,41 +557,40 @@ IOReturn DiceDuplexRestartCoordinator::RunRecoveryStreaming(uint64_t guid,
     }
 
     if (decision.disposition == DiceRecoveryDisposition::kFailSession) {
-        const bool missingDependency = (!record || !diceProtocol);
+        const bool missingDependency = (!record || !deviceControl);
         session.terminalError = missingDependency
                                     ? kIOReturnNotReady
                                     : (session.lastFailure.has_value() ? session.lastFailure->status
                                                                        : kIOReturnUnsupported);
         if (missingDependency) {
             RecordIssue(session, session.lastFailure, session.phase,
-                        DiceRestartErrorClass::kMissingDependency, FailureCauseForReason(reason),
+                        DuplexRestartErrorClass::kMissingDependency, FailureCauseForReason(reason),
                         session.terminalError, false, false, kIOReturnSuccess, false, false);
         }
-        ApplyTerminalPhase(session, DiceRestartPhase::kFailed, ToString(decision.reason));
+        ApplyTerminalPhase(session, DuplexRestartPhase::kFailed, ToString(decision.reason));
         StoreSession(session);
         LogTerminal(session);
         return session.terminalError;
     }
 
-    if (!record || !diceProtocol) {
+    if (!record || !deviceControl) {
         return kIOReturnNotReady;
     }
 
-    const DiceDesiredClockConfig desiredClock =
-        (session.desiredClock.sampleRateHz != 0 && session.desiredClock.clockSelect != 0)
+    const AudioClockConfig desiredClock =
+        (session.desiredClock.sampleRateHz != 0)
             ? session.desiredClock
-            : ((session.appliedClock.sampleRateHz != 0 && session.appliedClock.clockSelect != 0)
+            : ((session.appliedClock.sampleRateHz != 0)
                    ? session.appliedClock
-                   : DiceDesiredClockConfig{
+                   : AudioClockConfig{
                          .sampleRateHz = 48000U,
-                         .clockSelect = kDiceClockSelect48kInternal,
                      });
 
-    if (HasAnyRestartState(session) || session.phase == DiceRestartPhase::kRunning) {
+    if (HasAnyRestartState(session) || session.phase == DuplexRestartPhase::kRunning) {
         if (TeardownRequested()) {
             return kIOReturnAborted;
         }
-        const IOReturn stopStatus = RunDuplexStop(guid, *record, *diceProtocol, session);
+        const IOReturn stopStatus = RunDuplexStop(guid, *record, *deviceControl, session);
         if (stopStatus != kIOReturnSuccess) {
             return stopStatus;
         }
@@ -618,30 +600,30 @@ IOReturn DiceDuplexRestartCoordinator::RunRecoveryStreaming(uint64_t guid,
         return kIOReturnAborted;
     }
 
-    return RunDuplexStart(guid, *record, *diceProtocol, session, desiredClock, reason);
+    return RunDuplexStart(guid, *record, *deviceControl, session, desiredClock, reason);
 }
 
 IOReturn
-DiceDuplexRestartCoordinator::RunClockRequestLoop(uint64_t guid,
+AudioDuplexCoordinator::RunClockRequestLoop(uint64_t guid,
                                                   PendingClockRequest initialRequest) noexcept {
     PendingClockRequest current = initialRequest;
     IOReturn lastStatus = kIOReturnSuccess;
 
     while (true) {
         if (IsStopRequested(guid) || TeardownRequested()) {
-            const DiceRestartSession completionSession = LoadSession(guid);
+            const DuplexRestartSession completionSession = LoadSession(guid);
             CompleteClockRequest(
-                DiceClockRequestCompletion{
+                DuplexClockRequestCompletion{
                     .token = current.token,
                     .desiredClock = current.desiredClock,
                     .reason = current.reason,
-                    .outcome = DiceClockRequestOutcome::kAbortedByStop,
+                    .outcome = DuplexClockRequestOutcome::kAbortedByStop,
                     .status = kIOReturnAborted,
                     .restartId = completionSession.restartId,
                     .generation = completionSession.topologyGeneration,
                 },
                 guid);
-            FailPendingClockRequest(guid, DiceClockRequestOutcome::kAbortedByStop,
+            FailPendingClockRequest(guid, DuplexClockRequestOutcome::kAbortedByStop,
                                     kIOReturnAborted);
             break;
         }
@@ -649,31 +631,31 @@ DiceDuplexRestartCoordinator::RunClockRequestLoop(uint64_t guid,
         lastStatus = ApplyClockRequest(guid, current);
 
         if (IsStopRequested(guid) || TeardownRequested()) {
-            const DiceRestartSession completionSession = LoadSession(guid);
+            const DuplexRestartSession completionSession = LoadSession(guid);
             CompleteClockRequest(
-                DiceClockRequestCompletion{
+                DuplexClockRequestCompletion{
                     .token = current.token,
                     .desiredClock = current.desiredClock,
                     .reason = current.reason,
-                    .outcome = DiceClockRequestOutcome::kAbortedByStop,
+                    .outcome = DuplexClockRequestOutcome::kAbortedByStop,
                     .status = kIOReturnAborted,
                     .restartId = completionSession.restartId,
                     .generation = completionSession.topologyGeneration,
                 },
                 guid);
-            FailPendingClockRequest(guid, DiceClockRequestOutcome::kAbortedByStop,
+            FailPendingClockRequest(guid, DuplexClockRequestOutcome::kAbortedByStop,
                                     kIOReturnAborted);
             break;
         }
 
-        const DiceRestartSession completionSession = LoadSession(guid);
+        const DuplexRestartSession completionSession = LoadSession(guid);
         CompleteClockRequest(
-            DiceClockRequestCompletion{
+            DuplexClockRequestCompletion{
                 .token = current.token,
                 .desiredClock = current.desiredClock,
                 .reason = current.reason,
-                .outcome = (lastStatus == kIOReturnSuccess) ? DiceClockRequestOutcome::kApplied
-                                                            : DiceClockRequestOutcome::kFailed,
+                .outcome = (lastStatus == kIOReturnSuccess) ? DuplexClockRequestOutcome::kApplied
+                                                            : DuplexClockRequestOutcome::kFailed,
                 .status = lastStatus,
                 .restartId = completionSession.restartId,
                 .generation = completionSession.topologyGeneration,
@@ -691,38 +673,38 @@ DiceDuplexRestartCoordinator::RunClockRequestLoop(uint64_t guid,
 }
 
 IOReturn
-DiceDuplexRestartCoordinator::ApplyClockRequest(uint64_t guid,
+AudioDuplexCoordinator::ApplyClockRequest(uint64_t guid,
                                                 const PendingClockRequest& request) noexcept {
     if (IsStopRequested(guid) || TeardownRequested()) {
         return kIOReturnAborted;
     }
 
-    DICE::IDICEDuplexProtocol* diceProtocol = nullptr;
+    IDuplexDeviceControl* deviceControl = nullptr;
     std::shared_ptr<IDeviceProtocol> protoHold; // keeps the protocol alive for this op
-    auto* record = RequireDiceRecord(guid, diceProtocol, protoHold);
-    if (!record || !diceProtocol) {
+    auto* record = RequireDuplexRecord(guid, deviceControl, protoHold);
+    if (!record || !deviceControl) {
         return kIOReturnNotReady;
     }
-    if (!IsSupportedClockConfig(request.desiredClock)) {
+    if (!IsSupportedAudioClockConfig(request.desiredClock)) {
         return kIOReturnUnsupported;
     }
 
-    DiceRestartSession session = LoadSession(guid);
-    if (HasAnyRestartState(session) || session.phase == DiceRestartPhase::kRunning ||
-        session.state == DiceRestartState::kRunning ||
-        session.state == DiceRestartState::kRecovering ||
-        session.state == DiceRestartState::kFailed) {
+    DuplexRestartSession session = LoadSession(guid);
+    if (HasAnyRestartState(session) || session.phase == DuplexRestartPhase::kRunning ||
+        session.state == DuplexRestartState::kRunning ||
+        session.state == DuplexRestartState::kRecovering ||
+        session.state == DuplexRestartState::kFailed) {
         if (TeardownRequested()) {
             return kIOReturnAborted;
         }
-        const IOReturn stopStatus = RunDuplexStop(guid, *record, *diceProtocol, session);
+        const IOReturn stopStatus = RunDuplexStop(guid, *record, *deviceControl, session);
         if (stopStatus != kIOReturnSuccess) {
             return stopStatus;
         }
         if (TeardownRequested()) {
             return kIOReturnAborted;
         }
-        return RunDuplexStart(guid, *record, *diceProtocol, session, request.desiredClock,
+        return RunDuplexStart(guid, *record, *deviceControl, session, request.desiredClock,
                               request.reason);
     }
 
@@ -730,17 +712,17 @@ DiceDuplexRestartCoordinator::ApplyClockRequest(uint64_t guid,
         return kIOReturnAborted;
     }
 
-    return RunIdleClockApply(guid, *diceProtocol, session, record->gen, request.desiredClock,
+    return RunIdleClockApply(guid, *deviceControl, session, record->gen, request.desiredClock,
                              request.reason);
 }
 
 IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
     const uint64_t guid = request.guid;
     Discovery::DeviceRecord& record = request.record;
-    DICE::IDICEDuplexProtocol& diceProtocol = request.deviceControl;
-    DiceRestartSession& session = request.session;
-    const DiceDesiredClockConfig& desiredClock = request.desiredClock;
-    const DiceRestartReason reason = request.reason;
+    IDuplexDeviceControl& deviceControl = request.deviceControl;
+    DuplexRestartSession& session = request.session;
+    const AudioClockConfig& desiredClock = request.desiredClock;
+    const DuplexRestartReason reason = request.reason;
     auto& runtime_ = dependencies_.runtime;
     auto& hostTransport_ = dependencies_.hostTransport;
     auto& hardware_ = dependencies_.hardware;
@@ -752,7 +734,7 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
         this->RecordTeardownAbort(stage, abortGuid);
     };
     auto AllocateRestartId = [this]() noexcept { return dependencies_.sessionStore.AllocateRestartId(); };
-    auto StoreSession = [this](const DiceRestartSession& updatedSession) noexcept {
+    auto StoreSession = [this](const DuplexRestartSession& updatedSession) noexcept {
         dependencies_.sessionStore.StoreSession(updatedSession);
     };
     auto IsStopRequested = [this](uint64_t requestGuid) noexcept {
@@ -766,8 +748,8 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
         return this->GetDirectAudioBindingSource(requestGuid);
     };
     auto RunDuplexStop = [this](uint64_t stopGuid, Discovery::DeviceRecord& stopRecord,
-                                DICE::IDICEDuplexProtocol& stopDevice,
-                                DiceRestartSession& stopSession) noexcept {
+                                IDuplexDeviceControl& stopDevice,
+                                DuplexRestartSession& stopSession) noexcept {
         return Stop(StopRequest{stopGuid, stopRecord, stopDevice, stopSession});
     };
 
@@ -785,17 +767,16 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
     const FW::Generation topologyGeneration = record.gen;
     auto runtimeProtocol = runtime_.FindShared(record.guid);
 
-    // Pre-read the device's static stream format (DICE TX_NUMBER/RX_NUMBER +
-    // per-stream channels) so the channel resolution + IRM reservation below see
+    // Pre-read the device's static stream geometry so channel resolution and IRM reservation see
     // the real stream count. EnsureRuntimeStreamGeometry publishes the per-stream
     // caps that DuplexStreamProfileResolver consumes via GetRuntimeAudioStreamCaps.
     // Non-fatal: on failure we fall back to the legacy single-stream resolution
     // and PrepareDuplex will surface any genuine device error. A multi-stream
-    // device (Venice F32 = 2×16) needs this to allocate a channel per stream;
+    // device needs this to allocate a channel per stream. The DICE implementation is
     // cross-validated with FFADO dice_avdevice.cpp prepare() (m_nb_rx/m_nb_tx).
     const auto geometryLoad = WaitForAsyncResult<bool>(
         [&](auto callback) {
-            diceProtocol.EnsureRuntimeStreamGeometry(
+            deviceControl.EnsureRuntimeStreamGeometry(
                 [callback = std::move(callback)](IOReturn st) mutable { callback(st, true); });
         },
         kSyncBridgeTimeoutMs, kIOReturnTimeout, cancel_);
@@ -811,8 +792,8 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
     const AudioDuplexChannels channels = initialProfile.channels;
     const uint64_t restartId = AllocateRestartId();
 
-    auto finalizeFailure = [&](IOReturn failureStatus, DiceRestartPhase failedPhase,
-                               DiceRestartFailureCause cause, DiceRestartErrorClass errorClass,
+    auto finalizeFailure = [&](IOReturn failureStatus, DuplexRestartPhase failedPhase,
+                               DuplexRestartFailureCause cause, DuplexRestartErrorClass errorClass,
                                bool rollbackAttempted, IOReturn rollbackStatus, bool hostStateKnown,
                                bool deviceStateKnown) noexcept {
         session.guid = guid;
@@ -826,33 +807,33 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
         RecordIssue(session, session.lastFailure, failedPhase, errorClass, cause, failureStatus,
                     IsRetryableStatus(failureStatus), rollbackAttempted, rollbackStatus,
                     hostStateKnown, deviceStateKnown);
-        ApplyTerminalPhase(session, DiceRestartPhase::kFailed, ToString(errorClass));
+        ApplyTerminalPhase(session, DuplexRestartPhase::kFailed, ToString(errorClass));
         StoreSession(session);
         LogTerminal(session);
         return failureStatus;
     };
 
-    auto rollbackToFailure = [&](IOReturn failureStatus, DiceRestartPhase failedPhase,
-                                 DiceRestartFailureCause cause) noexcept {
+    auto rollbackToFailure = [&](IOReturn failureStatus, DuplexRestartPhase failedPhase,
+                                 DuplexRestartFailureCause cause) noexcept {
         if (failureStatus == kIOReturnAborted && TeardownRequested()) {
             return failureStatus;
         }
-        const IOReturn rollbackStatus = RunDuplexStop(guid, record, diceProtocol, session);
+        const IOReturn rollbackStatus = RunDuplexStop(guid, record, deviceControl, session);
         return finalizeFailure(failureStatus, failedPhase, cause,
-                               DiceRestartErrorClass::kStageFailure, true, rollbackStatus, true,
+                               DuplexRestartErrorClass::kStageFailure, true, rollbackStatus, true,
                                true);
     };
 
-    auto rollbackToInvalidation = [&](IOReturn invalidationStatus, DiceRestartPhase failedPhase,
-                                      DiceRestartFailureCause cause) noexcept {
+    auto rollbackToInvalidation = [&](IOReturn invalidationStatus, DuplexRestartPhase failedPhase,
+                                      DuplexRestartFailureCause cause) noexcept {
         if (invalidationStatus == kIOReturnAborted && TeardownRequested()) {
             return invalidationStatus;
         }
-        const IOReturn rollbackStatus = RunDuplexStop(guid, record, diceProtocol, session);
+        const IOReturn rollbackStatus = RunDuplexStop(guid, record, deviceControl, session);
         if (rollbackStatus != kIOReturnSuccess) {
             return finalizeFailure(
-                rollbackStatus, DiceRestartPhase::kStopping, DiceRestartFailureCause::kStop,
-                DiceRestartErrorClass::kStageFailure, true, rollbackStatus, true, true);
+                rollbackStatus, DuplexRestartPhase::kStopping, DuplexRestartFailureCause::kStop,
+                DuplexRestartErrorClass::kStageFailure, true, rollbackStatus, true, true);
         }
 
         session.guid = guid;
@@ -864,11 +845,11 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
         session.desiredClock = desiredClock;
         session.terminalError = kIOReturnSuccess;
         RecordIssue(session, session.lastInvalidation, failedPhase,
-                    IsStopRequested(guid) ? DiceRestartErrorClass::kStopIntent
-                                          : DiceRestartErrorClass::kEpochInvalidated,
+                    IsStopRequested(guid) ? DuplexRestartErrorClass::kStopIntent
+                                          : DuplexRestartErrorClass::kEpochInvalidated,
                     cause, invalidationStatus, true, true, rollbackStatus, true, true);
         ClearFailureSnapshot(session);
-        ApplyTerminalPhase(session, DiceRestartPhase::kIdle,
+        ApplyTerminalPhase(session, DuplexRestartPhase::kIdle,
                            ToString(session.lastInvalidation->errorClass));
         StoreSession(session);
         LogInvalidation(session);
@@ -876,21 +857,21 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
         return invalidationStatus;
     };
 
-    auto* irmClient = diceProtocol.GetIRMClient();
+    auto* irmClient = deviceControl.GetIRMClient();
     if (irmClient == nullptr) {
-        ASFW_LOG_ERROR(Audio, "DiceDuplexRestartCoordinator: protocol missing IRM client GUID=%llx",
+        ASFW_LOG_ERROR(Audio, "AudioDuplexCoordinator: device control missing IRM client GUID=%llx",
                        guid);
-        return finalizeFailure(kIOReturnNotReady, DiceRestartPhase::kPreparingDevice,
-                               DiceRestartFailureCause::kPrepare,
-                               DiceRestartErrorClass::kMissingDependency, false, kIOReturnSuccess,
+        return finalizeFailure(kIOReturnNotReady, DuplexRestartPhase::kPreparingDevice,
+                               DuplexRestartFailureCause::kPrepare,
+                               DuplexRestartErrorClass::kMissingDependency, false, kIOReturnSuccess,
                                false, false);
     }
 
     auto* bindingSource = GetDirectAudioBindingSource(guid);
     if (!bindingSource) {
-        return finalizeFailure(kIOReturnNotReady, DiceRestartPhase::kPreparingDevice,
-                               DiceRestartFailureCause::kPrepare,
-                               DiceRestartErrorClass::kMissingDependency, false, kIOReturnSuccess,
+        return finalizeFailure(kIOReturnNotReady, DuplexRestartPhase::kPreparingDevice,
+                               DuplexRestartFailureCause::kPrepare,
+                               DuplexRestartErrorClass::kMissingDependency, false, kIOReturnSuccess,
                                false, true);
     }
 
@@ -902,12 +883,12 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
     session.reason = reason;
     session.desiredClock = desiredClock;
     session.terminalError = kIOReturnSuccess;
-    ApplyTerminalPhase(session, DiceRestartPhase::kIdle, "reset_before_start");
+    ApplyTerminalPhase(session, DuplexRestartPhase::kIdle, "reset_before_start");
     SetSessionState(session, RestartStateForStartReason(reason), ToString(reason));
-    SetSessionPhase(session, DiceRestartPhase::kPreparingDevice);
+    SetSessionPhase(session, DuplexRestartPhase::kPreparingDevice);
     StoreSession(session);
     LogFsmEvent("start", guid, restartId, topologyGeneration, session.state, session.phase, reason);
-    ASFW_LOG(Audio, "DiceDuplexRestartCoordinator: using DICE iso channels d2h=%u h2d=%u GUID=%llx",
+    ASFW_LOG(Audio, "AudioDuplexCoordinator: using isoch channels d2h=%u h2d=%u GUID=%llx",
              channels.deviceToHostIsoChannel, channels.hostToDeviceIsoChannel, guid);
 
     if (abortIfTeardown("BeginSplitDuplex")) {
@@ -916,8 +897,8 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
     const kern_return_t claimStatus = hostTransport_.BeginSplitDuplex(guid);
     if (claimStatus != kIOReturnSuccess) {
         return finalizeFailure(
-            claimStatus, DiceRestartPhase::kPreparingDevice, DiceRestartFailureCause::kPrepare,
-            DiceRestartErrorClass::kStageFailure, false, kIOReturnSuccess, true, true);
+            claimStatus, DuplexRestartPhase::kPreparingDevice, DuplexRestartFailureCause::kPrepare,
+            DuplexRestartErrorClass::kStageFailure, false, kIOReturnSuccess, true, true);
     }
     session.hostDuplexClaimed = true;
     StoreSession(session);
@@ -925,21 +906,21 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
     if (abortIfTeardown("PreparingDevice")) {
         return kIOReturnAborted;
     }
-    const auto prepare = WaitForAsyncResult<DiceDuplexPrepareResult>(
+    const auto prepare = WaitForAsyncResult<DuplexPrepareResult>(
         [&](auto callback) {
-            diceProtocol.PrepareDuplex(channels, desiredClock, std::move(callback));
+            deviceControl.PrepareDuplex(channels, desiredClock, std::move(callback));
         },
         kSyncBridgeTimeoutMs, kIOReturnTimeout, cancel_);
     if (prepare.status != kIOReturnSuccess) {
         if (prepare.status == kIOReturnAborted && TeardownRequested()) {
             RecordTeardownAbort("PreparingDevice", guid);
         }
-        return rollbackToFailure(prepare.status, DiceRestartPhase::kPreparingDevice,
-                                 DiceRestartFailureCause::kPrepare);
+        return rollbackToFailure(prepare.status, DuplexRestartPhase::kPreparingDevice,
+                                 DuplexRestartFailureCause::kPrepare);
     }
     if (!IsRestartEpochCurrent(guid, restartId, topologyGeneration)) {
-        return rollbackToInvalidation(kIOReturnAborted, DiceRestartPhase::kPreparingDevice,
-                                      DiceRestartFailureCause::kPrepare);
+        return rollbackToInvalidation(kIOReturnAborted, DuplexRestartPhase::kPreparingDevice,
+                                      DuplexRestartFailureCause::kPrepare);
     }
     session.ownerClaimed = true;
     session.devicePrepared = true;
@@ -948,12 +929,12 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
     session.runtimeCaps = prepare.value.runtimeCaps;
     const DuplexStreamProfile streamProfile =
         DuplexStreamProfileResolver::Resolve(record, session.runtimeCaps, channels);
-    SetSessionPhase(session, DiceRestartPhase::kPrepared);
+    SetSessionPhase(session, DuplexRestartPhase::kPrepared);
     StoreSession(session);
 
     // Reserve IRM bandwidth + channel for EVERY playback (host IT -> device RX)
-    // stream. A multi-stream DICE device (Venice F32) needs all of its RX iso
-    // channels reserved before GLOBAL_ENABLE; single-stream devices loop once.
+    // stream. A multi-stream device needs all of its playback isoch channels reserved before
+    // the device-enable stage; single-stream devices loop once.
     if (abortIfTeardown("ReservingPlaybackResources")) {
         return kIOReturnAborted;
     }
@@ -962,16 +943,16 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
             guid, *irmClient, channels.PlaybackChannel(i), streamProfile.playbackBandwidthUnits);
         if (reservePlaybackStatus != kIOReturnSuccess) {
             return rollbackToFailure(reservePlaybackStatus,
-                                     DiceRestartPhase::kReservingPlaybackResources,
-                                     DiceRestartFailureCause::kReservePlayback);
+                                     DuplexRestartPhase::kReservingPlaybackResources,
+                                     DuplexRestartFailureCause::kReservePlayback);
         }
         if (!IsRestartEpochCurrent(guid, restartId, topologyGeneration)) {
             return rollbackToInvalidation(kIOReturnAborted,
-                                          DiceRestartPhase::kReservingPlaybackResources,
-                                          DiceRestartFailureCause::kReservePlayback);
+                                          DuplexRestartPhase::kReservingPlaybackResources,
+                                          DuplexRestartFailureCause::kReservePlayback);
         }
     }
-    SetSessionPhase(session, DiceRestartPhase::kReservingPlaybackResources);
+    SetSessionPhase(session, DuplexRestartPhase::kReservingPlaybackResources);
     session.hostPlaybackReserved = true;
     StoreSession(session);
 
@@ -984,21 +965,21 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
             guid, *irmClient, channels.CaptureChannel(i), streamProfile.captureBandwidthUnits);
         if (reserveCaptureStatus != kIOReturnSuccess) {
             return rollbackToFailure(reserveCaptureStatus,
-                                     DiceRestartPhase::kReservingCaptureResources,
-                                     DiceRestartFailureCause::kReserveCapture);
+                                     DuplexRestartPhase::kReservingCaptureResources,
+                                     DuplexRestartFailureCause::kReserveCapture);
         }
         if (!IsRestartEpochCurrent(guid, restartId, topologyGeneration)) {
             return rollbackToInvalidation(kIOReturnAborted,
-                                          DiceRestartPhase::kReservingCaptureResources,
-                                          DiceRestartFailureCause::kReserveCapture);
+                                          DuplexRestartPhase::kReservingCaptureResources,
+                                          DuplexRestartFailureCause::kReserveCapture);
         }
     }
-    SetSessionPhase(session, DiceRestartPhase::kReservingCaptureResources);
+    SetSessionPhase(session, DuplexRestartPhase::kReservingCaptureResources);
     session.hostCaptureReserved = true;
     StoreSession(session);
 
     ASFW_LOG(Audio,
-             "DICE DUPLEX START guid=0x%016llx ir=%u it=%u inCh=%u outCh=%u inSlots=%u outSlots=%u "
+             "AUDIO DUPLEX START guid=0x%016llx ir=%u it=%u inCh=%u outCh=%u inSlots=%u outSlots=%u "
              "mode=blocking rxFmt=%u txFmt=%u",
              guid, channels.deviceToHostIsoChannel, channels.hostToDeviceIsoChannel,
              session.runtimeCaps.hostInputPcmChannels, session.runtimeCaps.hostOutputPcmChannels,
@@ -1007,8 +988,8 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
              static_cast<uint32_t>(streamProfile.playbackWireFormat));
 
     // Saffire.kext allocates every local/remote isoch port before it reports
-    // the assigned channels to DICE. Keep the expensive DMA setup on the
-    // disabled side of GLOBAL_ENABLE as well.
+    // the assigned channels to the device adapter. Keep the expensive DMA setup before the
+    // device-enable stage as well.
     // Multi-stream capture (e.g. Venice F32 = 2×16) is described by the
     // profile's per-stream AM824/PCM geometry. The master owns clock/ZTS/replay;
     // secondaries write their PCM slice only. A single stream retains the legacy
@@ -1026,13 +1007,13 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
                                               masterCapture.am824Slots, masterCapture.pcmChannels);
             if (prepareReceiveStatus != kIOReturnSuccess) {
                 return rollbackToFailure(prepareReceiveStatus,
-                                         DiceRestartPhase::kStartingHostReceive,
-                                         DiceRestartFailureCause::kStartReceive);
+                                         DuplexRestartPhase::kStartingHostReceive,
+                                         DuplexRestartFailureCause::kStartReceive);
             }
             if (!IsRestartEpochCurrent(guid, restartId, topologyGeneration)) {
                 return rollbackToInvalidation(kIOReturnAborted,
-                                              DiceRestartPhase::kStartingHostReceive,
-                                              DiceRestartFailureCause::kStartReceive);
+                                              DuplexRestartPhase::kStartingHostReceive,
+                                              DuplexRestartFailureCause::kStartReceive);
             }
 
             // Prepare each secondary capture stream on its own OHCI IR context, writing
@@ -1047,13 +1028,13 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
                     captureStream.pcmChannelOffset, captureStream.pcmChannels,
                     streamProfile.captureWireFormat, captureStream.am824Slots);
                 if (status != kIOReturnSuccess) {
-                    return rollbackToFailure(status, DiceRestartPhase::kStartingHostReceive,
-                                             DiceRestartFailureCause::kStartReceive);
+                    return rollbackToFailure(status, DuplexRestartPhase::kStartingHostReceive,
+                                             DuplexRestartFailureCause::kStartReceive);
                 }
                 if (!IsRestartEpochCurrent(guid, restartId, topologyGeneration)) {
                     return rollbackToInvalidation(kIOReturnAborted,
-                                                  DiceRestartPhase::kStartingHostReceive,
-                                                  DiceRestartFailureCause::kStartReceive);
+                                                  DuplexRestartPhase::kStartingHostReceive,
+                                                  DuplexRestartFailureCause::kStartReceive);
                 }
             }
 
@@ -1066,12 +1047,12 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
         const kern_return_t prepareTransmitStatus = hostTransport_.PrepareTransmit(
             channels.hostToDeviceIsoChannel, hardware_, ReadLocalSid(hardware_));
         if (prepareTransmitStatus != kIOReturnSuccess) {
-            return rollbackToFailure(prepareTransmitStatus, DiceRestartPhase::kStartingHostTransmit,
-                                     DiceRestartFailureCause::kStartTransmit);
+            return rollbackToFailure(prepareTransmitStatus, DuplexRestartPhase::kStartingHostTransmit,
+                                     DuplexRestartFailureCause::kStartTransmit);
         }
         if (!IsRestartEpochCurrent(guid, restartId, topologyGeneration)) {
-            return rollbackToInvalidation(kIOReturnAborted, DiceRestartPhase::kStartingHostTransmit,
-                                          DiceRestartFailureCause::kStartTransmit);
+            return rollbackToInvalidation(kIOReturnAborted, DuplexRestartPhase::kStartingHostTransmit,
+                                          DuplexRestartFailureCause::kStartTransmit);
         }
 
         // Prepare each secondary playback stream on its own host IT context. It
@@ -1086,96 +1067,94 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
             const kern_return_t status = hostTransport_.PrepareTransmitStream(
                 i, channels.PlaybackChannel(i), hardware_, ReadLocalSid(hardware_));
             if (status != kIOReturnSuccess) {
-                return rollbackToFailure(status, DiceRestartPhase::kStartingHostTransmit,
-                                         DiceRestartFailureCause::kStartTransmit);
+                return rollbackToFailure(status, DuplexRestartPhase::kStartingHostTransmit,
+                                         DuplexRestartFailureCause::kStartTransmit);
             }
             if (!IsRestartEpochCurrent(guid, restartId, topologyGeneration)) {
                 return rollbackToInvalidation(kIOReturnAborted,
-                                              DiceRestartPhase::kStartingHostTransmit,
-                                              DiceRestartFailureCause::kStartTransmit);
+                                              DuplexRestartPhase::kStartingHostTransmit,
+                                              DuplexRestartFailureCause::kStartTransmit);
             }
         }
     }
 
-    SetSessionPhase(session, DiceRestartPhase::kWaitingGlobalClock);
+    SetSessionPhase(session, DuplexRestartPhase::kWaitingGlobalClock);
     StoreSession(session);
     if (abortIfTeardown("WaitingGlobalClock")) {
         return kIOReturnAborted;
     }
     const IOReturn clockLockStatus =
-        WaitForStableGlobalClock(guid, diceProtocol, topologyGeneration, desiredClock);
+        WaitForStableGlobalClock(guid, deviceControl, topologyGeneration, desiredClock);
     if (clockLockStatus != kIOReturnSuccess) {
-        return rollbackToFailure(clockLockStatus, DiceRestartPhase::kWaitingGlobalClock,
-                                 DiceRestartFailureCause::kGlobalClockLock);
+        return rollbackToFailure(clockLockStatus, DuplexRestartPhase::kWaitingGlobalClock,
+                                 DuplexRestartFailureCause::kGlobalClockLock);
     }
     if (!IsRestartEpochCurrent(guid, restartId, topologyGeneration)) {
-        return rollbackToInvalidation(kIOReturnAborted, DiceRestartPhase::kWaitingGlobalClock,
-                                      DiceRestartFailureCause::kGlobalClockLock);
+        return rollbackToInvalidation(kIOReturnAborted, DuplexRestartPhase::kWaitingGlobalClock,
+                                      DuplexRestartFailureCause::kGlobalClockLock);
     }
 
     if (abortIfTeardown("ProgrammingDeviceRx")) {
         return kIOReturnAborted;
     }
-    const auto programRx = WaitForAsyncResult<DiceDuplexStageResult>(
-        [&](auto callback) { diceProtocol.ProgramRx(std::move(callback)); }, kSyncBridgeTimeoutMs,
+    const auto programRx = WaitForAsyncResult<DuplexStageResult>(
+        [&](auto callback) { deviceControl.ProgramRx(std::move(callback)); }, kSyncBridgeTimeoutMs,
         kIOReturnTimeout, cancel_);
     if (programRx.status != kIOReturnSuccess) {
         if (programRx.status == kIOReturnAborted && TeardownRequested()) {
             RecordTeardownAbort("ProgrammingDeviceRx", guid);
         }
-        return rollbackToFailure(programRx.status, DiceRestartPhase::kProgrammingDeviceRx,
-                                 DiceRestartFailureCause::kProgramRx);
+        return rollbackToFailure(programRx.status, DuplexRestartPhase::kProgrammingDeviceRx,
+                                 DuplexRestartFailureCause::kProgramRx);
     }
     if (!IsRestartEpochCurrent(guid, restartId, topologyGeneration)) {
-        return rollbackToInvalidation(kIOReturnAborted, DiceRestartPhase::kProgrammingDeviceRx,
-                                      DiceRestartFailureCause::kProgramRx);
+        return rollbackToInvalidation(kIOReturnAborted, DuplexRestartPhase::kProgrammingDeviceRx,
+                                      DuplexRestartFailureCause::kProgramRx);
     }
     session.generation = programRx.value.generation;
-    SetSessionPhase(session, DiceRestartPhase::kProgrammingDeviceRx);
+    SetSessionPhase(session, DuplexRestartPhase::kProgrammingDeviceRx);
     session.deviceRxProgrammed = true;
     session.runtimeCaps = programRx.value.runtimeCaps.hostInputPcmChannels != 0
                               ? programRx.value.runtimeCaps
                               : session.runtimeCaps;
-    SetSessionPhase(session, DiceRestartPhase::kDeviceRxProgrammed);
+    SetSessionPhase(session, DuplexRestartPhase::kDeviceRxProgrammed);
     StoreSession(session);
 
     if (abortIfTeardown("ProgrammingDeviceTx")) {
         return kIOReturnAborted;
     }
-    const auto programTx = WaitForAsyncResult<DiceDuplexStageResult>(
-        [&](auto callback) { diceProtocol.ProgramTxAndEnableDuplex(std::move(callback)); },
+    const auto programTx = WaitForAsyncResult<DuplexStageResult>(
+        [&](auto callback) { deviceControl.ProgramTxAndEnableDuplex(std::move(callback)); },
         kSyncBridgeTimeoutMs, kIOReturnTimeout, cancel_);
     if (programTx.status != kIOReturnSuccess) {
         if (programTx.status == kIOReturnAborted && TeardownRequested()) {
             RecordTeardownAbort("ProgrammingDeviceTx", guid);
         }
-        return rollbackToFailure(programTx.status, DiceRestartPhase::kProgrammingDeviceTx,
-                                 DiceRestartFailureCause::kProgramTx);
+        return rollbackToFailure(programTx.status, DuplexRestartPhase::kProgrammingDeviceTx,
+                                 DuplexRestartFailureCause::kProgramTx);
     }
     if (!IsRestartEpochCurrent(guid, restartId, topologyGeneration)) {
-        return rollbackToInvalidation(kIOReturnAborted, DiceRestartPhase::kProgrammingDeviceTx,
-                                      DiceRestartFailureCause::kProgramTx);
+        return rollbackToInvalidation(kIOReturnAborted, DuplexRestartPhase::kProgrammingDeviceTx,
+                                      DuplexRestartFailureCause::kProgramTx);
     }
     session.generation = programTx.value.generation;
-    SetSessionPhase(session, DiceRestartPhase::kProgrammingDeviceTx);
+    SetSessionPhase(session, DuplexRestartPhase::kProgrammingDeviceTx);
     session.deviceTxArmed = true;
     session.runtimeCaps = programTx.value.runtimeCaps.hostInputPcmChannels != 0
                               ? programTx.value.runtimeCaps
                               : session.runtimeCaps;
-    SetSessionPhase(session, DiceRestartPhase::kDeviceTxArmed);
+    SetSessionPhase(session, DuplexRestartPhase::kDeviceTxArmed);
     StoreSession(session);
 
-    // The DICE recipe waits after GLOBAL_ENABLE before starting
-    // the already-allocated host isoch channels.
+    // The device-control contract completes its enable stage before the already-allocated host
+    // isoch channels start.
     IOSleep(streamProfile.startOrder.postDeviceEnableDelayMs);
     if (abortIfTeardown("PostGlobalEnableDelay")) {
         return kIOReturnAborted;
     }
 
-    // The profile's DICE recipe starts RX first: the device needs to be
-    // receiving before it can lock its TX clock. Starting IT before IR causes
-    // the DICE PLL to see TX without a valid RX reference, leading to timing
-    // instability.
+    // A profile may start host receive first so the device is already transmitting before host
+    // transmit begins, avoiding a window without the expected clock reference.
     for (const DuplexHostDirection direction : streamProfile.startOrder.startOrder) {
         if (direction == DuplexHostDirection::kReceive) {
             if (abortIfTeardown("StartingHostReceive")) {
@@ -1183,15 +1162,15 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
             }
             const kern_return_t startReceiveStatus = hostTransport_.StartPreparedReceive();
             if (startReceiveStatus != kIOReturnSuccess) {
-                return rollbackToFailure(startReceiveStatus, DiceRestartPhase::kStartingHostReceive,
-                                         DiceRestartFailureCause::kStartReceive);
+                return rollbackToFailure(startReceiveStatus, DuplexRestartPhase::kStartingHostReceive,
+                                         DuplexRestartFailureCause::kStartReceive);
             }
             if (!IsRestartEpochCurrent(guid, restartId, topologyGeneration)) {
                 return rollbackToInvalidation(kIOReturnAborted,
-                                              DiceRestartPhase::kStartingHostReceive,
-                                              DiceRestartFailureCause::kStartReceive);
+                                              DuplexRestartPhase::kStartingHostReceive,
+                                              DuplexRestartFailureCause::kStartReceive);
             }
-            SetSessionPhase(session, DiceRestartPhase::kStartingHostReceive);
+            SetSessionPhase(session, DuplexRestartPhase::kStartingHostReceive);
             session.hostReceiveStarted = true;
             StoreSession(session);
 
@@ -1203,14 +1182,14 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
         }
         const kern_return_t startTransmitStatus = hostTransport_.StartPreparedTransmit();
         if (startTransmitStatus != kIOReturnSuccess) {
-            return rollbackToFailure(startTransmitStatus, DiceRestartPhase::kStartingHostTransmit,
-                                     DiceRestartFailureCause::kStartTransmit);
+            return rollbackToFailure(startTransmitStatus, DuplexRestartPhase::kStartingHostTransmit,
+                                     DuplexRestartFailureCause::kStartTransmit);
         }
         if (!IsRestartEpochCurrent(guid, restartId, topologyGeneration)) {
-            return rollbackToInvalidation(kIOReturnAborted, DiceRestartPhase::kStartingHostTransmit,
-                                          DiceRestartFailureCause::kStartTransmit);
+            return rollbackToInvalidation(kIOReturnAborted, DuplexRestartPhase::kStartingHostTransmit,
+                                          DuplexRestartFailureCause::kStartTransmit);
         }
-        SetSessionPhase(session, DiceRestartPhase::kStartingHostTransmit);
+        SetSessionPhase(session, DuplexRestartPhase::kStartingHostTransmit);
         session.hostTransmitStarted = true;
         StoreSession(session);
     }
@@ -1218,24 +1197,24 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
     if (abortIfTeardown("ConfirmingDeviceStart")) {
     return kIOReturnAborted;
 }
-const auto confirm = WaitForAsyncResult<DiceDuplexConfirmResult>(
-    [&](auto callback) { diceProtocol.ConfirmDuplexStart(std::move(callback)); },
+const auto confirm = WaitForAsyncResult<DuplexConfirmResult>(
+    [&](auto callback) { deviceControl.ConfirmDuplexStart(std::move(callback)); },
     kSyncBridgeTimeoutMs, kIOReturnTimeout, cancel_);
 if (confirm.status != kIOReturnSuccess) {
     if (confirm.status == kIOReturnAborted && TeardownRequested()) {
         RecordTeardownAbort("ConfirmingDeviceStart", guid);
     }
-    return rollbackToFailure(confirm.status, DiceRestartPhase::kConfirmingDeviceStart,
-                             DiceRestartFailureCause::kConfirmStart);
+    return rollbackToFailure(confirm.status, DuplexRestartPhase::kConfirmingDeviceStart,
+                             DuplexRestartFailureCause::kConfirmStart);
 }
 if (!IsRestartEpochCurrent(guid, restartId, topologyGeneration)) {
-    return rollbackToInvalidation(kIOReturnAborted, DiceRestartPhase::kConfirmingDeviceStart,
-                                  DiceRestartFailureCause::kConfirmStart);
+    return rollbackToInvalidation(kIOReturnAborted, DuplexRestartPhase::kConfirmingDeviceStart,
+                                  DuplexRestartFailureCause::kConfirmStart);
 }
 
-SetSessionPhase(session, DiceRestartPhase::kConfirmingDeviceStart);
-SetSessionPhase(session, DiceRestartPhase::kRunning);
-SetSessionState(session, DiceRestartState::kRunning, "confirmed_running");
+SetSessionPhase(session, DuplexRestartPhase::kConfirmingDeviceStart);
+SetSessionPhase(session, DuplexRestartPhase::kRunning);
+SetSessionState(session, DuplexRestartState::kRunning, "confirmed_running");
 session.generation = confirm.value.generation;
 session.deviceRunning = true;
 session.appliedClock = confirm.value.appliedClock;
@@ -1248,8 +1227,8 @@ return kIOReturnSuccess;
 }
 
 IOReturn DuplexStartTransaction::WaitForStableGlobalClock(
-    uint64_t guid, DICE::IDICEDuplexProtocol& diceProtocol, const FW::Generation topologyGeneration,
-    const DiceDesiredClockConfig& desiredClock) noexcept {
+    uint64_t guid, IDuplexDeviceControl& deviceControl, const FW::Generation topologyGeneration,
+    const AudioClockConfig& desiredClock) noexcept {
     const std::atomic<bool>* const cancel_ = dependencies_.cancel;
     const uint32_t kGlobalClockLockTimeoutMs = dependencies_.globalClockLockTimeoutMs;
     const uint32_t kGlobalClockLockPollMs = dependencies_.globalClockLockPollMs;
@@ -1271,36 +1250,35 @@ IOReturn DuplexStartTransaction::WaitForStableGlobalClock(
 
         const uint64_t nowMs = UptimeMilliseconds();
         const uint32_t remainingMs = static_cast<uint32_t>(deadlineMs - nowMs);
-        const auto health = WaitForAsyncResult<DiceDuplexHealthResult>(
-            [&](auto callback) { diceProtocol.ReadDuplexHealth(std::move(callback)); },
+        const auto health = WaitForAsyncResult<DuplexHealthResult>(
+            [&](auto callback) { deviceControl.ReadDuplexHealth(std::move(callback)); },
             std::max(remainingMs, 1U), kIOReturnTimeout, cancel_);
         if (health.status != kIOReturnSuccess) {
             if (health.status == kIOReturnAborted && TeardownRequested()) {
                 RecordTeardownAbort("WaitingGlobalClock", guid);
                 return health.status;
             }
-            ASFW_LOG_ERROR(Audio, "DICE global clock health read failed before isoch start kr=0x%x",
+            ASFW_LOG_ERROR(Audio, "Device clock health read failed before isoch start kr=0x%x",
                            health.status);
             return health.status;
         }
         if (health.value.generation != topologyGeneration) {
             ASFW_LOG_ERROR(
                 Audio,
-                "DICE global clock generation changed before isoch start expected=%u actual=%u",
+                "Device clock generation changed before isoch start expected=%u actual=%u",
                 GenerationValue(topologyGeneration), GenerationValue(health.value.generation));
             return kIOReturnOffline;
         }
 
         const bool lockedAtTarget =
-            DICE::IsSourceLocked(health.value.status) &&
-            DICE::NominalRateHz(health.value.status) == desiredClock.sampleRateHz &&
-            health.value.appliedClock.sampleRateHz == desiredClock.sampleRateHz &&
-            health.value.appliedClock.clockSelect == desiredClock.clockSelect;
+            health.value.sourceLocked &&
+            health.value.nominalRateHz == desiredClock.sampleRateHz &&
+            health.value.appliedClock.sampleRateHz == desiredClock.sampleRateHz;
         consecutiveLockedReads = lockedAtTarget ? consecutiveLockedReads + 1 : 0;
 
         if (consecutiveLockedReads >= kGlobalClockStableReads) {
             ASFW_LOG(Audio,
-                     "DICE global clock stable before isoch start rate=%u status=0x%08x reads=%u",
+                     "Device clock stable before isoch start rate=%u status=0x%08x reads=%u",
                      desiredClock.sampleRateHz, health.value.status, consecutiveLockedReads);
             return kIOReturnSuccess;
         }
@@ -1317,7 +1295,7 @@ IOReturn DuplexStartTransaction::WaitForStableGlobalClock(
     }
 
     ASFW_LOG_ERROR(Audio,
-                   "DICE global clock failed to stabilize before isoch start rate=%u timeoutMs=%u",
+                   "Device clock failed to stabilize before isoch start rate=%u timeoutMs=%u",
                    desiredClock.sampleRateHz, kGlobalClockLockTimeoutMs);
     return kIOReturnTimeout;
 }
@@ -1325,14 +1303,14 @@ IOReturn DuplexStartTransaction::WaitForStableGlobalClock(
 IOReturn DuplexStartTransaction::Stop(const StopRequest& request) noexcept {
     const uint64_t guid = request.guid;
     Discovery::DeviceRecord& record = request.record;
-    DICE::IDICEDuplexProtocol& diceProtocol = request.deviceControl;
-    DiceRestartSession& session = request.session;
+    IDuplexDeviceControl& deviceControl = request.deviceControl;
+    DuplexRestartSession& session = request.session;
     auto& hostTransport_ = dependencies_.hostTransport;
     auto TeardownRequested = [this]() noexcept { return this->TeardownRequested(); };
     auto RecordTeardownAbort = [this](const char* stage, uint64_t abortGuid) noexcept {
         this->RecordTeardownAbort(stage, abortGuid);
     };
-    auto StoreSession = [this](const DiceRestartSession& updatedSession) noexcept {
+    auto StoreSession = [this](const DuplexRestartSession& updatedSession) noexcept {
         dependencies_.sessionStore.StoreSession(updatedSession);
     };
 
@@ -1344,8 +1322,8 @@ IOReturn DuplexStartTransaction::Stop(const StopRequest& request) noexcept {
     }
 
     IOReturn result = kIOReturnSuccess;
-    SetSessionPhase(session, DiceRestartPhase::kStopping);
-    SetSessionState(session, DiceRestartState::kStopping, "stop_requested");
+    SetSessionPhase(session, DuplexRestartPhase::kStopping);
+    SetSessionState(session, DuplexRestartState::kStopping, "stop_requested");
     StoreSession(session);
 
     const kern_return_t hostStatus = hostTransport_.StopAll();
@@ -1353,7 +1331,7 @@ IOReturn DuplexStartTransaction::Stop(const StopRequest& request) noexcept {
         result = hostStatus;
     }
 
-    const IOReturn deviceStatus = diceProtocol.StopDuplex();
+    const IOReturn deviceStatus = deviceControl.StopDuplex();
     if (deviceStatus == kIOReturnAborted && TeardownRequested()) {
         RecordTeardownAbort("DeviceStop", guid);
         return kIOReturnAborted;
@@ -1366,13 +1344,13 @@ IOReturn DuplexStartTransaction::Stop(const StopRequest& request) noexcept {
     if (result == kIOReturnSuccess) {
         session.terminalError = kIOReturnSuccess;
         ClearFailureSnapshot(session);
-        ApplyTerminalPhase(session, DiceRestartPhase::kIdle, "stop_complete");
+        ApplyTerminalPhase(session, DuplexRestartPhase::kIdle, "stop_complete");
     } else {
         session.terminalError = result;
-        RecordIssue(session, session.lastFailure, DiceRestartPhase::kStopping,
-                    DiceRestartErrorClass::kStageFailure, DiceRestartFailureCause::kStop, result,
+        RecordIssue(session, session.lastFailure, DuplexRestartPhase::kStopping,
+                    DuplexRestartErrorClass::kStageFailure, DuplexRestartFailureCause::kStop, result,
                     IsRetryableStatus(result), false, kIOReturnSuccess, true, true);
-        ApplyTerminalPhase(session, DiceRestartPhase::kFailed, "stop_failed");
+        ApplyTerminalPhase(session, DuplexRestartPhase::kFailed, "stop_failed");
     }
     StoreSession(session);
     LogTerminal(session);
@@ -1381,11 +1359,11 @@ IOReturn DuplexStartTransaction::Stop(const StopRequest& request) noexcept {
 
 IOReturn DuplexStartTransaction::ApplyIdleClock(const IdleClockApplyRequest& request) noexcept {
     const uint64_t guid = request.guid;
-    DICE::IDICEDuplexProtocol& diceProtocol = request.deviceControl;
-    DiceRestartSession& session = request.session;
+    IDuplexDeviceControl& deviceControl = request.deviceControl;
+    DuplexRestartSession& session = request.session;
     const FW::Generation topologyGeneration = request.topologyGeneration;
-    const DiceDesiredClockConfig& desiredClock = request.desiredClock;
-    const DiceRestartReason reason = request.reason;
+    const AudioClockConfig& desiredClock = request.desiredClock;
+    const DuplexRestartReason reason = request.reason;
     const std::atomic<bool>* const cancel_ = dependencies_.cancel;
     const uint32_t kSyncBridgeTimeoutMs = dependencies_.syncBridgeTimeoutMs;
     auto TeardownRequested = [this]() noexcept { return this->TeardownRequested(); };
@@ -1393,7 +1371,7 @@ IOReturn DuplexStartTransaction::ApplyIdleClock(const IdleClockApplyRequest& req
         this->RecordTeardownAbort(stage, abortGuid);
     };
     auto AllocateRestartId = [this]() noexcept { return dependencies_.sessionStore.AllocateRestartId(); };
-    auto StoreSession = [this](const DiceRestartSession& updatedSession) noexcept {
+    auto StoreSession = [this](const DuplexRestartSession& updatedSession) noexcept {
         dependencies_.sessionStore.StoreSession(updatedSession);
     };
     auto IsStopRequested = [this](uint64_t requestGuid) noexcept {
@@ -1417,37 +1395,37 @@ IOReturn DuplexStartTransaction::ApplyIdleClock(const IdleClockApplyRequest& req
     session.reason = reason;
     session.desiredClock = desiredClock;
     session.terminalError = kIOReturnSuccess;
-    ApplyTerminalPhase(session, DiceRestartPhase::kIdle, "reset_before_idle_apply");
-    SetSessionState(session, DiceRestartState::kApplyingIdleClock, ToString(reason));
-    SetSessionPhase(session, DiceRestartPhase::kPreparingDevice);
+    ApplyTerminalPhase(session, DuplexRestartPhase::kIdle, "reset_before_idle_apply");
+    SetSessionState(session, DuplexRestartState::kApplyingIdleClock, ToString(reason));
+    SetSessionPhase(session, DuplexRestartPhase::kPreparingDevice);
     StoreSession(session);
 
-    const auto apply = WaitForAsyncResult<DICE::DiceClockApplyResult>(
-        [&](auto callback) { diceProtocol.ApplyClockConfig(desiredClock, std::move(callback)); },
+    const auto apply = WaitForAsyncResult<ClockApplyResult>(
+        [&](auto callback) { deviceControl.ApplyClockConfig(desiredClock, std::move(callback)); },
         kSyncBridgeTimeoutMs, kIOReturnTimeout, cancel_);
     if (apply.status != kIOReturnSuccess) {
         if (apply.status == kIOReturnAborted && TeardownRequested()) {
             RecordTeardownAbort("IdleClockApply", guid);
         }
         session.terminalError = apply.status;
-        RecordIssue(session, session.lastFailure, DiceRestartPhase::kPreparingDevice,
-                    DiceRestartErrorClass::kStageFailure, DiceRestartFailureCause::kIdleClockApply,
+        RecordIssue(session, session.lastFailure, DuplexRestartPhase::kPreparingDevice,
+                    DuplexRestartErrorClass::kStageFailure, DuplexRestartFailureCause::kIdleClockApply,
                     apply.status, IsRetryableStatus(apply.status), false, kIOReturnSuccess, true,
                     true);
-        ApplyTerminalPhase(session, DiceRestartPhase::kFailed, "idle_apply_failed");
+        ApplyTerminalPhase(session, DuplexRestartPhase::kFailed, "idle_apply_failed");
         StoreSession(session);
         LogTerminal(session);
         return apply.status;
     }
     if (!IsRestartEpochCurrent(guid, restartId, topologyGeneration)) {
         session.terminalError = kIOReturnSuccess;
-        RecordIssue(session, session.lastInvalidation, DiceRestartPhase::kPreparingDevice,
-                    IsStopRequested(guid) ? DiceRestartErrorClass::kStopIntent
-                                          : DiceRestartErrorClass::kEpochInvalidated,
-                    DiceRestartFailureCause::kIdleClockApply, kIOReturnAborted, true, false,
+        RecordIssue(session, session.lastInvalidation, DuplexRestartPhase::kPreparingDevice,
+                    IsStopRequested(guid) ? DuplexRestartErrorClass::kStopIntent
+                                          : DuplexRestartErrorClass::kEpochInvalidated,
+                    DuplexRestartFailureCause::kIdleClockApply, kIOReturnAborted, true, false,
                     kIOReturnSuccess, true, true);
         ClearFailureSnapshot(session);
-        ApplyTerminalPhase(session, DiceRestartPhase::kIdle, "idle_apply_invalidated");
+        ApplyTerminalPhase(session, DuplexRestartPhase::kIdle, "idle_apply_invalidated");
         StoreSession(session);
         LogInvalidation(session);
         LogTerminal(session);
@@ -1459,53 +1437,53 @@ IOReturn DuplexStartTransaction::ApplyIdleClock(const IdleClockApplyRequest& req
     session.runtimeCaps = apply.value.runtimeCaps;
     session.terminalError = kIOReturnSuccess;
     ClearFailureSnapshot(session);
-    ApplyTerminalPhase(session, DiceRestartPhase::kIdle, "idle_apply_complete");
+    ApplyTerminalPhase(session, DuplexRestartPhase::kIdle, "idle_apply_complete");
     StoreSession(session);
     LogTerminal(session);
     return kIOReturnSuccess;
 }
 
-IOReturn DiceDuplexRestartCoordinator::RunDuplexStart(
-    uint64_t guid, Discovery::DeviceRecord& record, DICE::IDICEDuplexProtocol& diceProtocol,
-    DiceRestartSession& session, const DiceDesiredClockConfig& desiredClock,
-    DiceRestartReason reason) noexcept {
+IOReturn AudioDuplexCoordinator::RunDuplexStart(
+    uint64_t guid, Discovery::DeviceRecord& record, IDuplexDeviceControl& deviceControl,
+    DuplexRestartSession& session, const AudioClockConfig& desiredClock,
+    DuplexRestartReason reason) noexcept {
     DuplexStartTransaction transaction{DuplexStartTransaction::Dependencies{
         registry_, runtime_, hostTransport_, hardware_, cancel_, bindingSourceProvider_, gate_, store_,
         teardownAbortCount_, kSyncBridgeTimeoutMs, kGlobalClockLockTimeoutMs,
         kGlobalClockLockPollMs, kGlobalClockStableReads}};
     return transaction.Run(
-        DuplexStartTransaction::StartRequest{guid, record, diceProtocol, session, desiredClock,
+        DuplexStartTransaction::StartRequest{guid, record, deviceControl, session, desiredClock,
                                              reason});
 }
 
-IOReturn DiceDuplexRestartCoordinator::RunDuplexStop(
-    uint64_t guid, Discovery::DeviceRecord& record, DICE::IDICEDuplexProtocol& diceProtocol,
-    DiceRestartSession& session) noexcept {
+IOReturn AudioDuplexCoordinator::RunDuplexStop(
+    uint64_t guid, Discovery::DeviceRecord& record, IDuplexDeviceControl& deviceControl,
+    DuplexRestartSession& session) noexcept {
     DuplexStartTransaction transaction{DuplexStartTransaction::Dependencies{
         registry_, runtime_, hostTransport_, hardware_, cancel_, bindingSourceProvider_, gate_, store_,
         teardownAbortCount_, kSyncBridgeTimeoutMs, kGlobalClockLockTimeoutMs,
         kGlobalClockLockPollMs, kGlobalClockStableReads}};
     return transaction.Stop(
-        DuplexStartTransaction::StopRequest{guid, record, diceProtocol, session});
+        DuplexStartTransaction::StopRequest{guid, record, deviceControl, session});
 }
 
-IOReturn DiceDuplexRestartCoordinator::RunIdleClockApply(
-    uint64_t guid, DICE::IDICEDuplexProtocol& diceProtocol, DiceRestartSession& session,
-    FW::Generation topologyGeneration, const DiceDesiredClockConfig& desiredClock,
-    DiceRestartReason reason) noexcept {
+IOReturn AudioDuplexCoordinator::RunIdleClockApply(
+    uint64_t guid, IDuplexDeviceControl& deviceControl, DuplexRestartSession& session,
+    FW::Generation topologyGeneration, const AudioClockConfig& desiredClock,
+    DuplexRestartReason reason) noexcept {
     DuplexStartTransaction transaction{DuplexStartTransaction::Dependencies{
         registry_, runtime_, hostTransport_, hardware_, cancel_, bindingSourceProvider_, gate_, store_,
         teardownAbortCount_, kSyncBridgeTimeoutMs, kGlobalClockLockTimeoutMs,
         kGlobalClockLockPollMs, kGlobalClockStableReads}};
     return transaction.ApplyIdleClock(
-        DuplexStartTransaction::IdleClockApplyRequest{guid, diceProtocol, session,
+        DuplexStartTransaction::IdleClockApplyRequest{guid, deviceControl, session,
                                                        topologyGeneration, desiredClock, reason});
 }
 
-Discovery::DeviceRecord* DiceDuplexRestartCoordinator::RequireDiceRecord(
-    uint64_t guid, DICE::IDICEDuplexProtocol*& outDiceProtocol,
+Discovery::DeviceRecord* AudioDuplexCoordinator::RequireDuplexRecord(
+    uint64_t guid, IDuplexDeviceControl*& outDeviceControl,
     std::shared_ptr<IDeviceProtocol>& outHold) noexcept {
-    outDiceProtocol = nullptr;
+    outDeviceControl = nullptr;
     outHold.reset();
     auto* record = registry_.FindByGuid(guid);
     if (!record) {
@@ -1517,18 +1495,18 @@ Discovery::DeviceRecord* DiceDuplexRestartCoordinator::RequireDiceRecord(
         return nullptr;
     }
 
-    outDiceProtocol = protocol->AsDiceDuplexProtocol();
-    if (outDiceProtocol == nullptr) {
+    outDeviceControl = protocol->AsDuplexDeviceControl();
+    if (outDeviceControl == nullptr) {
         return nullptr;
     }
-    outDiceProtocol->SetTeardownCancelToken(cancel_);
+    outDeviceControl->SetTeardownCancelToken(cancel_);
 
     outHold = std::move(protocol);
     return record;
 }
 
 ASFW::Audio::Runtime::IDirectAudioBindingSource*
-DiceDuplexRestartCoordinator::GetDirectAudioBindingSource(uint64_t guid) const noexcept {
+AudioDuplexCoordinator::GetDirectAudioBindingSource(uint64_t guid) const noexcept {
     if (!bindingSourceProvider_) {
         return nullptr;
     }
@@ -1538,29 +1516,29 @@ DiceDuplexRestartCoordinator::GetDirectAudioBindingSource(uint64_t guid) const n
 // FW-68: the per-GUID gating state + logic now lives in DuplexOperationGate (gate_). These
 // entry points are thin forwarders to its self-locking API; behaviour is byte-for-byte the
 // former inline bodies (gate_ borrows the same lock_).
-bool DiceDuplexRestartCoordinator::TryAcquireGuid(uint64_t guid) noexcept {
+bool AudioDuplexCoordinator::TryAcquireGuid(uint64_t guid) noexcept {
     return gate_.Acquire(guid);
 }
 
-void DiceDuplexRestartCoordinator::ReleaseGuid(uint64_t guid) noexcept { gate_.Release(guid); }
+void AudioDuplexCoordinator::ReleaseGuid(uint64_t guid) noexcept { gate_.Release(guid); }
 
-void DiceDuplexRestartCoordinator::RequestStopIntent(uint64_t guid) noexcept {
+void AudioDuplexCoordinator::RequestStopIntent(uint64_t guid) noexcept {
     gate_.RequestStop(guid);
 }
 
-void DiceDuplexRestartCoordinator::ClearStopIntent(uint64_t guid) noexcept {
+void AudioDuplexCoordinator::ClearStopIntent(uint64_t guid) noexcept {
     gate_.ClearStop(guid);
 }
 
-bool DiceDuplexRestartCoordinator::IsStopRequested(uint64_t guid) const noexcept {
+bool AudioDuplexCoordinator::IsStopRequested(uint64_t guid) const noexcept {
     return gate_.IsStopRequested(guid);
 }
 
-uint64_t DiceDuplexRestartCoordinator::AllocateRestartId() noexcept {
+uint64_t AudioDuplexCoordinator::AllocateRestartId() noexcept {
     return store_.AllocateRestartId();
 }
 
-bool DiceDuplexRestartCoordinator::IsRestartEpochCurrent(
+bool AudioDuplexCoordinator::IsRestartEpochCurrent(
     uint64_t guid, uint64_t restartId, FW::Generation topologyGeneration) const noexcept {
     if (guid == 0 || restartId == 0) {
         return false;
@@ -1590,33 +1568,33 @@ bool DiceDuplexRestartCoordinator::IsRestartEpochCurrent(
     return true;
 }
 
-bool DiceDuplexRestartCoordinator::TryConsumePendingClockRequest(uint64_t guid,
+bool AudioDuplexCoordinator::TryConsumePendingClockRequest(uint64_t guid,
                                                                  PendingClockRequest& outRequest) noexcept {
     return clockRequests_.TryConsumePending(guid, outRequest);
 }
 
-bool DiceDuplexRestartCoordinator::TryTakeCompletedClockRequest(
+bool AudioDuplexCoordinator::TryTakeCompletedClockRequest(
     uint64_t guid,
     uint64_t token,
-    DiceClockRequestCompletion& outCompletion) noexcept {
+    DuplexClockRequestCompletion& outCompletion) noexcept {
     return clockRequests_.TryTakeCompleted(guid, token, outCompletion);
 }
 
-void DiceDuplexRestartCoordinator::CompleteClockRequest(const DiceClockRequestCompletion& completion,
+void AudioDuplexCoordinator::CompleteClockRequest(const DuplexClockRequestCompletion& completion,
                                                         uint64_t guid) noexcept {
     clockRequests_.Complete(completion, guid);
 }
 
-void DiceDuplexRestartCoordinator::FailPendingClockRequest(uint64_t guid,
-                                                           DiceClockRequestOutcome outcome,
+void AudioDuplexCoordinator::FailPendingClockRequest(uint64_t guid,
+                                                           DuplexClockRequestOutcome outcome,
                                                            IOReturn status) noexcept {
     clockRequests_.FailPending(guid, outcome, status);
 }
 
-void DiceDuplexRestartCoordinator::RecordTeardownAbort(const char* stage, uint64_t guid) noexcept {
+void AudioDuplexCoordinator::RecordTeardownAbort(const char* stage, uint64_t guid) noexcept {
     teardownAbortCount_.fetch_add(1, std::memory_order_acq_rel);
     ASFW_LOG(Audio,
-             "DiceDuplexRestartCoordinator: recovery aborted by teardown stage=%{public}s "
+             "AudioDuplexCoordinator: recovery aborted by teardown stage=%{public}s "
              "GUID=%llx kr=0x%x",
              stage ? stage : "unknown", guid, kIOReturnAborted);
 }
@@ -1624,11 +1602,11 @@ void DiceDuplexRestartCoordinator::RecordTeardownAbort(const char* stage, uint64
 // FW-69b: session persistence + the restart-id allocator now live in RestartSessionStore
 // (store_). These entry points are thin forwarders to its self-locking API; behaviour is
 // byte-for-byte the former inline bodies (store_ borrows the same lock_).
-DiceRestartSession DiceDuplexRestartCoordinator::LoadSession(uint64_t guid) const noexcept {
+DuplexRestartSession AudioDuplexCoordinator::LoadSession(uint64_t guid) const noexcept {
     return store_.LoadSession(guid);
 }
 
-void DiceDuplexRestartCoordinator::StoreSession(const DiceRestartSession& session) noexcept {
+void AudioDuplexCoordinator::StoreSession(const DuplexRestartSession& session) noexcept {
     store_.StoreSession(session);
 }
 

--- a/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.hpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
-// DiceDuplexRestartCoordinator.hpp - Top-level DICE restart FSM owner
+// DiceDuplexRestartCoordinator.hpp - Top-level audio duplex lifecycle owner
 
 #pragma once
 
@@ -9,11 +9,10 @@
 #include "DiceHostTransport.hpp"
 #include "DuplexOperationGate.hpp"
 #include "RestartSessionStore.hpp"
+#include "../Duplex/IDuplexDeviceControl.hpp"
 
 #include "../../../Discovery/DeviceRegistry.hpp"
 #include "../../../Hardware/HardwareInterface.hpp"
-#include "../DICE/Core/IDICEDuplexProtocol.hpp"
-#include "../DICE/Core/DICERestartSession.hpp"
 
 #include <atomic>
 #include <functional>
@@ -29,32 +28,31 @@ class IDirectAudioBindingSource;
 class AudioRuntimeRegistry;
 class IDeviceProtocol;
 
-class DiceDuplexRestartCoordinator final {
+class AudioDuplexCoordinator final {
 public:
     using DirectAudioBindingSourceProvider = std::function<ASFW::Audio::Runtime::IDirectAudioBindingSource*(uint64_t guid)>;
 
-    DiceDuplexRestartCoordinator(Discovery::DeviceRegistry& registry,
-                                 AudioRuntimeRegistry& runtime,
-                                 IDiceHostTransport& hostTransport,
-                                 Driver::HardwareInterface& hardware,
-                                 const std::atomic<bool>* cancel,
-                                 DirectAudioBindingSourceProvider bindingSourceProvider) noexcept;
-    ~DiceDuplexRestartCoordinator() noexcept;
+    AudioDuplexCoordinator(Discovery::DeviceRegistry& registry,
+                           AudioRuntimeRegistry& runtime,
+                           IIsochDuplexHostTransport& hostTransport,
+                           Driver::HardwareInterface& hardware,
+                           const std::atomic<bool>* cancel,
+                           DirectAudioBindingSourceProvider bindingSourceProvider) noexcept;
+    ~AudioDuplexCoordinator() noexcept;
 
-    DiceDuplexRestartCoordinator(const DiceDuplexRestartCoordinator&) = delete;
-    DiceDuplexRestartCoordinator& operator=(const DiceDuplexRestartCoordinator&) = delete;
+    AudioDuplexCoordinator(const AudioDuplexCoordinator&) = delete;
+    AudioDuplexCoordinator& operator=(const AudioDuplexCoordinator&) = delete;
 
     [[nodiscard]] IOReturn StartStreaming(uint64_t guid) noexcept;
     [[nodiscard]] IOReturn StopStreaming(uint64_t guid) noexcept;
     [[nodiscard]] IOReturn RequestClockConfig(
         uint64_t guid,
-        const DICE::DiceDesiredClockConfig& desiredClock,
-        DICE::DiceRestartReason reason) noexcept;
-    [[nodiscard]] IOReturn RecoverStreaming(uint64_t guid,
-                                            DICE::DiceRestartReason reason) noexcept;
+        const AudioClockConfig& desiredClock,
+        DuplexRestartReason reason) noexcept;
+    [[nodiscard]] IOReturn RecoverStreaming(uint64_t guid, DuplexRestartReason reason) noexcept;
 
     void ClearSession(uint64_t guid) noexcept;
-    [[nodiscard]] std::optional<DICE::DiceRestartSession> GetSession(uint64_t guid) const noexcept;
+    [[nodiscard]] std::optional<DuplexRestartSession> GetSession(uint64_t guid) const noexcept;
 
     [[nodiscard]] uint64_t TeardownAbortCount() const noexcept {
         return teardownAbortCount_.load(std::memory_order_acquire);
@@ -66,32 +64,32 @@ private:
     [[nodiscard]] IOReturn RunStartStreaming(uint64_t guid) noexcept;
     [[nodiscard]] IOReturn RunStopStreaming(uint64_t guid) noexcept;
     [[nodiscard]] IOReturn RunRecoveryStreaming(uint64_t guid,
-                                                DICE::DiceRestartReason reason) noexcept;
+                                                DuplexRestartReason reason) noexcept;
     [[nodiscard]] IOReturn RunClockRequestLoop(uint64_t guid, PendingClockRequest initialRequest) noexcept;
     [[nodiscard]] IOReturn ApplyClockRequest(uint64_t guid, const PendingClockRequest& request) noexcept;
 
     [[nodiscard]] IOReturn RunDuplexStart(uint64_t guid,
                                           Discovery::DeviceRecord& record,
-                                          DICE::IDICEDuplexProtocol& diceProtocol,
-                                          DICE::DiceRestartSession& session,
-                                          const DICE::DiceDesiredClockConfig& desiredClock,
-                                          DICE::DiceRestartReason reason) noexcept;
+                                          IDuplexDeviceControl& deviceControl,
+                                          DuplexRestartSession& session,
+                                          const AudioClockConfig& desiredClock,
+                                          DuplexRestartReason reason) noexcept;
     [[nodiscard]] IOReturn RunDuplexStop(uint64_t guid,
                                          Discovery::DeviceRecord& record,
-                                         DICE::IDICEDuplexProtocol& diceProtocol,
-                                         DICE::DiceRestartSession& session) noexcept;
+                                         IDuplexDeviceControl& deviceControl,
+                                         DuplexRestartSession& session) noexcept;
     [[nodiscard]] IOReturn RunIdleClockApply(uint64_t guid,
-                                             DICE::IDICEDuplexProtocol& diceProtocol,
-                                             DICE::DiceRestartSession& session,
+                                             IDuplexDeviceControl& deviceControl,
+                                             DuplexRestartSession& session,
                                              FW::Generation topologyGeneration,
-                                             const DICE::DiceDesiredClockConfig& desiredClock,
-                                             DICE::DiceRestartReason reason) noexcept;
-    // Resolves the record + its DICE duplex surface for `guid`. `outHold` receives a
+                                             const AudioClockConfig& desiredClock,
+                                             DuplexRestartReason reason) noexcept;
+    // Resolves the record + its protocol-neutral duplex surface for `guid`. `outHold` receives a
     // shared_ptr to the owning IDeviceProtocol; callers must keep it alive for as long as
-    // they use `outDiceProtocol` (it is a view into the held protocol).
-    [[nodiscard]] Discovery::DeviceRecord* RequireDiceRecord(
+    // they use `outDeviceControl` (it is a view into the held protocol).
+    [[nodiscard]] Discovery::DeviceRecord* RequireDuplexRecord(
         uint64_t guid,
-        DICE::IDICEDuplexProtocol*& outDiceProtocol,
+        IDuplexDeviceControl*& outDeviceControl,
         std::shared_ptr<IDeviceProtocol>& outHold) noexcept;
     [[nodiscard]] ASFW::Audio::Runtime::IDirectAudioBindingSource* GetDirectAudioBindingSource(uint64_t guid) const noexcept;
     [[nodiscard]] bool TryAcquireGuid(uint64_t guid) noexcept;
@@ -107,15 +105,15 @@ private:
     [[nodiscard]] bool TryTakeCompletedClockRequest(
         uint64_t guid,
         uint64_t token,
-        DICE::DiceClockRequestCompletion& outCompletion) noexcept;
-    void CompleteClockRequest(const DICE::DiceClockRequestCompletion& completion, uint64_t guid) noexcept;
+        DuplexClockRequestCompletion& outCompletion) noexcept;
+    void CompleteClockRequest(const DuplexClockRequestCompletion& completion, uint64_t guid) noexcept;
     void FailPendingClockRequest(uint64_t guid,
-                                 DICE::DiceClockRequestOutcome outcome,
+                                 DuplexClockRequestOutcome outcome,
                                  IOReturn status) noexcept;
     void RecordTeardownAbort(const char* stage, uint64_t guid) noexcept;
 
-    [[nodiscard]] DICE::DiceRestartSession LoadSession(uint64_t guid) const noexcept;
-    void StoreSession(const DICE::DiceRestartSession& session) noexcept;
+    [[nodiscard]] DuplexRestartSession LoadSession(uint64_t guid) const noexcept;
+    void StoreSession(const DuplexRestartSession& session) noexcept;
 
     // FW-61: global teardown cancel token. Distinct from the per-guid stop intent
     // (gate_, see DuplexOperationGate) - that aborts one stream; this aborts everything for
@@ -126,7 +124,7 @@ private:
 
     Discovery::DeviceRegistry& registry_;
     AudioRuntimeRegistry& runtime_;
-    IDiceHostTransport& hostTransport_;
+    IIsochDuplexHostTransport& hostTransport_;
     Driver::HardwareInterface& hardware_;
     const std::atomic<bool>* cancel_{nullptr};
     DirectAudioBindingSourceProvider bindingSourceProvider_;

--- a/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.hpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
-// DiceHostTransport.hpp - Host-side isoch orchestration seam for DICE restart FSM
+// DiceHostTransport.hpp - Host-side isoch orchestration seam
 
 #pragma once
 
@@ -21,9 +21,9 @@ class ASFWAudioNub;
 
 namespace ASFW::Audio {
 
-class IDiceHostTransport {
+class IIsochDuplexHostTransport {
   public:
-    virtual ~IDiceHostTransport() = default;
+    virtual ~IIsochDuplexHostTransport() = default;
 
     [[nodiscard]] virtual kern_return_t BeginSplitDuplex(uint64_t guid) noexcept = 0;
     [[nodiscard]] virtual kern_return_t
@@ -56,7 +56,7 @@ class IDiceHostTransport {
     [[nodiscard]] virtual kern_return_t StopAll() noexcept = 0;
 };
 
-class DiceIsochHostTransport final : public IDiceHostTransport {
+class DiceIsochHostTransport final : public IIsochDuplexHostTransport {
   public:
     explicit DiceIsochHostTransport(Driver::IsochService& isoch) noexcept : isoch_(isoch) {}
 
@@ -95,5 +95,9 @@ class DiceIsochHostTransport final : public IDiceHostTransport {
   private:
     Driver::IsochService& isoch_;
 };
+
+// FW-71 leaves the file move to FW-73. No production caller should use this
+// compatibility spelling after the neutral seam promotion.
+using IDiceHostTransport = IIsochDuplexHostTransport;
 
 } // namespace ASFW::Audio

--- a/ASFWDriver/Audio/Protocols/DICE/Core/DICEDuplexBringupController.cpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Core/DICEDuplexBringupController.cpp
@@ -157,9 +157,9 @@ void DICEDuplexBringupController::ConfirmDuplexStart(ConfirmCallback callback) {
         });
 }
 
-void DICEDuplexBringupController::ApplyClockConfig(const DiceDesiredClockConfig& desiredClock,
-                                                   ClockApplyCallback callback) {
-    if (!IsSupportedClockConfig(desiredClock)) {
+void DICEDuplexBringupController::ApplyClockConfig(
+    const DiceClockConfiguration& desiredClock, ClockApplyCallback callback) {
+    if (!IsSupportedDiceClockConfiguration(desiredClock)) {
         callback(kIOReturnUnsupported, {});
         return;
     }
@@ -177,10 +177,11 @@ void DICEDuplexBringupController::ApplyClockConfig(const DiceDesiredClockConfig&
     flowMode_ = FlowMode::kClockApply;
     NotificationMailbox::Reset();
     stopSequenceError_ = kIOReturnSuccess;
+    diceClock_ = desiredClock;
     restartSession_ = DiceRestartSession{
         .generation = busInfo_.GetGeneration(),
         .reason = DiceRestartReason::kManualReconfigure,
-        .desiredClock = desiredClock,
+        .desiredClock = AudioClockConfig{.sampleRateHz = desiredClock.sampleRateHz},
         .phase = DiceRestartPhase::kPreparingDevice,
     };
     runtimeCaps_ = {};
@@ -297,13 +298,16 @@ void DICEDuplexBringupController::PrepareDuplex48k(
     flowMode_ = FlowMode::kPrepareDuplex;
     NotificationMailbox::Reset();
     stopSequenceError_ = kIOReturnSuccess;
+    diceClock_ = DiceClockConfiguration{
+        .sampleRateHz = 48000U,
+        .clockSelect = kDiceClockSelect48kInternal,
+    };
     restartSession_ = DiceRestartSession{
         .generation = busInfo_.GetGeneration(),
         .channels = channels,
         .reason = DiceRestartReason::kInitialStart,
-        .desiredClock = DiceDesiredClockConfig{
+        .desiredClock = AudioClockConfig{
             .sampleRateHz = 48000U,
-            .clockSelect = kDiceClockSelect48kInternal,
         },
         .phase = DiceRestartPhase::kPreparingDevice,
     };
@@ -324,7 +328,7 @@ void DICEDuplexBringupController::PrepareDuplex48k(
 
 void DICEDuplexBringupController::PrepareDuplex(
     const AudioDuplexChannels& channels,
-    const DiceDesiredClockConfig& desiredClock,
+    const DiceClockConfiguration& desiredClock,
     PrepareCallback callback) {
     if (channels.deviceToHostIsoChannel > 63 || channels.hostToDeviceIsoChannel > 63) {
         callback(kIOReturnBadArgument, {});
@@ -334,7 +338,7 @@ void DICEDuplexBringupController::PrepareDuplex(
         callback(kIOReturnNotReady, {});
         return;
     }
-    if (!IsSupportedClockConfig(desiredClock)) {
+    if (!IsSupportedDiceClockConfiguration(desiredClock)) {
         callback(kIOReturnUnsupported, {});
         return;
     }
@@ -350,11 +354,12 @@ void DICEDuplexBringupController::PrepareDuplex(
     refreshRuntimeCapsOnPrepare_ = true;
     NotificationMailbox::Reset();
     stopSequenceError_ = kIOReturnSuccess;
+    diceClock_ = desiredClock;
     restartSession_ = DiceRestartSession{
         .generation = busInfo_.GetGeneration(),
         .channels = channels,
         .reason = DiceRestartReason::kInitialStart,
-        .desiredClock = desiredClock,
+        .desiredClock = AudioClockConfig{.sampleRateHz = desiredClock.sampleRateHz},
         .phase = DiceRestartPhase::kPreparingDevice,
     };
     runtimeCaps_ = {};
@@ -533,7 +538,7 @@ void DICEDuplexBringupController::DoWriteClockSelect(
 
     NotificationMailbox::Reset();
     (void)io_.WriteQuadBE(MakeDICEAddress(sections_.global.offset + GlobalOffset::kClockSelect),
-                    restartSession_.desiredClock.clockSelect,
+                    diceClock_.clockSelect,
                     [this, channels, cb = std::move(cb)](Async::AsyncStatus transportStatus) mutable {
                          const IOReturn status = MapTransportStatus(transportStatus);
                          if (status != kIOReturnSuccess) {
@@ -701,7 +706,7 @@ void DICEDuplexBringupController::DoReadGlobalAfterClockAccepted(
                                 const bool sampleRateAtTarget =
                                     state.sampleRate == restartSession_.desiredClock.sampleRateHz;
 
-                                if (state.clockSelect != restartSession_.desiredClock.clockSelect) {
+                                if (state.clockSelect != diceClock_.clockSelect) {
                                     ASFW_LOG(DICE,
                                              "PrepareDuplex48k: clock confirm failed, clockSelect=0x%08x notify=0x%08x status=0x%08x sampleRate=%u",
                                              state.clockSelect,
@@ -1159,9 +1164,8 @@ void DICEDuplexBringupController::RefreshRuntimeCaps(VoidCallback cb) {
                             state->rx = rx;
                             CacheRuntimeCaps(runtimeCaps_, state->global, state->tx, state->rx);
                             restartSession_.runtimeCaps = runtimeCaps_;
-                            restartSession_.appliedClock = DiceDesiredClockConfig{
+                            restartSession_.appliedClock = AudioClockConfig{
                                 .sampleRateHz = state->global.sampleRate,
-                                .clockSelect = state->global.clockSelect,
                             };
                             cb(kIOReturnSuccess);
                         });

--- a/ASFWDriver/Audio/Protocols/DICE/Core/DICEDuplexBringupController.hpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Core/DICEDuplexBringupController.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "IDICEDuplexProtocol.hpp"
+#include "../../Duplex/IDuplexDeviceControl.hpp"
 #include "DICERestartSession.hpp"
 #include "DICETypes.hpp"
 #include "DICETransaction.hpp"
@@ -28,10 +28,10 @@ namespace ASFW::Audio::DICE {
 class DICEDuplexBringupController {
 public:
     using VoidCallback = std::function<void(IOReturn)>;
-    using PrepareCallback = IDICEDuplexProtocol::PrepareCallback;
-    using StageCallback = IDICEDuplexProtocol::StageCallback;
-    using ConfirmCallback = IDICEDuplexProtocol::ConfirmCallback;
-    using ClockApplyCallback = IDICEDuplexProtocol::ClockApplyCallback;
+    using PrepareCallback = IDuplexDeviceControl::PrepareCallback;
+    using StageCallback = IDuplexDeviceControl::StageCallback;
+    using ConfirmCallback = IDuplexDeviceControl::ConfirmCallback;
+    using ClockApplyCallback = IDuplexDeviceControl::ClockApplyCallback;
 
     DICEDuplexBringupController(
         DICETransaction& diceReader,
@@ -45,12 +45,13 @@ public:
 
     // Async duplex methods (were IOReturn, now void + callback)
     void PrepareDuplex(const AudioDuplexChannels& channels,
-                       const DiceDesiredClockConfig& desiredClock,
+                       const DiceClockConfiguration& desiredClock,
                        PrepareCallback callback);
     void ProgramRx(StageCallback callback);
     void ProgramTxAndEnableDuplex(StageCallback callback);
     void ConfirmDuplexStart(ConfirmCallback callback);
-    void ApplyClockConfig(const DiceDesiredClockConfig& desiredClock, ClockApplyCallback callback);
+    void ApplyClockConfig(const DiceClockConfiguration& desiredClock,
+                          ClockApplyCallback callback);
     void SetTeardownCancelToken(const std::atomic<bool>* cancel) noexcept {
         teardownCancel_ = cancel;
     }
@@ -130,6 +131,7 @@ private:
     GeneralSections sections_;
 
     DiceRestartSession restartSession_{};
+    DiceClockConfiguration diceClock_{};
     FlowMode flowMode_{FlowMode::kNone};
     AudioStreamRuntimeCaps runtimeCaps_{};
     uint32_t confirmNotification_{0};

--- a/ASFWDriver/Audio/Protocols/DICE/Core/DICERestartSession.hpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Core/DICERestartSession.hpp
@@ -5,8 +5,9 @@
 
 #pragma once
 
-#include "DICETypes.hpp"
 #include "../../AudioTypes.hpp"
+#include "../../Duplex/AudioClockConfig.hpp"
+#include "../../../../Async/AsyncTypes.hpp"
 
 #include <DriverKit/IOReturn.h>
 
@@ -14,10 +15,6 @@
 #include <optional>
 
 namespace ASFW::Audio::DICE {
-
-constexpr uint32_t kDiceClockSelect48kInternal =
-    (ClockRateIndex::k48000 << ClockSelect::kRateShift) |
-    static_cast<uint32_t>(ClockSource::Internal);
 
 enum class DiceRestartReason : uint8_t {
     kInitialStart,
@@ -95,14 +92,9 @@ enum class DiceRestartFailureCause : uint8_t {
     kTxFault,
 };
 
-struct DiceDesiredClockConfig {
-    uint32_t sampleRateHz{0};
-    uint32_t clockSelect{0};
-};
-
 struct DiceClockRequestCompletion {
     uint64_t token{0};
-    DiceDesiredClockConfig desiredClock{};
+    AudioClockConfig desiredClock{};
     DiceRestartReason reason{DiceRestartReason::kManualReconfigure};
     DiceClockRequestOutcome outcome{DiceClockRequestOutcome::kFailed};
     IOReturn status{kIOReturnSuccess};
@@ -127,7 +119,7 @@ struct DiceRestartIssueInfo {
 struct DiceDuplexPrepareResult {
     FW::Generation generation{0};
     AudioDuplexChannels channels{};
-    DiceDesiredClockConfig appliedClock{};
+    AudioClockConfig appliedClock{};
     AudioStreamRuntimeCaps runtimeCaps{};
 };
 
@@ -141,7 +133,7 @@ struct DiceDuplexStageResult {
 struct DiceDuplexConfirmResult {
     FW::Generation generation{0};
     AudioDuplexChannels channels{};
-    DiceDesiredClockConfig appliedClock{};
+    AudioClockConfig appliedClock{};
     AudioStreamRuntimeCaps runtimeCaps{};
     uint32_t notification{0};
     uint32_t status{0};
@@ -150,14 +142,17 @@ struct DiceDuplexConfirmResult {
 
 struct DiceClockApplyResult {
     FW::Generation generation{0};
-    DiceDesiredClockConfig appliedClock{};
+    AudioClockConfig appliedClock{};
     AudioStreamRuntimeCaps runtimeCaps{};
 };
 
 struct DiceDuplexHealthResult {
     FW::Generation generation{0};
-    DiceDesiredClockConfig appliedClock{};
+    AudioClockConfig appliedClock{};
     AudioStreamRuntimeCaps runtimeCaps{};
+    bool sourceLocked{false};
+    bool clockReferenceHealthy{true};
+    uint32_t nominalRateHz{0};
     uint32_t notification{0};
     uint32_t status{0};
     uint32_t extStatus{0};
@@ -170,9 +165,9 @@ struct DiceRestartSession {
     FW::Generation topologyGeneration{0};
     AudioDuplexChannels channels{};
     DiceRestartReason reason{DiceRestartReason::kInitialStart};
-    DiceDesiredClockConfig desiredClock{};
-    DiceDesiredClockConfig appliedClock{};
-    DiceDesiredClockConfig pendingClock{};
+    AudioClockConfig desiredClock{};
+    AudioClockConfig appliedClock{};
+    AudioClockConfig pendingClock{};
     DiceRestartReason pendingReason{DiceRestartReason::kInitialStart};
     AudioStreamRuntimeCaps runtimeCaps{};
     DiceRestartPhase phase{DiceRestartPhase::kIdle};
@@ -197,9 +192,7 @@ struct DiceRestartSession {
 };
 
 [[nodiscard]] constexpr bool HasRestartIntent(const DiceRestartSession& session) noexcept {
-    return session.desiredClock.sampleRateHz != 0 ||
-           session.desiredClock.clockSelect != 0 ||
-           session.hasPendingClockRequest;
+    return session.desiredClock.sampleRateHz != 0 || session.hasPendingClockRequest;
 }
 
 [[nodiscard]] constexpr bool HasDeviceRestartState(const DiceRestartSession& session) noexcept {
@@ -247,15 +240,9 @@ constexpr void ClearRestartProgress(DiceRestartSession& session,
     session.hostTransmitStarted = false;
 }
 
-[[nodiscard]] constexpr bool IsSupportedClockConfig(
-    const DiceDesiredClockConfig& desiredClock) noexcept {
-    return desiredClock.sampleRateHz == 48000U &&
-           desiredClock.clockSelect == kDiceClockSelect48kInternal;
-}
-
 [[nodiscard]] constexpr DiceRestartReason ClassifyRestartReason(
     const DiceRestartSession* previousSession,
-    const DiceDesiredClockConfig& desiredClock) noexcept {
+    const AudioClockConfig& desiredClock) noexcept {
     if (previousSession == nullptr || !HasRestartIntent(*previousSession)) {
         return DiceRestartReason::kInitialStart;
     }
@@ -263,11 +250,6 @@ constexpr void ClearRestartProgress(DiceRestartSession& session,
     if (previousSession->desiredClock.sampleRateHz != 0 &&
         previousSession->desiredClock.sampleRateHz != desiredClock.sampleRateHz) {
         return DiceRestartReason::kSampleRateChange;
-    }
-
-    if (previousSession->desiredClock.clockSelect != 0 &&
-        previousSession->desiredClock.clockSelect != desiredClock.clockSelect) {
-        return DiceRestartReason::kClockSourceChange;
     }
 
     if (previousSession->phase == DiceRestartPhase::kFailed) {

--- a/ASFWDriver/Audio/Protocols/DICE/Core/DICETypes.hpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Core/DICETypes.hpp
@@ -483,6 +483,23 @@ namespace ClockRateIndex {
     constexpr uint32_t k192000 = 0x06;
 }
 
+// DICE GLOBAL_CLOCK_SELECT encoding. This stays inside the DICE adapter; the
+// protocol-neutral duplex seam carries only AudioClockConfig::sampleRateHz.
+struct DiceClockConfiguration {
+    uint32_t sampleRateHz{0};
+    uint32_t clockSelect{0};
+};
+
+constexpr uint32_t kDiceClockSelect48kInternal =
+    (ClockRateIndex::k48000 << ClockSelect::kRateShift) |
+    static_cast<uint32_t>(ClockSource::Internal);
+
+[[nodiscard]] constexpr bool IsSupportedDiceClockConfiguration(
+    const DiceClockConfiguration& clock) noexcept {
+    return clock.sampleRateHz == 48000U &&
+           clock.clockSelect == kDiceClockSelect48kInternal;
+}
+
 /// Parsed global section state
 struct GlobalState {
     uint64_t owner{0};           ///< Owner node ID

--- a/ASFWDriver/Audio/Protocols/DICE/Core/IDICEDuplexProtocol.hpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Core/IDICEDuplexProtocol.hpp
@@ -1,60 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 ASFireWire Project
 //
-// IDICEDuplexProtocol.hpp - Typed DICE duplex restart/control surface
+// IDICEDuplexProtocol.hpp - Transitional DICE compatibility alias
 
 #pragma once
 
-#include "DICERestartSession.hpp"
-
-#include <DriverKit/IOReturn.h>
-#include <atomic>
-#include <functional>
-
-namespace ASFW::IRM {
-class IRMClient;
-}
+#include "../../Duplex/IDuplexDeviceControl.hpp"
 
 namespace ASFW::Audio::DICE {
 
-class IDICEDuplexProtocol {
-public:
-    using PrepareCallback = std::function<void(IOReturn, DiceDuplexPrepareResult)>;
-    using StageCallback = std::function<void(IOReturn, DiceDuplexStageResult)>;
-    using ConfirmCallback = std::function<void(IOReturn, DiceDuplexConfirmResult)>;
-    using ClockApplyCallback = std::function<void(IOReturn, DiceClockApplyResult)>;
-    using HealthCallback = std::function<void(IOReturn, DiceDuplexHealthResult)>;
-    using VoidCallback = std::function<void(IOReturn)>;
-
-    virtual ~IDICEDuplexProtocol() = default;
-
-    // Pre-read the device's static stream format (DICE TX_NUMBER/RX_NUMBER +
-    // per-stream channel counts) and publish it through GetRuntimeAudioStreamCaps
-    // BEFORE duplex channel resolution. A multi-stream device (e.g. Venice F32 =
-    // 2×16) must allocate an iso channel + IRM reservation per stream; without
-    // this the first start resolves with empty caps (streamCount=1) and brings
-    // the device up as a single aggregate stream it rejects. Cross-validated with
-    // FFADO dice_avdevice.cpp prepare() (m_nb_rx/m_nb_tx loop). Default is a no-op
-    // success for protocols that derive geometry by other means.
-    virtual void EnsureRuntimeStreamGeometry(VoidCallback callback) {
-        callback(kIOReturnSuccess);
-    }
-
-    virtual void PrepareDuplex(const AudioDuplexChannels& channels,
-                               const DiceDesiredClockConfig& desiredClock,
-                               PrepareCallback callback) = 0;
-    virtual void ProgramRx(StageCallback callback) = 0;
-    virtual void ProgramTxAndEnableDuplex(StageCallback callback) = 0;
-    virtual void ConfirmDuplexStart(ConfirmCallback callback) = 0;
-    virtual void ApplyClockConfig(const DiceDesiredClockConfig& desiredClock,
-                                  ClockApplyCallback callback) = 0;
-    virtual void ReadDuplexHealth(HealthCallback callback) = 0;
-
-    virtual void SetTeardownCancelToken(const std::atomic<bool>* cancel) noexcept {
-        (void)cancel;
-    }
-    [[nodiscard]] virtual IOReturn StopDuplex() = 0;
-    [[nodiscard]] virtual ::ASFW::IRM::IRMClient* GetIRMClient() const = 0;
-};
+// DICE implementations are the first IDuplexDeviceControl providers. Keep this
+// alias only until FW-73 moves/removes the legacy DICE-named header.
+using IDICEDuplexProtocol = ::ASFW::Audio::IDuplexDeviceControl;
 
 } // namespace ASFW::Audio::DICE

--- a/ASFWDriver/Audio/Protocols/DICE/Focusrite/SPro24DspProtocol.hpp
+++ b/ASFWDriver/Audio/Protocols/DICE/Focusrite/SPro24DspProtocol.hpp
@@ -63,8 +63,12 @@ public:
     
     /// Get device name
     const char* GetName() const override { return "Focusrite Saffire Pro 24 DSP"; }
-    Audio::DICE::IDICEDuplexProtocol* AsDiceDuplexProtocol() noexcept override { return tcat_.AsDiceDuplexProtocol(); }
-    const Audio::DICE::IDICEDuplexProtocol* AsDiceDuplexProtocol() const noexcept override { return tcat_.AsDiceDuplexProtocol(); }
+    Audio::IDuplexDeviceControl* AsDuplexDeviceControl() noexcept override {
+        return tcat_.AsDuplexDeviceControl();
+    }
+    const Audio::IDuplexDeviceControl* AsDuplexDeviceControl() const noexcept override {
+        return tcat_.AsDuplexDeviceControl();
+    }
     
     /// Device has DSP effects
     bool HasDsp() const override { return true; }

--- a/ASFWDriver/Audio/Protocols/DICE/TCAT/DICETcatProtocol.cpp
+++ b/ASFWDriver/Audio/Protocols/DICE/TCAT/DICETcatProtocol.cpp
@@ -46,6 +46,21 @@ void LogStreamConfigSummary(const char* label, const StreamConfig& config) {
 
 } // namespace
 
+bool DICETcatProtocol::MakeDiceClockConfiguration(
+    const AudioClockConfig& requested, DiceClockConfiguration& out) noexcept {
+    if (!IsSupportedAudioClockConfig(requested)) {
+        return false;
+    }
+    // The DICE adapter owns the register encoding: Linux selects the requested
+    // rate by updating GLOBAL_CLOCK_SELECT while preserving the source bits
+    // (dice-stream.c:60-85; dice-interface.h:80-95).
+    out = DiceClockConfiguration{
+        .sampleRateHz = requested.sampleRateHz,
+        .clockSelect = kDiceClockSelect48kInternal,
+    };
+    return true;
+}
+
 DICETcatProtocol::DICETcatProtocol(Protocols::Ports::FireWireBusOps& busOps,
                                    Protocols::Ports::FireWireBusInfo& busInfo,
                                    uint16_t nodeId,
@@ -129,16 +144,22 @@ void DICETcatProtocol::SetTeardownCancelToken(const std::atomic<bool>* cancel) n
 }
 
 void DICETcatProtocol::PrepareDuplex(const AudioDuplexChannels& channels,
-                                     const DiceDesiredClockConfig& desiredClock,
+                                     const AudioClockConfig& desiredClock,
                                      PrepareCallback callback) {
     if (!initialized_ || !duplexCtrl_) {
         callback(kIOReturnNotReady, {});
         return;
     }
 
+    DiceClockConfiguration diceClock{};
+    if (!MakeDiceClockConfiguration(desiredClock, diceClock)) {
+        callback(kIOReturnUnsupported, {});
+        return;
+    }
+
     duplexCtrl_->PrepareDuplex(
         channels,
-        desiredClock,
+        diceClock,
         [this, callback = std::move(callback)](IOReturn status, DiceDuplexPrepareResult result) mutable {
             if (status == kIOReturnSuccess) {
                 CacheRuntimeCaps(result.runtimeCaps);
@@ -180,15 +201,21 @@ void DICETcatProtocol::ConfirmDuplexStart(ConfirmCallback callback) {
         });
 }
 
-void DICETcatProtocol::ApplyClockConfig(const DiceDesiredClockConfig& desiredClock,
+void DICETcatProtocol::ApplyClockConfig(const AudioClockConfig& desiredClock,
                                         ClockApplyCallback callback) {
     if (!initialized_ || !duplexCtrl_) {
         callback(kIOReturnNotReady, {});
         return;
     }
 
+    DiceClockConfiguration diceClock{};
+    if (!MakeDiceClockConfiguration(desiredClock, diceClock)) {
+        callback(kIOReturnUnsupported, {});
+        return;
+    }
+
     duplexCtrl_->ApplyClockConfig(
-        desiredClock,
+        diceClock,
         [this, callback = std::move(callback)](IOReturn status, DiceClockApplyResult result) mutable {
             if (status == kIOReturnSuccess) {
                 CacheRuntimeCaps(result.runtimeCaps);
@@ -219,16 +246,23 @@ void DICETcatProtocol::ReadDuplexHealth(HealthCallback callback) {
 
                 AudioStreamRuntimeCaps caps{};
                 (void)GetRuntimeAudioStreamCaps(caps);
+                const uint32_t clockSource =
+                    global.clockSelect & ClockSelect::kSourceMask;
+                const bool clockReferenceHealthy =
+                    clockSource != static_cast<uint32_t>(ClockSource::ARX1) ||
+                    (IsArx1Locked(global.extStatus) && !HasArx1Slip(global.extStatus));
 
                 callback(status,
                          DiceDuplexHealthResult{
                              .generation = busInfo_.GetGeneration(),
                              .appliedClock =
-                                 DiceDesiredClockConfig{
+                                 AudioClockConfig{
                                      .sampleRateHz = global.sampleRate,
-                                     .clockSelect = global.clockSelect,
                                  },
                              .runtimeCaps = caps,
+                             .sourceLocked = IsSourceLocked(global.status),
+                             .clockReferenceHealthy = clockReferenceHealthy,
+                             .nominalRateHz = NominalRateHz(global.status),
                              .notification = global.notification,
                              .status = global.status,
                              .extStatus = global.extStatus,
@@ -239,9 +273,8 @@ void DICETcatProtocol::ReadDuplexHealth(HealthCallback callback) {
 
 void DICETcatProtocol::PrepareDuplex48k(const AudioDuplexChannels& channels, VoidCallback callback) {
     PrepareDuplex(channels,
-                  DiceDesiredClockConfig{
+                  AudioClockConfig{
                       .sampleRateHz = 48000U,
-                      .clockSelect = kDiceClockSelect48kInternal,
                   },
                   [callback = std::move(callback)](IOReturn status, DiceDuplexPrepareResult) mutable {
                       callback(status);

--- a/ASFWDriver/Audio/Protocols/DICE/TCAT/DICETcatProtocol.hpp
+++ b/ASFWDriver/Audio/Protocols/DICE/TCAT/DICETcatProtocol.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "../Core/IDICEDuplexProtocol.hpp"
+#include "../../Duplex/IDuplexDeviceControl.hpp"
 #include "../Core/DICEDuplexBringupController.hpp"
 #include "../Core/DICETransaction.hpp"
 #include "../Core/DICETypes.hpp"
@@ -23,14 +23,14 @@ class IRMClient;
 namespace ASFW::Audio::DICE::TCAT {
 
 class DICETcatProtocol final : public Audio::IDeviceProtocol,
-                               public Audio::DICE::IDICEDuplexProtocol {
+                               public Audio::IDuplexDeviceControl {
 public:
     using VoidCallback = std::function<void(IOReturn)>;
-    using PrepareCallback = IDICEDuplexProtocol::PrepareCallback;
-    using StageCallback = IDICEDuplexProtocol::StageCallback;
-    using ConfirmCallback = IDICEDuplexProtocol::ConfirmCallback;
-    using ClockApplyCallback = IDICEDuplexProtocol::ClockApplyCallback;
-    using HealthCallback = IDICEDuplexProtocol::HealthCallback;
+    using PrepareCallback = IDuplexDeviceControl::PrepareCallback;
+    using StageCallback = IDuplexDeviceControl::StageCallback;
+    using ConfirmCallback = IDuplexDeviceControl::ConfirmCallback;
+    using ClockApplyCallback = IDuplexDeviceControl::ClockApplyCallback;
+    using HealthCallback = IDuplexDeviceControl::HealthCallback;
 
     DICETcatProtocol(Protocols::Ports::FireWireBusOps& busOps,
                      Protocols::Ports::FireWireBusInfo& busInfo,
@@ -40,20 +40,20 @@ public:
     IOReturn Initialize() override;
     IOReturn Shutdown() override;
     const char* GetName() const override { return "TCAT DICE"; }
-    Audio::DICE::IDICEDuplexProtocol* AsDiceDuplexProtocol() noexcept override { return this; }
-    const Audio::DICE::IDICEDuplexProtocol* AsDiceDuplexProtocol() const noexcept override { return this; }
+    Audio::IDuplexDeviceControl* AsDuplexDeviceControl() noexcept override { return this; }
+    const Audio::IDuplexDeviceControl* AsDuplexDeviceControl() const noexcept override { return this; }
 
     bool GetRuntimeAudioStreamCaps(AudioStreamRuntimeCaps& outCaps) const override;
     bool GetChannelLabels(std::vector<std::string>& inNames,
                           std::vector<std::string>& outNames) const override;
 
     void PrepareDuplex(const AudioDuplexChannels& channels,
-                       const DiceDesiredClockConfig& desiredClock,
+                       const AudioClockConfig& desiredClock,
                        PrepareCallback callback) override;
     void ProgramRx(StageCallback callback) override;
     void ProgramTxAndEnableDuplex(StageCallback callback) override;
     void ConfirmDuplexStart(ConfirmCallback callback) override;
-    void ApplyClockConfig(const DiceDesiredClockConfig& desiredClock,
+    void ApplyClockConfig(const AudioClockConfig& desiredClock,
                           ClockApplyCallback callback) override;
     void ReadDuplexHealth(HealthCallback callback) override;
     void EnsureRuntimeStreamGeometry(VoidCallback callback) override;
@@ -74,6 +74,9 @@ public:
 private:
     friend class DICETcatProtocolTestPeer;
 
+    [[nodiscard]] static bool MakeDiceClockConfiguration(
+        const AudioClockConfig& requested,
+        DiceClockConfiguration& out) noexcept;
     void EnsureSectionsLoaded(VoidCallback callback);
     void EnsureRuntimeCapsLoaded(VoidCallback callback);
     void CacheRuntimeCaps(const GlobalState& global,

--- a/ASFWDriver/Audio/Protocols/Duplex/AudioClockConfig.hpp
+++ b/ASFWDriver/Audio/Protocols/Duplex/AudioClockConfig.hpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 ASFireWire Project
+//
+// AudioClockConfig.hpp - Protocol-neutral duplex clock request
+
+#pragma once
+
+#include <cstdint>
+
+namespace ASFW::Audio {
+
+// The duplex lifecycle is presently 48 kHz-only. Protocol adapters translate
+// this generic request into their device-specific clock command or register value.
+struct AudioClockConfig {
+    uint32_t sampleRateHz{0};
+};
+
+[[nodiscard]] constexpr bool IsSupportedAudioClockConfig(
+    const AudioClockConfig& desiredClock) noexcept {
+    return desiredClock.sampleRateHz == 48000U;
+}
+
+} // namespace ASFW::Audio

--- a/ASFWDriver/Audio/Protocols/Duplex/DuplexControlTypes.hpp
+++ b/ASFWDriver/Audio/Protocols/Duplex/DuplexControlTypes.hpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 ASFireWire Project
+//
+// DuplexControlTypes.hpp - Neutral names for the pre-FW-73 restart vocabulary
+
+#pragma once
+
+#include "../DICE/Core/DICERestartSession.hpp"
+
+namespace ASFW::Audio {
+
+// FW-71 exposes these neutral names at the duplex seam. FW-73 will mechanically
+// rename the underlying restart/session declarations and move their files.
+using DuplexRestartReason = DICE::DiceRestartReason;
+using DuplexRestartPhase = DICE::DiceRestartPhase;
+using DuplexRestartState = DICE::DiceRestartState;
+using DuplexClockRequestOutcome = DICE::DiceClockRequestOutcome;
+using DuplexRestartErrorClass = DICE::DiceRestartErrorClass;
+using DuplexRestartFailureCause = DICE::DiceRestartFailureCause;
+using DuplexClockRequestCompletion = DICE::DiceClockRequestCompletion;
+using DuplexRestartIssueInfo = DICE::DiceRestartIssueInfo;
+using DuplexRestartSession = DICE::DiceRestartSession;
+using DuplexPrepareResult = DICE::DiceDuplexPrepareResult;
+using DuplexStageResult = DICE::DiceDuplexStageResult;
+using DuplexConfirmResult = DICE::DiceDuplexConfirmResult;
+using ClockApplyResult = DICE::DiceClockApplyResult;
+using DuplexHealthResult = DICE::DiceDuplexHealthResult;
+
+} // namespace ASFW::Audio

--- a/ASFWDriver/Audio/Protocols/Duplex/IDuplexDeviceControl.hpp
+++ b/ASFWDriver/Audio/Protocols/Duplex/IDuplexDeviceControl.hpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 ASFireWire Project
+//
+// IDuplexDeviceControl.hpp - Protocol-neutral device-control seam
+
+#pragma once
+
+#include "DuplexControlTypes.hpp"
+
+#include <DriverKit/IOReturn.h>
+
+#include <atomic>
+#include <functional>
+
+namespace ASFW::IRM {
+class IRMClient;
+}
+
+namespace ASFW::Audio {
+
+class IDuplexDeviceControl {
+public:
+    using PrepareCallback = std::function<void(IOReturn, DuplexPrepareResult)>;
+    using StageCallback = std::function<void(IOReturn, DuplexStageResult)>;
+    using ConfirmCallback = std::function<void(IOReturn, DuplexConfirmResult)>;
+    using ClockApplyCallback = std::function<void(IOReturn, ClockApplyResult)>;
+    using HealthCallback = std::function<void(IOReturn, DuplexHealthResult)>;
+    using VoidCallback = std::function<void(IOReturn)>;
+
+    virtual ~IDuplexDeviceControl() = default;
+
+    virtual void EnsureRuntimeStreamGeometry(VoidCallback callback) {
+        callback(kIOReturnSuccess);
+    }
+
+    virtual void PrepareDuplex(const AudioDuplexChannels& channels,
+                               const AudioClockConfig& desiredClock,
+                               PrepareCallback callback) = 0;
+    virtual void ProgramRx(StageCallback callback) = 0;
+    virtual void ProgramTxAndEnableDuplex(StageCallback callback) = 0;
+    virtual void ConfirmDuplexStart(ConfirmCallback callback) = 0;
+    virtual void ApplyClockConfig(const AudioClockConfig& desiredClock,
+                                  ClockApplyCallback callback) = 0;
+    virtual void ReadDuplexHealth(HealthCallback callback) = 0;
+
+    virtual void SetTeardownCancelToken(const std::atomic<bool>* cancel) noexcept {
+        (void)cancel;
+    }
+    [[nodiscard]] virtual IOReturn StopDuplex() = 0;
+    [[nodiscard]] virtual ::ASFW::IRM::IRMClient* GetIRMClient() const = 0;
+};
+
+} // namespace ASFW::Audio

--- a/ASFWDriver/Audio/Protocols/IDeviceProtocol.hpp
+++ b/ASFWDriver/Audio/Protocols/IDeviceProtocol.hpp
@@ -21,8 +21,8 @@ namespace ASFW::IRM {
     class IRMClient;
 }
 
-namespace ASFW::Audio::DICE {
-    class IDICEDuplexProtocol;
+namespace ASFW::Audio {
+class IDuplexDeviceControl;
 }
 
 namespace ASFW::Audio {
@@ -109,12 +109,12 @@ public:
         return nullptr;
     }
 
-    /// Optional typed DICE duplex control interface used by the restart coordinator.
-    virtual DICE::IDICEDuplexProtocol* AsDiceDuplexProtocol() noexcept {
+    /// Optional protocol-neutral duplex control interface used by the audio lifecycle.
+    virtual IDuplexDeviceControl* AsDuplexDeviceControl() noexcept {
         return nullptr;
     }
 
-    virtual const DICE::IDICEDuplexProtocol* AsDiceDuplexProtocol() const noexcept {
+    virtual const IDuplexDeviceControl* AsDuplexDeviceControl() const noexcept {
         return nullptr;
     }
 

--- a/tests/devices/ClockRequestBrokerTests.cpp
+++ b/tests/devices/ClockRequestBrokerTests.cpp
@@ -36,7 +36,7 @@ protected:
         DiceRestartReason reason = DiceRestartReason::kManualReconfigure) {
         IOLockLock(lock_);
         ClockRequestBroker::PendingClockRequest request{
-            .desiredClock = {.sampleRateHz = sampleRateHz, .clockSelect = sampleRateHz / 1000U},
+            .desiredClock = {.sampleRateHz = sampleRateHz},
             .reason = reason,
             .token = broker_.AllocateTokenLocked(),
         };
@@ -67,14 +67,14 @@ TEST_F(ClockRequestBrokerTest, QueuePendingLatestWinsAndMirrorsRestartSession) {
 
     IOLockLock(lock_);
     const ClockRequestBroker::PendingClockRequest first{
-        .desiredClock = {.sampleRateHz = 44100, .clockSelect = 44},
+        .desiredClock = {.sampleRateHz = 44100},
         .reason = DiceRestartReason::kSampleRateChange,
         .token = broker_.AllocateTokenLocked(),
     };
     EXPECT_FALSE(broker_.QueuePendingLocked(kGuid, first).has_value());
 
     const ClockRequestBroker::PendingClockRequest replacement{
-        .desiredClock = {.sampleRateHz = 48000, .clockSelect = 48},
+        .desiredClock = {.sampleRateHz = 48000},
         .reason = DiceRestartReason::kClockSourceChange,
         .token = broker_.AllocateTokenLocked(),
     };
@@ -122,7 +122,7 @@ TEST_F(ClockRequestBrokerTest, CompleteDeliversOnceAndUpdatesLastClockCompletion
 
     const DiceClockRequestCompletion completion{
         .token = 17,
-        .desiredClock = {.sampleRateHz = 96000, .clockSelect = 96},
+        .desiredClock = {.sampleRateHz = 96000},
         .reason = DiceRestartReason::kManualReconfigure,
         .outcome = DiceClockRequestOutcome::kApplied,
         .status = kIOReturnSuccess,

--- a/tests/devices/DICEDuplexBringupControllerTests.cpp
+++ b/tests/devices/DICEDuplexBringupControllerTests.cpp
@@ -1147,7 +1147,6 @@ TEST(DICEDuplexBringupControllerTests, RestartSessionTracksDevicePhasesAcrossBri
     ASSERT_TRUE(prepareResult.has_value());
     EXPECT_EQ(prepareResult->generation.value, 1U);
     EXPECT_EQ(prepareResult->appliedClock.sampleRateHz, 48000U);
-    EXPECT_EQ(prepareResult->appliedClock.clockSelect, kClockSelect48kInternal);
     EXPECT_EQ(prepareResult->channels.deviceToHostIsoChannel, channels.deviceToHostIsoChannel);
     EXPECT_EQ(prepareResult->channels.hostToDeviceIsoChannel, channels.hostToDeviceIsoChannel);
     EXPECT_EQ(prepareResult->runtimeCaps.sampleRateHz, 48000U);

--- a/tests/devices/DICERestartSessionTests.cpp
+++ b/tests/devices/DICERestartSessionTests.cpp
@@ -5,11 +5,11 @@
 namespace {
 
 using ASFW::Audio::AudioDuplexChannels;
+using ASFW::Audio::AudioClockConfig;
 using ASFW::Audio::DICE::ClassifyRestartReason;
 using ASFW::Audio::DICE::ClearRestartProgress;
 using ASFW::Audio::DICE::DiceClockRequestCompletion;
 using ASFW::Audio::DICE::DiceClockRequestOutcome;
-using ASFW::Audio::DICE::DiceDesiredClockConfig;
 using ASFW::Audio::DICE::DiceRestartErrorClass;
 using ASFW::Audio::DICE::DiceRestartFailureCause;
 using ASFW::Audio::DICE::DiceRestartIssueInfo;
@@ -18,19 +18,12 @@ using ASFW::Audio::DICE::DiceRestartReason;
 using ASFW::Audio::DICE::DiceRestartState;
 using ASFW::Audio::DICE::DiceRestartSession;
 
-constexpr DiceDesiredClockConfig k48kInternal{
+constexpr AudioClockConfig k48kInternal{
     .sampleRateHz = 48000U,
-    .clockSelect = 0x10010U,
 };
 
-constexpr DiceDesiredClockConfig k96kInternal{
+constexpr AudioClockConfig k96kInternal{
     .sampleRateHz = 96000U,
-    .clockSelect = 0x20010U,
-};
-
-constexpr DiceDesiredClockConfig k48kAdat{
-    .sampleRateHz = 48000U,
-    .clockSelect = 0x10040U,
 };
 
 TEST(DICERestartSessionTests, ClassifyRestartReasonReturnsInitialStartWithoutPriorIntent) {
@@ -47,7 +40,7 @@ TEST(DICERestartSessionTests, ClassifyRestartReasonReturnsInitialStartWithoutPri
     EXPECT_EQ(ClassifyRestartReason(&guidOnlySession, k48kInternal), DiceRestartReason::kInitialStart);
 }
 
-TEST(DICERestartSessionTests, ClassifyRestartReasonDetectsClockIntentChangesBeforeRecovery) {
+TEST(DICERestartSessionTests, ClassifyRestartReasonDetectsRateChangesBeforeRecovery) {
     DiceRestartSession prior{
         .guid = 0x130e0402004713ULL,
         .channels = AudioDuplexChannels{.deviceToHostIsoChannel = 1, .hostToDeviceIsoChannel = 0},
@@ -57,7 +50,6 @@ TEST(DICERestartSessionTests, ClassifyRestartReasonDetectsClockIntentChangesBefo
     };
 
     EXPECT_EQ(ClassifyRestartReason(&prior, k96kInternal), DiceRestartReason::kSampleRateChange);
-    EXPECT_EQ(ClassifyRestartReason(&prior, k48kAdat), DiceRestartReason::kClockSourceChange);
 }
 
 TEST(DICERestartSessionTests, ClassifyRestartReasonReturnsRecoveryForFailedSameConfigRestart) {
@@ -130,7 +122,6 @@ TEST(DICERestartSessionTests, ClearRestartProgressPreservesIntentButClearsExecut
     EXPECT_EQ(session.guid, 0x130e0402004713ULL);
     EXPECT_EQ(session.reason, DiceRestartReason::kManualReconfigure);
     EXPECT_EQ(session.desiredClock.sampleRateHz, k48kInternal.sampleRateHz);
-    EXPECT_EQ(session.desiredClock.clockSelect, k48kInternal.clockSelect);
     EXPECT_EQ(session.phase, DiceRestartPhase::kIdle);
     EXPECT_EQ(session.state, DiceRestartState::kIdle);
     EXPECT_FALSE(session.ownerClaimed);

--- a/tests/devices/DICETcatProtocolTests.cpp
+++ b/tests/devices/DICETcatProtocolTests.cpp
@@ -26,6 +26,11 @@ public:
                                  const StreamConfig& rx) {
         protocol.CacheRuntimeCaps(global, tx, rx);
     }
+
+    static bool MakeDiceClockConfiguration(const AudioClockConfig& requested,
+                                           DiceClockConfiguration& out) {
+        return DICETcatProtocol::MakeDiceClockConfiguration(requested, out);
+    }
 };
 
 } // namespace ASFW::Audio::DICE::TCAT
@@ -37,12 +42,14 @@ using ASFW::Async::AsyncStatus;
 using ASFW::Async::FWAddress;
 using ASFW::Async::IFireWireBus;
 using ASFW::Audio::AudioStreamRuntimeCaps;
+using ASFW::Audio::AudioClockConfig;
 using ASFW::Audio::DICE::ClockSource;
 using ASFW::Audio::DICE::DecodeDiceNickname;
 using ASFW::Audio::DICE::SplitDiceLabels;
 using ASFW::Audio::DICE::ExtensionSections;
 using ASFW::Audio::DICE::Focusrite::EffectGeneralParams;
 using ASFW::Audio::DICE::GeneralSections;
+using ASFW::Audio::DICE::DiceClockConfiguration;
 using ASFW::Audio::DICE::Focusrite::SPro24DspProtocol;
 using ASFW::Audio::DICE::Focusrite::kEffectGeneralOffset;
 using ASFW::Audio::DICE::TCAT::DICETcatProtocol;
@@ -253,6 +260,17 @@ TEST(DICETcatProtocolTests, InitializeIsSideEffectFree) {
     EXPECT_EQ(bus.lockCount, 0);
 }
 
+TEST(DICETcatProtocolTests, Neutral48kClockRequestMapsToDiceClockSelectInsideAdapter) {
+    DiceClockConfiguration mapped{};
+    EXPECT_TRUE(ASFW::Audio::DICE::TCAT::DICETcatProtocolTestPeer::MakeDiceClockConfiguration(
+        AudioClockConfig{.sampleRateHz = 48000U}, mapped));
+    EXPECT_EQ(mapped.sampleRateHz, 48000U);
+    EXPECT_EQ(mapped.clockSelect, kClockSelect48kInternal);
+
+    EXPECT_FALSE(ASFW::Audio::DICE::TCAT::DICETcatProtocolTestPeer::MakeDiceClockConfiguration(
+        AudioClockConfig{.sampleRateHz = 44100U}, mapped));
+}
+
 TEST(DICETcatProtocolTests, RuntimeCapsAggregateTotalConfiguredStreams) {
     CountingFireWireBus bus;
     DICETcatProtocol protocol(bus, bus, 2, nullptr);
@@ -359,7 +377,8 @@ TEST(DICETcatProtocolTests, ReadDuplexHealthReturnsCurrentGlobalLockState) {
     ASSERT_EQ(healthStatus, kIOReturnSuccess);
     ASSERT_TRUE(health.has_value());
     EXPECT_EQ(health->appliedClock.sampleRateHz, 48000U);
-    EXPECT_EQ(health->appliedClock.clockSelect, kClockSelect48kInternal);
+    EXPECT_TRUE(health->sourceLocked);
+    EXPECT_EQ(health->nominalRateHz, 48000U);
     EXPECT_EQ(health->notification, ASFW::Audio::DICE::Notify::kLockChange);
     EXPECT_EQ(health->status, kLocked48kStatus);
     EXPECT_EQ(health->extStatus, 0x40U);

--- a/tests/devices/DiceDuplexRestartCoordinatorTests.cpp
+++ b/tests/devices/DiceDuplexRestartCoordinatorTests.cpp
@@ -4,7 +4,8 @@
 #include "Audio/Core/AudioRuntimeRegistry.hpp"
 #include "Audio/DriverKit/Runtime/DirectAudioBindingSource.hpp"
 #include "Audio/Protocols/Backends/DiceDuplexRestartCoordinator.hpp"
-#include "Audio/Protocols/DICE/Core/IDICEDuplexProtocol.hpp"
+#include "Audio/Protocols/DICE/Core/DICETypes.hpp"
+#include "Audio/Protocols/Duplex/IDuplexDeviceControl.hpp"
 #include "Audio/Protocols/DeviceProtocolFactory.hpp"
 #include "Audio/Protocols/IDeviceProtocol.hpp"
 #include "Bus/IRM/IRMClient.hpp"
@@ -35,12 +36,13 @@ using ASFW::Async::IFireWireBus;
 using ASFW::Audio::AudioDuplexChannels;
 using ASFW::Audio::AudioRuntimeRegistry;
 using ASFW::Audio::AudioStreamRuntimeCaps;
-using ASFW::Audio::DiceDuplexRestartCoordinator;
+using ASFW::Audio::AudioDuplexCoordinator;
 using ASFW::Audio::IDeviceProtocol;
-using ASFW::Audio::IDiceHostTransport;
+using ASFW::Audio::IDuplexDeviceControl;
+using ASFW::Audio::IIsochDuplexHostTransport;
+using ASFW::Audio::AudioClockConfig;
 using ASFW::Audio::DICE::DiceClockApplyResult;
 using ASFW::Audio::DICE::DiceClockRequestOutcome;
-using ASFW::Audio::DICE::DiceDesiredClockConfig;
 using ASFW::Audio::DICE::DiceDuplexConfirmResult;
 using ASFW::Audio::DICE::DiceDuplexHealthResult;
 using ASFW::Audio::DICE::DiceDuplexPrepareResult;
@@ -51,7 +53,6 @@ using ASFW::Audio::DICE::DiceRestartPhase;
 using ASFW::Audio::DICE::DiceRestartReason;
 using ASFW::Audio::DICE::DiceRestartSession;
 using ASFW::Audio::DICE::DiceRestartState;
-using ASFW::Audio::DICE::IDICEDuplexProtocol;
 using ASFW::Discovery::CfgKey;
 using ASFW::Discovery::ConfigROM;
 using ASFW::Discovery::DeviceRegistry;
@@ -69,9 +70,8 @@ constexpr uint64_t kTestGuid = 0x00130E0402004713ULL;
 constexpr uint32_t kQueueBytes = 4096;
 constexpr uint32_t kFocusriteVendorId = ASFW::Audio::DeviceProtocolFactory::kFocusriteVendorId;
 constexpr uint32_t kSPro24DspModelId = ASFW::Audio::DeviceProtocolFactory::kSPro24DspModelId;
-constexpr DiceDesiredClockConfig kSupportedClock{
+constexpr AudioClockConfig kSupportedClock{
     .sampleRateHz = 48000U,
-    .clockSelect = ASFW::Audio::DICE::kDiceClockSelect48kInternal,
 };
 constexpr AudioStreamRuntimeCaps kDefaultRuntimeCaps{
     .hostInputPcmChannels = 8,
@@ -149,7 +149,7 @@ class FakeDirectAudioBindingSource final : public ASFW::Audio::Runtime::IDirectA
     }
 };
 
-class FakeDiceHostTransport final : public IDiceHostTransport {
+class FakeDiceHostTransport final : public IIsochDuplexHostTransport {
   public:
     explicit FakeDiceHostTransport(SharedCallLog& log) noexcept : log_(log) {}
 
@@ -300,7 +300,7 @@ class FakeDiceHostTransport final : public IDiceHostTransport {
     SharedCallLog& log_;
 };
 
-class FakeDiceProtocol final : public IDeviceProtocol, public IDICEDuplexProtocol {
+class FakeDiceProtocol final : public IDeviceProtocol, public IDuplexDeviceControl {
   public:
     FakeDiceProtocol(SharedCallLog& log, IRMClient& irmClient) noexcept
         : log_(log), irmClient_(irmClient) {}
@@ -314,11 +314,11 @@ class FakeDiceProtocol final : public IDeviceProtocol, public IDICEDuplexProtoco
         return true;
     }
 
-    IDICEDuplexProtocol* AsDiceDuplexProtocol() noexcept override { return this; }
-    const IDICEDuplexProtocol* AsDiceDuplexProtocol() const noexcept override { return this; }
+    IDuplexDeviceControl* AsDuplexDeviceControl() noexcept override { return this; }
+    const IDuplexDeviceControl* AsDuplexDeviceControl() const noexcept override { return this; }
 
     void PrepareDuplex(const AudioDuplexChannels& channels,
-                       const DiceDesiredClockConfig& desiredClock,
+                       const AudioClockConfig& desiredClock,
                        PrepareCallback callback) override {
         log_.Add("device.prepare");
         {
@@ -392,7 +392,7 @@ class FakeDiceProtocol final : public IDeviceProtocol, public IDICEDuplexProtoco
                                 });
     }
 
-    void ApplyClockConfig(const DiceDesiredClockConfig& desiredClock,
+    void ApplyClockConfig(const AudioClockConfig& desiredClock,
                           ClockApplyCallback callback) override {
         log_.Add("device.apply_clock");
         {
@@ -430,6 +430,8 @@ class FakeDiceProtocol final : public IDeviceProtocol, public IDICEDuplexProtoco
                                    .generation = healthGeneration,
                                    .appliedClock = currentClock_,
                                    .runtimeCaps = currentCaps_,
+                                   .sourceLocked = ASFW::Audio::DICE::IsSourceLocked(statusValue),
+                                   .nominalRateHz = ASFW::Audio::DICE::NominalRateHz(statusValue),
                                    .notification = healthNotification,
                                    .status = statusValue,
                                    .extStatus = healthExtStatusValue,
@@ -473,7 +475,7 @@ class FakeDiceProtocol final : public IDeviceProtocol, public IDICEDuplexProtoco
         });
     }
 
-    DiceDesiredClockConfig currentClock_{kSupportedClock};
+    AudioClockConfig currentClock_{kSupportedClock};
     AudioStreamRuntimeCaps currentCaps_{kDefaultRuntimeCaps};
     AudioStreamRuntimeCaps prepareCaps_{kDefaultRuntimeCaps};
     AudioStreamRuntimeCaps confirmCaps_{kDefaultRuntimeCaps};
@@ -505,7 +507,7 @@ class FakeDiceProtocol final : public IDeviceProtocol, public IDICEDuplexProtoco
     SharedCallLog& log_;
     IRMClient& irmClient_;
     AudioDuplexChannels lastChannels_{};
-    DiceDesiredClockConfig lastDesiredClock_{};
+    AudioClockConfig lastDesiredClock_{};
 
     mutable std::mutex mutex_;
     std::condition_variable cv_;
@@ -595,7 +597,7 @@ class DiceDuplexRestartCoordinatorTests : public ::testing::Test {
     std::shared_ptr<FakeDiceProtocol> protocol_;
     FakeDirectAudioBindingSource bindingSource_{};
     std::atomic<bool> cancel_{false};
-    DiceDuplexRestartCoordinator coordinator_;
+    AudioDuplexCoordinator coordinator_;
 };
 
 TEST_F(DiceDuplexRestartCoordinatorTests, ColdStartTransitionsIdleToRunning) {
@@ -1045,9 +1047,8 @@ TEST_F(DiceDuplexRestartCoordinatorTests, ProgramRxFailureRollsBackHostAndDevice
 }
 
 TEST_F(DiceDuplexRestartCoordinatorTests, UnsupportedClockConfigFailsBeforeHostAllocation) {
-    const DiceDesiredClockConfig unsupportedClock{
+    const AudioClockConfig unsupportedClock{
         .sampleRateHz = 44100U,
-        .clockSelect = kSupportedClock.clockSelect,
     };
 
     EXPECT_EQ(coordinator_.RequestClockConfig(kTestGuid, unsupportedClock,


### PR DESCRIPTION
## Summary

- promote the device-control and host-transport seams to `IDuplexDeviceControl` and `IIsochDuplexHostTransport`
- rename the lifecycle owner to `AudioDuplexCoordinator` while leaving mechanical file/type moves for FW-73
- replace the DICE clock-select value in shared code with a neutral 48 kHz `AudioClockConfig`
- confine the unchanged `GLOBAL_CLOCK_SELECT` encoding to the DICE/TCAT adapter and expose neutral clock-health fields
- update production call sites and focused host tests

## Why

FW-71 makes the duplex lifecycle reusable by non-DICE families without changing the existing DICE 48 kHz behavior. This unblocks the generic CMP/AV/C adapter work in FW-72 and later device-family bring-up.

## Behavior

The supported-rate policy remains 48 kHz-only. This PR does not add 44.1, 88.2, or 96 kHz handling. A regression test verifies that a neutral 48 kHz request maps to the existing DICE clock-select encoding and that 44.1 kHz is rejected.

## Validation

- `./build.sh --test --no-bump` — 1,255 C++ tests passed (6 reference-fixture tests skipped because this worktree has no local `references/` checkout)
- `./build.sh --no-bump` — Debug Xcode build completed successfully; existing repository warnings remain
- `git diff --check`