### PR TITLE
FW-75 Publish runtime DICE geometry for MultiMix

### DIFF
--- a/ASFWDriver/Audio/DriverKit/ASFWAudioDriverGraph.cpp
+++ b/ASFWDriver/Audio/DriverKit/ASFWAudioDriverGraph.cpp
@@ -150,13 +150,9 @@ kern_return_t BuildAudioGraph(ASFWAudioDriver& driver,
 
         const uint32_t rxChannels = profile->RxChannelCount();
         const uint32_t txChannels = profile->TxChannelCount();
-        if (rxChannels > 0) {
-            parsedConfig.inputChannelCount = rxChannels;
-        }
-        if (txChannels > 0) {
-            parsedConfig.outputChannelCount = txChannels;
-        }
-        parsedConfig.channelCount = std::max(parsedConfig.inputChannelCount, parsedConfig.outputChannelCount);
+        ASFW::Isoch::Audio::ApplyProfileChannelCountFallback(parsedConfig,
+                                                            rxChannels,
+                                                            txChannels);
 
         // Regenerate channel names for the updated channel counts. Prefers the
         // device's per-channel labels (published by the core side) and falls

--- a/ASFWDriver/Audio/DriverKit/Config/AudioDriverConfig.cpp
+++ b/ASFWDriver/Audio/DriverKit/Config/AudioDriverConfig.cpp
@@ -45,9 +45,11 @@ void ParseIdentityProperties(OSDictionary* properties, ParsedAudioDriverConfig& 
     }
     if (auto* inputChannels = OSDynamicCast(OSNumber, properties->getObject(Keys::kInputChannelCount))) {
         inOutConfig.inputChannelCount = inputChannels->unsigned32BitValue();
+        inOutConfig.hasExplicitInputChannelCount = true;
     }
     if (auto* outputChannels = OSDynamicCast(OSNumber, properties->getObject(Keys::kOutputChannelCount))) {
         inOutConfig.outputChannelCount = outputChannels->unsigned32BitValue();
+        inOutConfig.hasExplicitOutputChannelCount = true;
     }
 }
 

--- a/ASFWDriver/Audio/DriverKit/Config/AudioDriverConfig.hpp
+++ b/ASFWDriver/Audio/DriverKit/Config/AudioDriverConfig.hpp
@@ -46,6 +46,8 @@ struct ParsedAudioDriverConfig {
     uint32_t channelCount{kDefaultChannelCount};
     uint32_t inputChannelCount{kDefaultChannelCount};
     uint32_t outputChannelCount{kDefaultChannelCount};
+    bool hasExplicitInputChannelCount{false};
+    bool hasExplicitOutputChannelCount{false};
 
     double sampleRates[kMaxSampleRates]{};
     uint32_t sampleRateCount{1};
@@ -89,6 +91,12 @@ void ApplyBringupSingleFormatPolicy(ParsedAudioDriverConfig& inOutConfig);
 
 void ClampAudioDriverChannels(ParsedAudioDriverConfig& inOutConfig,
                               uint32_t maxSupportedChannels);
+
+// Device-published runtime counts win. Profile counts are fallback geometry for
+// older nubs that do not publish directional channel properties.
+void ApplyProfileChannelCountFallback(ParsedAudioDriverConfig& inOutConfig,
+                                      uint32_t profileInputChannels,
+                                      uint32_t profileOutputChannels);
 
 [[nodiscard]] const char* ScopeLabel(uint32_t scopeFourCC);
 

--- a/ASFWDriver/Audio/DriverKit/Config/AudioDriverConfigPolicy.cpp
+++ b/ASFWDriver/Audio/DriverKit/Config/AudioDriverConfigPolicy.cpp
@@ -93,6 +93,19 @@ void ClampAudioDriverChannels(ParsedAudioDriverConfig& inOutConfig,
                                         inOutConfig.outputChannelCount);
 }
 
+void ApplyProfileChannelCountFallback(ParsedAudioDriverConfig& inOutConfig,
+                                      uint32_t profileInputChannels,
+                                      uint32_t profileOutputChannels) {
+    if (!inOutConfig.hasExplicitInputChannelCount && profileInputChannels > 0) {
+        inOutConfig.inputChannelCount = profileInputChannels;
+    }
+    if (!inOutConfig.hasExplicitOutputChannelCount && profileOutputChannels > 0) {
+        inOutConfig.outputChannelCount = profileOutputChannels;
+    }
+    inOutConfig.channelCount = std::max(inOutConfig.inputChannelCount,
+                                        inOutConfig.outputChannelCount);
+}
+
 const char* ScopeLabel(uint32_t scopeFourCC) {
     switch (scopeFourCC) {
         case static_cast<uint32_t>('inpt'):

--- a/ASFWDriver/Audio/Model/ASFWAudioDevice.hpp
+++ b/ASFWDriver/Audio/Model/ASFWAudioDevice.hpp
@@ -63,18 +63,44 @@ struct ASFWAudioDevice {
         }
 
         auto deviceNameStr = OSSharedPtr(OSString::withCString(deviceName.c_str()), OSNoRetain);
+        auto channelCountNum = OSSharedPtr(OSNumber::withNumber(channelCount, 32), OSNoRetain);
         auto guidNum = OSSharedPtr(OSNumber::withNumber(guid, 64), OSNoRetain);
         auto vendorIdNum = OSSharedPtr(OSNumber::withNumber(vendorId, 32), OSNoRetain);
         auto modelIdNum = OSSharedPtr(OSNumber::withNumber(modelId, 32), OSNoRetain);
+        auto inputChannelCountNum =
+            OSSharedPtr(OSNumber::withNumber(inputChannelCount, 32), OSNoRetain);
+        auto outputChannelCountNum =
+            OSSharedPtr(OSNumber::withNumber(outputChannelCount, 32), OSNoRetain);
+        auto sampleRatesArray = OSSharedPtr(
+            OSArray::withCapacity(static_cast<uint32_t>(sampleRates.size())), OSNoRetain);
+        auto inputPlugNameStr = OSSharedPtr(OSString::withCString(inputPlugName.c_str()), OSNoRetain);
+        auto outputPlugNameStr = OSSharedPtr(OSString::withCString(outputPlugName.c_str()), OSNoRetain);
+        auto currentRateNum = OSSharedPtr(OSNumber::withNumber(currentSampleRate, 32), OSNoRetain);
 
-        if (!deviceNameStr || !guidNum || !vendorIdNum || !modelIdNum) {
+        if (!deviceNameStr || !channelCountNum || !guidNum || !vendorIdNum || !modelIdNum ||
+            !inputChannelCountNum || !outputChannelCountNum || !sampleRatesArray ||
+            !inputPlugNameStr || !outputPlugNameStr || !currentRateNum) {
             return false;
         }
 
+        for (uint32_t rate : sampleRates) {
+            auto rateNum = OSSharedPtr(OSNumber::withNumber(rate, 32), OSNoRetain);
+            if (rateNum) {
+                sampleRatesArray->setObject(rateNum.get());
+            }
+        }
+
         properties->setObject(PropertyKeys::kDeviceName, deviceNameStr.get());
+        properties->setObject(PropertyKeys::kChannelCount, channelCountNum.get());
+        properties->setObject(PropertyKeys::kSampleRates, sampleRatesArray.get());
         properties->setObject(PropertyKeys::kGuid, guidNum.get());
         properties->setObject(PropertyKeys::kVendorId, vendorIdNum.get());
         properties->setObject(PropertyKeys::kModelId, modelIdNum.get());
+        properties->setObject(PropertyKeys::kInputChannelCount, inputChannelCountNum.get());
+        properties->setObject(PropertyKeys::kOutputChannelCount, outputChannelCountNum.get());
+        properties->setObject(PropertyKeys::kInputPlugName, inputPlugNameStr.get());
+        properties->setObject(PropertyKeys::kOutputPlugName, outputPlugNameStr.get());
+        properties->setObject(PropertyKeys::kCurrentSampleRate, currentRateNum.get());
 
         // Per-channel device labels (optional). The audio side reads these in
         // channel order and prefers them over synthesized names.

--- a/ASFWDriver/Audio/Protocols/Backends/DiceAudioBackend.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceAudioBackend.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 ASFireWire Project
 
 #include "DiceAudioBackend.hpp"
+#include "DiceRuntimeDeviceConfig.hpp"
 
 #include "../../../Audio/Core/AudioEndpointRuntime.hpp"
 #include "../../../Audio/Core/AudioRuntimeRegistry.hpp"
@@ -438,6 +439,17 @@ void DiceAudioBackend::EnsureNubForGuid(uint64_t guid) noexcept {
             return;
         }
         if (protocol) {
+            AudioStreamRuntimeCaps caps{};
+            if (protocol->GetRuntimeAudioStreamCaps(caps) &&
+                ApplyDiceRuntimeCapsToDeviceConfig(caps, dev)) {
+                ASFW_LOG(Audio,
+                         "DiceAudioBackend::EnsureNubForGuid: applied runtime geometry rate=%u in=%u out=%u (GUID=0x%016llx)",
+                         dev.currentSampleRate,
+                         dev.inputChannelCount,
+                         dev.outputChannelCount,
+                         guid);
+            }
+
             std::vector<std::string> inNames;
             std::vector<std::string> outNames;
             if (protocol->GetChannelLabels(inNames, outNames)) {

--- a/ASFWDriver/Audio/Protocols/Backends/DiceRuntimeDeviceConfig.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceRuntimeDeviceConfig.hpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 ASFireWire Project
+//
+// DiceRuntimeDeviceConfig.hpp - Publish discovered DICE geometry to the audio endpoint model
+
+#pragma once
+
+#include "../../Model/ASFWAudioDevice.hpp"
+#include "../AudioTypes.hpp"
+
+#include <algorithm>
+
+namespace ASFW::Audio {
+
+// DICE stream geometry is discovered from the device's TX/RX sections. Keep
+// that runtime result as the source of truth for the HAL-facing endpoint rather
+// than replacing it with the generic profile's stereo fallback.
+[[nodiscard]] inline bool ApplyDiceRuntimeCapsToDeviceConfig(
+    const AudioStreamRuntimeCaps& caps,
+    Model::ASFWAudioDevice& config) {
+    if (caps.sampleRateHz == 0 || caps.hostInputPcmChannels == 0 ||
+        caps.hostOutputPcmChannels == 0) {
+        return false;
+    }
+
+    config.inputChannelCount = caps.hostInputPcmChannels;
+    config.outputChannelCount = caps.hostOutputPcmChannels;
+    config.channelCount = std::max(config.inputChannelCount, config.outputChannelCount);
+    config.currentSampleRate = caps.sampleRateHz;
+    config.sampleRates.assign(1, caps.sampleRateHz);
+    return true;
+}
+
+} // namespace ASFW::Audio

--- a/tests/audio/AudioDriverConfigPolicyTests.cpp
+++ b/tests/audio/AudioDriverConfigPolicyTests.cpp
@@ -70,6 +70,32 @@ TEST(AudioDriverConfigPolicyTests, ClampChannelsRespectsMaxSupportedForExplicitD
     EXPECT_EQ(config.channelCount, 16u);
 }
 
+TEST(AudioDriverConfigPolicyTests, RuntimeDirectionalCountsWinOverProfileFallback) {
+    ParsedAudioDriverConfig config{};
+    ASFW::Isoch::Audio::InitializeAudioDriverConfigDefaults(config);
+    config.inputChannelCount = 16;
+    config.outputChannelCount = 2;
+    config.hasExplicitInputChannelCount = true;
+    config.hasExplicitOutputChannelCount = true;
+
+    ASFW::Isoch::Audio::ApplyProfileChannelCountFallback(config, 2, 2);
+
+    EXPECT_EQ(config.inputChannelCount, 16U);
+    EXPECT_EQ(config.outputChannelCount, 2U);
+    EXPECT_EQ(config.channelCount, 16U);
+}
+
+TEST(AudioDriverConfigPolicyTests, ProfileCountsRemainFallbackForLegacyNubs) {
+    ParsedAudioDriverConfig config{};
+    ASFW::Isoch::Audio::InitializeAudioDriverConfigDefaults(config);
+
+    ASFW::Isoch::Audio::ApplyProfileChannelCountFallback(config, 8, 6);
+
+    EXPECT_EQ(config.inputChannelCount, 8U);
+    EXPECT_EQ(config.outputChannelCount, 6U);
+    EXPECT_EQ(config.channelCount, 8U);
+}
+
 TEST(AudioDriverConfigPolicyTests, BuildFallbackBoolControlsMapsPhantomMask) {
     ParsedAudioDriverConfig config{};
     ASFW::Isoch::Audio::InitializeAudioDriverConfigDefaults(config);

--- a/tests/devices/CMakeLists.txt
+++ b/tests/devices/CMakeLists.txt
@@ -60,6 +60,10 @@ add_device_test(DuplexStreamProfileTests
     DuplexStreamProfileTests.cpp
 )
 
+add_device_test(DiceRuntimeDeviceConfigTests
+    DiceRuntimeDeviceConfigTests.cpp
+)
+
 # FW-65: sync/async bridge (WaitForAsyncResult) characterization tests (header-only)
 add_device_test(WaitForAsyncResultTests
     WaitForAsyncResultTests.cpp
@@ -100,4 +104,3 @@ add_device_test(ApogeeDuetVendorCmdTests
     ApogeeDuetVendorCmdTests.cpp
     "${ASFW_DRIVER_DIR}/Audio/Protocols/Oxford/Apogee/ApogeeDuetProtocol.cpp"
 )
-

--- a/tests/devices/DiceRuntimeDeviceConfigTests.cpp
+++ b/tests/devices/DiceRuntimeDeviceConfigTests.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+
+#include "Audio/Protocols/Backends/DiceRuntimeDeviceConfig.hpp"
+
+namespace {
+
+using ASFW::Audio::ApplyDiceRuntimeCapsToDeviceConfig;
+using ASFW::Audio::AudioStreamRuntimeCaps;
+using ASFW::Audio::Model::ASFWAudioDevice;
+
+TEST(DiceRuntimeDeviceConfigTests, AppliesDiscoveredPcmGeometryAndRateWithoutChannelTable) {
+    ASFWAudioDevice config{};
+    config.deviceName = "Generic DICE";
+
+    const AudioStreamRuntimeCaps caps{
+        .hostInputPcmChannels = 16,
+        .hostOutputPcmChannels = 2,
+        .deviceToHostAm824Slots = 16,
+        .hostToDeviceAm824Slots = 2,
+        .sampleRateHz = 48000,
+        .deviceToHostStreamCount = 2,
+        .hostToDeviceStreamCount = 1,
+    };
+
+    ASSERT_TRUE(ApplyDiceRuntimeCapsToDeviceConfig(caps, config));
+    EXPECT_EQ(config.inputChannelCount, 16U);
+    EXPECT_EQ(config.outputChannelCount, 2U);
+    EXPECT_EQ(config.channelCount, 16U);
+    EXPECT_EQ(config.currentSampleRate, 48000U);
+    ASSERT_EQ(config.sampleRates.size(), 1U);
+    EXPECT_EQ(config.sampleRates[0], 48000U);
+    EXPECT_EQ(config.deviceName, "Generic DICE");
+}
+
+TEST(DiceRuntimeDeviceConfigTests, RejectsPartialCapsWithoutChangingFallbackConfig) {
+    ASFWAudioDevice config{};
+    const ASFWAudioDevice before = config;
+    const AudioStreamRuntimeCaps partial{
+        .hostInputPcmChannels = 16,
+        .hostOutputPcmChannels = 0,
+        .sampleRateHz = 48000,
+    };
+
+    EXPECT_FALSE(ApplyDiceRuntimeCapsToDeviceConfig(partial, config));
+    EXPECT_EQ(config.inputChannelCount, before.inputChannelCount);
+    EXPECT_EQ(config.outputChannelCount, before.outputChannelCount);
+    EXPECT_EQ(config.channelCount, before.channelCount);
+    EXPECT_EQ(config.currentSampleRate, before.currentSampleRate);
+    EXPECT_EQ(config.sampleRates, before.sampleRates);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

- publish runtime-discovered DICE PCM channel counts and sample rate into the audio endpoint/nub model
- restore channel-count, rate, and plug-name properties consumed by the AudioDriverKit side
- preserve explicit asymmetric runtime channel counts instead of replacing them with generic profile fallbacks
- retain the existing FW-74 Alesis one-capture-stream clamp and standard AM824 path
- add focused runtime-geometry and fallback-policy tests

## Why

The Alesis identity, DICE/TCAT routing, and phantom second-capture-stream clamp were already present, but the discovered TCAT geometry stopped before nub publication. A MultiMix could therefore be exposed to CoreAudio with the generic 2-in/2-out fallback even when the device reported wider asymmetric geometry.

## Behavior

No channel table is added. PCM counts, AM824 slots, and sample rate remain device-discovered. The driver remains 48 kHz-only and MIDI remains out of scope.

## Validation

- `./build.sh --test-only --no-bump` — 1,259 C++ tests passed; 6 local-reference fixture tests skipped
- `./build.sh --no-bump` — Debug Xcode build succeeded with the repository's existing warnings
- `git diff --check`

## Hardware gate

This draft does **not** claim FW-75 complete. MultiMix enumeration, published channel geometry, simultaneous 48 kHz playback/capture, single capture-stream programming, teardown, and reconnect/bus-reset recovery still require hardware validation.