### PR TITLE
FW-72 Route AV/C (Apogee Duet) duplex through the neutral coordinator

### DIFF
--- a/ASFWDriver/Audio/Core/AudioCoordinator.cpp
+++ b/ASFWDriver/Audio/Core/AudioCoordinator.cpp
@@ -40,7 +40,7 @@ AudioCoordinator::~AudioCoordinator() noexcept {
 }
 
 void AudioCoordinator::SetCMPClient(ASFW::CMP::CMPClient* client) noexcept {
-    avc_.SetCMPClient(client);
+    runtime_.SetCMPClient(client);
 }
 
 void AudioCoordinator::OnDeviceAdded(std::shared_ptr<Discovery::FWDevice> device) {
@@ -332,6 +332,7 @@ IOReturn AudioCoordinator::RequestClockConfig(
 void AudioCoordinator::BeginTeardown() noexcept {
     ASFW_LOG(Audio, "AudioCoordinator: BeginTeardown");
     dice_.BeginTeardown();
+    avc_.BeginTeardown();
 
     if (lock_) {
         IOLockLock(lock_);

--- a/ASFWDriver/Audio/Core/AudioRuntimeRegistry.cpp
+++ b/ASFWDriver/Audio/Core/AudioRuntimeRegistry.cpp
@@ -105,7 +105,8 @@ std::shared_ptr<IDeviceProtocol> AudioRuntimeRegistry::EnsureForDevice(
     // applied (recognized devices are precisely those with a non-None integration
     // mode). No protocol is created, and nothing is logged, for unknown devices.
     auto created = DeviceProtocolFactory::Create(
-        record.vendorId, record.modelId, *busOps, *busInfo, *operationalNodeId, irmClient);
+        record.vendorId, record.modelId, *busOps, *busInfo, *operationalNodeId, irmClient,
+        cmpClient_);
     if (!created) {
         return nullptr;
     }

--- a/ASFWDriver/Audio/Core/AudioRuntimeRegistry.hpp
+++ b/ASFWDriver/Audio/Core/AudioRuntimeRegistry.hpp
@@ -28,6 +28,10 @@ namespace ASFW::IRM {
 class IRMClient;
 }
 
+namespace ASFW::CMP {
+class CMPClient;
+}
+
 namespace ASFW::Discovery {
 struct DeviceRecord;
 }
@@ -52,6 +56,10 @@ public:
     [[nodiscard]] std::shared_ptr<AudioEndpointRuntime> FindEndpointRuntime(uint64_t guid) noexcept;
     [[nodiscard]] std::shared_ptr<AudioEndpointRuntime> EnsureEndpointRuntime(uint64_t guid) noexcept;
 
+    // Set before discovery creates AV/C protocol instances. The registry does not
+    // own the client; DriverContext owns it for the service lifetime.
+    void SetCMPClient(CMP::CMPClient* cmpClient) noexcept { cmpClient_ = cmpClient; }
+
     // Create-on-demand for a known device. Idempotent: an existing instance is
     // returned without re-creating (covers re-scan on device resume). Mirrors the
     // former DeviceRegistry::MaybeCreateKnownProtocol gate + DeviceProtocolFactory
@@ -75,6 +83,7 @@ private:
     IOLock* lock_{nullptr};
     std::unordered_map<uint64_t, std::shared_ptr<IDeviceProtocol>> protocolsByGuid_;
     std::unordered_map<uint64_t, std::shared_ptr<AudioEndpointRuntime>> endpointsByGuid_;
+    CMP::CMPClient* cmpClient_{nullptr};
 };
 
 } // namespace ASFW::Audio

--- a/ASFWDriver/Audio/Protocols/Backends/AVCAudioBackend.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/AVCAudioBackend.cpp
@@ -5,27 +5,12 @@
 
 #include "../../../Audio/Core/AudioEndpointRuntime.hpp"
 #include "../../../Audio/Core/AudioRuntimeRegistry.hpp"
-#include "../../../Common/DriverKitOwnership.hpp"
 #include "../../../Logging/Logging.hpp"
 
 #include <DriverKit/IOLib.h>
-#include <DriverKit/IOBufferMemoryDescriptor.h>
-#include <DriverKit/OSSharedPtr.h>
 #include <net.mrmidi.ASFW.ASFWDriver/ASFWAudioNub.h>
 
 namespace ASFW::Audio {
-
-namespace {
-
-constexpr uint8_t kDefaultIrChannel = 0;
-constexpr uint8_t kDefaultItChannel = 1;
-
-inline uint8_t ReadLocalSid(Driver::HardwareInterface& hw) noexcept {
-    // OHCI NodeID register: low 6 bits are node number.
-    return static_cast<uint8_t>(hw.ReadNodeID() & 0x3Fu);
-}
-
-} // namespace
 
 AVCAudioBackend::AVCAudioBackend(AudioNubPublisher& publisher,
                                  Discovery::DeviceRegistry& registry,
@@ -35,8 +20,18 @@ AVCAudioBackend::AVCAudioBackend(AudioNubPublisher& publisher,
     : publisher_(publisher)
     , registry_(registry)
     , runtime_(runtime)
-    , isoch_(isoch)
-    , hardware_(hardware) {
+    , hardware_(hardware)
+    , hostTransport_(isoch)
+    , duplexCoordinator_(
+          registry,
+          runtime,
+          hostTransport_,
+          hardware,
+          &stopping_,
+          [this](uint64_t guid) -> ASFW::Audio::Runtime::IDirectAudioBindingSource* {
+              auto endpoint = runtime_.FindEndpointRuntime(guid);
+              return endpoint ? endpoint.get() : nullptr;
+          }) {
     lock_ = IOLockAlloc();
     if (!lock_) {
         ASFW_LOG_ERROR(Audio, "AVCAudioBackend: Failed to allocate lock");
@@ -80,6 +75,7 @@ void AVCAudioBackend::OnDeviceRemoved(uint64_t guid) noexcept {
                  guid);
     }
     publisher_.TerminateNub(guid, "AVC-Removed");
+    duplexCoordinator_.ClearSession(guid);
 
     if (lock_) {
         IOLockLock(lock_);
@@ -91,21 +87,33 @@ void AVCAudioBackend::OnDeviceRemoved(uint64_t guid) noexcept {
     }
 }
 
-bool AVCAudioBackend::WaitForCMP(std::atomic<bool>& done,
-                                 std::atomic<ASFW::CMP::CMPStatus>& status,
-                                 uint32_t timeoutMs) noexcept {
-    constexpr uint32_t kPollMs = 5;
-    for (uint32_t waited = 0; waited < timeoutMs; waited += kPollMs) {
-        if (done.load(std::memory_order_acquire)) {
-            return status.load(std::memory_order_acquire) == ASFW::CMP::CMPStatus::Success;
-        }
-        IOSleep(kPollMs);
+void AVCAudioBackend::BeginTeardown() noexcept {
+    if (stopping_.load(std::memory_order_acquire)) {
+        return;
     }
-    return false;
+
+    uint64_t activeGuid = 0;
+    if (lock_) {
+        IOLockLock(lock_);
+        activeGuid = activeGuid_;
+        IOLockUnlock(lock_);
+    }
+    if (activeGuid != 0) {
+        // Quiesce while FCP/CMP and hardware are still alive. The AV/C profile
+        // preserves iPCR -> IT -> oPCR -> IR teardown ordering here too.
+        (void)duplexCoordinator_.StopStreaming(activeGuid);
+    }
+
+    const bool wasStopping = stopping_.exchange(true, std::memory_order_acq_rel);
+    (void)hostTransport_.StopAll();
+    ASFW_LOG(Audio,
+             "AVCAudioBackend: BeginTeardown stopping=true already=%u",
+             wasStopping ? 1U : 0U);
 }
 
 IOReturn AVCAudioBackend::StartStreaming(uint64_t guid) noexcept {
     if (guid == 0) return kIOReturnBadArgument;
+    if (stopping_.load(std::memory_order_acquire)) return kIOReturnAborted;
 
     if (lock_) {
         IOLockLock(lock_);
@@ -118,6 +126,9 @@ IOReturn AVCAudioBackend::StartStreaming(uint64_t guid) noexcept {
                              active);
             return kIOReturnBusy;
         }
+        // Claim the backend before leaving the lock. The coordinator performs
+        // blocking setup, so delaying this assignment until it returns would
+        // allow a second GUID to begin concurrently.
         activeGuid_ = guid;
         IOLockUnlock(lock_);
     }
@@ -138,11 +149,6 @@ IOReturn AVCAudioBackend::StartStreaming(uint64_t guid) noexcept {
         return status;
     };
 
-    if (!cmpClient_) {
-        ASFW_LOG(Audio, "AVCAudioBackend: StartStreaming not ready (CMPClient missing)");
-        return failStart(kIOReturnNotReady, "CMPClient");
-    }
-
     Model::ASFWAudioDevice config{};
     bool hasConfig = false;
     if (lock_) {
@@ -159,15 +165,10 @@ IOReturn AVCAudioBackend::StartStreaming(uint64_t guid) noexcept {
         return failStart(kIOReturnNotReady, "config");
     }
 
-    const auto* record = registry_.FindByGuid(guid);
-    if (!record) {
+    if (!registry_.FindByGuid(guid)) {
         ASFW_LOG(Audio, "AVCAudioBackend: StartStreaming not ready (no device record) GUID=0x%016llx", guid);
         return failStart(kIOReturnNotReady, "device record");
     }
-
-    // CMP targets PCR space on the remote device (AV/C family policy).
-    cmpClient_->SetDeviceNode(static_cast<uint8_t>(record->nodeId),
-                              static_cast<ASFW::IRM::Generation>(record->gen));
 
     auto* nub = publisher_.GetNub(guid);
     if (!nub) {
@@ -176,81 +177,17 @@ IOReturn AVCAudioBackend::StartStreaming(uint64_t guid) noexcept {
         if (!nub) return failStart(kIOReturnNotReady, "nub");
     }
 
-    auto endpoint = runtime_.FindEndpointRuntime(guid);
-    auto* bindingSource = endpoint.get();
-    if (!bindingSource) {
+    const auto endpoint = runtime_.FindEndpointRuntime(guid);
+    if (!endpoint) {
         return failStart(kIOReturnNotReady, "direct binding source");
     }
     if (!endpoint->HasCompleteDirectAudioMemory()) {
         return failStart(kIOReturnNotReady, "direct memory");
     }
 
-    // Start IR first so capture packets don't get dropped.
-    {
-        const kern_return_t krRx = isoch_.StartReceive(kDefaultIrChannel,
-                                                       hardware_,
-                                                       bindingSource);
-        if (krRx != kIOReturnSuccess) {
-            ASFW_LOG_ERROR(Audio, "AVCAudioBackend: StartReceive failed GUID=0x%016llx kr=0x%x", guid, krRx);
-            return failStart(krRx, "StartReceive");
-        }
-    }
-
-    // CMP connect oPCR[0] (device->host).
-    {
-        std::atomic<bool> done{false};
-        std::atomic<ASFW::CMP::CMPStatus> status{ASFW::CMP::CMPStatus::Failed};
-        cmpClient_->ConnectOPCR(0, [&done, &status](ASFW::CMP::CMPStatus s) {
-            status.store(s, std::memory_order_release);
-            done.store(true, std::memory_order_release);
-        });
-
-        if (!WaitForCMP(done, status, 250)) {
-            const auto s = status.load(std::memory_order_acquire);
-            ASFW_LOG_ERROR(Audio,
-                           "AVCAudioBackend: CMP ConnectOPCR failed GUID=0x%016llx status=%{public}s(%d)",
-                           guid,
-                           ASFW::IRM::ToString(s),
-                           static_cast<int>(s));
-            (void)isoch_.StopReceive();
-            return failStart(kIOReturnError, "ConnectOPCR");
-        }
-    }
-
-    // Start IT transport (host->device) and then connect iPCR[0].
-    {
-        const uint8_t sid = ReadLocalSid(hardware_);
-
-        const kern_return_t krTx = isoch_.StartTransmit(kDefaultItChannel,
-                                                        hardware_,
-                                                        sid);
-        if (krTx != kIOReturnSuccess) {
-            ASFW_LOG_ERROR(Audio, "AVCAudioBackend: StartTransmit failed GUID=0x%016llx kr=0x%x", guid, krTx);
-            (void)isoch_.StopReceive();
-            // Best-effort: disconnect oPCR.
-            cmpClient_->DisconnectOPCR(0, [](ASFW::CMP::CMPStatus) { /* best-effort, result ignored */ });
-            return failStart(krTx, "StartTransmit");
-        }
-
-        std::atomic<bool> done{false};
-        std::atomic<ASFW::CMP::CMPStatus> status{ASFW::CMP::CMPStatus::Failed};
-        cmpClient_->ConnectIPCR(0, kDefaultItChannel, [&done, &status](ASFW::CMP::CMPStatus s) {
-            status.store(s, std::memory_order_release);
-            done.store(true, std::memory_order_release);
-        });
-
-        if (!WaitForCMP(done, status, 250)) {
-            const auto s = status.load(std::memory_order_acquire);
-            ASFW_LOG_ERROR(Audio,
-                           "AVCAudioBackend: CMP ConnectIPCR failed GUID=0x%016llx status=%{public}s(%d)",
-                           guid,
-                           ASFW::IRM::ToString(s),
-                           static_cast<int>(s));
-            (void)isoch_.StopTransmit();
-            (void)isoch_.StopReceive();
-            cmpClient_->DisconnectOPCR(0, [](ASFW::CMP::CMPStatus) { /* best-effort, result ignored */ });
-            return failStart(kIOReturnError, "ConnectIPCR");
-        }
+    const IOReturn startStatus = duplexCoordinator_.StartStreaming(guid);
+    if (startStatus != kIOReturnSuccess) {
+        return failStart(startStatus, "AudioDuplexCoordinator");
     }
 
     ASFW_LOG(Audio,
@@ -265,6 +202,7 @@ IOReturn AVCAudioBackend::StartStreaming(uint64_t guid) noexcept {
 
 IOReturn AVCAudioBackend::StopStreaming(uint64_t guid) noexcept {
     if (guid == 0) return kIOReturnBadArgument;
+    if (stopping_.load(std::memory_order_acquire)) return kIOReturnAborted;
 
     if (lock_) {
         IOLockLock(lock_);
@@ -287,51 +225,8 @@ IOReturn AVCAudioBackend::StopStreaming(uint64_t guid) noexcept {
         IOLockUnlock(lock_);
     }
 
-    // Stop transport regardless of CMP availability (best-effort).
-    if (!cmpClient_) {
-        (void)isoch_.StopTransmit();
-        (void)isoch_.StopReceive();
-        if (lock_) {
-            IOLockLock(lock_);
-            if (activeGuid_ == guid) {
-                activeGuid_ = 0;
-            }
-            IOLockUnlock(lock_);
-        }
-        return kIOReturnSuccess;
-    }
-
-    const auto* record = registry_.FindByGuid(guid);
-    if (record) {
-        cmpClient_->SetDeviceNode(static_cast<uint8_t>(record->nodeId),
-                                  static_cast<ASFW::IRM::Generation>(record->gen));
-    }
-
-    // Disconnect iPCR first (host->device), then stop IT.
-    {
-        std::atomic<bool> done{false};
-        std::atomic<ASFW::CMP::CMPStatus> status{ASFW::CMP::CMPStatus::Failed};
-        cmpClient_->DisconnectIPCR(0, [&done, &status](ASFW::CMP::CMPStatus s) {
-            status.store(s, std::memory_order_release);
-            done.store(true, std::memory_order_release);
-        });
-        (void)WaitForCMP(done, status, 250);
-    }
-
-    (void)isoch_.StopTransmit();
-
-    // Disconnect oPCR, then stop IR.
-    {
-        std::atomic<bool> done{false};
-        std::atomic<ASFW::CMP::CMPStatus> status{ASFW::CMP::CMPStatus::Failed};
-        cmpClient_->DisconnectOPCR(0, [&done, &status](ASFW::CMP::CMPStatus s) {
-            status.store(s, std::memory_order_release);
-            done.store(true, std::memory_order_release);
-        });
-        (void)WaitForCMP(done, status, 250);
-    }
-
-    (void)isoch_.StopReceive();
+    const IOReturn stopStatus = duplexCoordinator_.StopStreaming(guid);
+    if (stopStatus != kIOReturnSuccess) return stopStatus;
 
     if (lock_) {
         IOLockLock(lock_);

--- a/ASFWDriver/Audio/Protocols/Backends/AVCAudioBackend.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/AVCAudioBackend.hpp
@@ -7,14 +7,16 @@
 #pragma once
 
 #include "IAudioBackend.hpp"
+#include "DiceDuplexRestartCoordinator.hpp"
+#include "DiceHostTransport.hpp"
 
 #include "../../../Audio/Core/AudioNubPublisher.hpp"
 
 #include "../../../Discovery/DeviceRegistry.hpp"
 #include "../../../Hardware/HardwareInterface.hpp"
 #include "../../../Isoch/IsochService.hpp"
-#include "../../../Protocols/AVC/CMP/CMPClient.hpp"
 
+#include <atomic>
 #include <cstdint>
 #include <unordered_map>
 
@@ -36,26 +38,21 @@ public:
 
     [[nodiscard]] const char* Name() const noexcept override { return "AV/C"; }
 
-    void SetCMPClient(ASFW::CMP::CMPClient* client) noexcept { cmpClient_ = client; }
-
     void OnAudioConfigurationReady(uint64_t guid, const Model::ASFWAudioDevice& config) noexcept;
     void OnDeviceRemoved(uint64_t guid) noexcept;
+    void BeginTeardown() noexcept;
 
     [[nodiscard]] IOReturn StartStreaming(uint64_t guid) noexcept override;
     [[nodiscard]] IOReturn StopStreaming(uint64_t guid) noexcept override;
 
 private:
-    [[nodiscard]] bool WaitForCMP(std::atomic<bool>& done,
-                                  std::atomic<ASFW::CMP::CMPStatus>& status,
-                                  uint32_t timeoutMs) noexcept;
-
     AudioNubPublisher& publisher_;
     Discovery::DeviceRegistry& registry_;
     AudioRuntimeRegistry& runtime_;
-    Driver::IsochService& isoch_;
     Driver::HardwareInterface& hardware_;
-
-    ASFW::CMP::CMPClient* cmpClient_{nullptr};
+    DiceIsochHostTransport hostTransport_;
+    std::atomic<bool> stopping_{false};
+    AudioDuplexCoordinator duplexCoordinator_;
 
     IOLock* lock_{nullptr};
     std::unordered_map<uint64_t, Model::ASFWAudioDevice> configByGuid_{};

--- a/ASFWDriver/Audio/Protocols/Backends/DiceAudioBackend.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceAudioBackend.cpp
@@ -113,6 +113,11 @@ void DiceAudioBackend::BeginTeardown() noexcept {
 #endif
     }
 
+    // Releases every generic-runner IRM reservation while the IRM client is
+    // still alive. IsochService::StopAll remains idempotent when the outer
+    // service teardown invokes it again.
+    (void)hostTransport_.StopAll();
+
     const uint64_t endMs = UptimeMilliseconds();
     const uint64_t drainMs = endMs >= startMs ? endMs - startMs : 0;
     const uint64_t coordinatorAborted =

--- a/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceDuplexRestartCoordinator.cpp
@@ -1094,6 +1094,27 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
                                       DuplexRestartFailureCause::kGlobalClockLock);
     }
 
+    // AV/C/CMP profiles retain the historical interleave in which the host
+    // context is running before the matching PCR connection is established.
+    if (streamProfile.startOrder.startReceiveBeforeDeviceRx) {
+        if (abortIfTeardown("StartingHostReceiveBeforeDeviceRx")) {
+            return kIOReturnAborted;
+        }
+        const kern_return_t status = hostTransport_.StartPreparedReceive();
+        if (status != kIOReturnSuccess) {
+            return rollbackToFailure(status, DuplexRestartPhase::kStartingHostReceive,
+                                     DuplexRestartFailureCause::kStartReceive);
+        }
+        if (!IsRestartEpochCurrent(guid, restartId, topologyGeneration)) {
+            return rollbackToInvalidation(kIOReturnAborted,
+                                          DuplexRestartPhase::kStartingHostReceive,
+                                          DuplexRestartFailureCause::kStartReceive);
+        }
+        SetSessionPhase(session, DuplexRestartPhase::kStartingHostReceive);
+        session.hostReceiveStarted = true;
+        StoreSession(session);
+    }
+
     if (abortIfTeardown("ProgrammingDeviceRx")) {
         return kIOReturnAborted;
     }
@@ -1119,6 +1140,25 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
                               : session.runtimeCaps;
     SetSessionPhase(session, DuplexRestartPhase::kDeviceRxProgrammed);
     StoreSession(session);
+
+    if (streamProfile.startOrder.startTransmitBeforeDeviceTx) {
+        if (abortIfTeardown("StartingHostTransmitBeforeDeviceTx")) {
+            return kIOReturnAborted;
+        }
+        const kern_return_t status = hostTransport_.StartPreparedTransmit();
+        if (status != kIOReturnSuccess) {
+            return rollbackToFailure(status, DuplexRestartPhase::kStartingHostTransmit,
+                                     DuplexRestartFailureCause::kStartTransmit);
+        }
+        if (!IsRestartEpochCurrent(guid, restartId, topologyGeneration)) {
+            return rollbackToInvalidation(kIOReturnAborted,
+                                          DuplexRestartPhase::kStartingHostTransmit,
+                                          DuplexRestartFailureCause::kStartTransmit);
+        }
+        SetSessionPhase(session, DuplexRestartPhase::kStartingHostTransmit);
+        session.hostTransmitStarted = true;
+        StoreSession(session);
+    }
 
     if (abortIfTeardown("ProgrammingDeviceTx")) {
         return kIOReturnAborted;
@@ -1157,6 +1197,9 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
     // transmit begins, avoiding a window without the expected clock reference.
     for (const DuplexHostDirection direction : streamProfile.startOrder.startOrder) {
         if (direction == DuplexHostDirection::kReceive) {
+            if (streamProfile.startOrder.startReceiveBeforeDeviceRx) {
+                continue;
+            }
             if (abortIfTeardown("StartingHostReceive")) {
                 return kIOReturnAborted;
             }
@@ -1177,6 +1220,9 @@ IOReturn DuplexStartTransaction::Run(const StartRequest& request) noexcept {
             continue;
         }
 
+        if (streamProfile.startOrder.startTransmitBeforeDeviceTx) {
+            continue;
+        }
         if (abortIfTeardown("StartingHostTransmit")) {
             return kIOReturnAborted;
         }
@@ -1314,8 +1360,6 @@ IOReturn DuplexStartTransaction::Stop(const StopRequest& request) noexcept {
         dependencies_.sessionStore.StoreSession(updatedSession);
     };
 
-    (void)record;
-
     if (TeardownRequested()) {
         RecordTeardownAbort("RunDuplexStop", guid);
         return kIOReturnAborted;
@@ -1326,19 +1370,51 @@ IOReturn DuplexStartTransaction::Stop(const StopRequest& request) noexcept {
     SetSessionState(session, DuplexRestartState::kStopping, "stop_requested");
     StoreSession(session);
 
-    const kern_return_t hostStatus = hostTransport_.StopAll();
-    if (hostStatus != kIOReturnSuccess) {
-        result = hostStatus;
-    }
+    const DuplexStreamProfile profile =
+        DuplexStreamProfileResolver::Resolve(record, session.runtimeCaps, session.channels);
+    if (profile.stopOrder
+            .disconnectPlaybackThenStopTransmitThenDisconnectCaptureThenStopReceive) {
+        const auto disconnectPlayback = WaitForAsyncResult<bool>(
+            [&](auto callback) {
+                deviceControl.DisconnectPlayback(
+                    [callback = std::move(callback)](IOReturn status) mutable {
+                        callback(status, true);
+                    });
+            },
+            dependencies_.syncBridgeTimeoutMs, kIOReturnTimeout, dependencies_.cancel);
+        (void)disconnectPlayback;
+        (void)hostTransport_.StopPreparedTransmit();
 
-    const IOReturn deviceStatus = deviceControl.StopDuplex();
-    if (deviceStatus == kIOReturnAborted && TeardownRequested()) {
-        RecordTeardownAbort("DeviceStop", guid);
-        return kIOReturnAborted;
-    }
-    if (deviceStatus != kIOReturnSuccess && deviceStatus != kIOReturnUnsupported &&
-        result == kIOReturnSuccess) {
-        result = deviceStatus;
+        const auto disconnectCapture = WaitForAsyncResult<bool>(
+            [&](auto callback) {
+                deviceControl.DisconnectCapture(
+                    [callback = std::move(callback)](IOReturn status) mutable {
+                        callback(status, true);
+                    });
+            },
+            dependencies_.syncBridgeTimeoutMs, kIOReturnTimeout, dependencies_.cancel);
+        (void)disconnectCapture;
+        (void)hostTransport_.StopPreparedReceive();
+
+        // Contexts are already stopped. StopAll performs the neutral ownership
+        // cleanup (reserved profile + active GUID) without another wire action.
+        (void)hostTransport_.StopAll();
+    } else {
+        // DICE retains its original teardown contract unchanged.
+        const kern_return_t hostStatus = hostTransport_.StopAll();
+        if (hostStatus != kIOReturnSuccess) {
+            result = hostStatus;
+        }
+
+        const IOReturn deviceStatus = deviceControl.StopDuplex();
+        if (deviceStatus == kIOReturnAborted && TeardownRequested()) {
+            RecordTeardownAbort("DeviceStop", guid);
+            return kIOReturnAborted;
+        }
+        if (deviceStatus != kIOReturnSuccess && deviceStatus != kIOReturnUnsupported &&
+            result == kIOReturnSuccess) {
+            result = deviceStatus;
+        }
     }
 
     if (result == kIOReturnSuccess) {

--- a/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.cpp
@@ -4,7 +4,6 @@
 #include "DiceHostTransport.hpp"
 
 #include "../../../Common/DriverKitOwnership.hpp"
-
 #include <net.mrmidi.ASFW.ASFWDriver/ASFWAudioNub.h>
 #include <utility>
 
@@ -16,6 +15,7 @@ void DiceIsochHostTransport::SetTimingLossCallback(
 }
 
 kern_return_t DiceIsochHostTransport::BeginSplitDuplex(uint64_t guid) noexcept {
+    reservations_.ReleaseAll();
     return isoch_.BeginSplitDuplex(guid);
 }
 
@@ -23,14 +23,34 @@ kern_return_t DiceIsochHostTransport::ReservePlaybackResources(uint64_t guid,
                                                                ::ASFW::IRM::IRMClient& irmClient,
                                                                uint8_t channel,
                                                                uint32_t bandwidthUnits) noexcept {
-    return isoch_.ReservePlaybackResources(guid, irmClient, channel, bandwidthUnits);
+    const kern_return_t status =
+        reservations_.ReservePlayback(irmClient, channel, bandwidthUnits);
+    if (status != kIOReturnSuccess) {
+        return status;
+    }
+    const kern_return_t bookkeeping =
+        isoch_.ReservePlaybackResources(guid, irmClient, channel, bandwidthUnits);
+    if (bookkeeping != kIOReturnSuccess) {
+        reservations_.ReleaseAll();
+    }
+    return bookkeeping;
 }
 
 kern_return_t DiceIsochHostTransport::ReserveCaptureResources(uint64_t guid,
                                                               ::ASFW::IRM::IRMClient& irmClient,
                                                               uint8_t channel,
                                                               uint32_t bandwidthUnits) noexcept {
-    return isoch_.ReserveCaptureResources(guid, irmClient, channel, bandwidthUnits);
+    const kern_return_t status =
+        reservations_.ReserveCapture(irmClient, channel, bandwidthUnits);
+    if (status != kIOReturnSuccess) {
+        return status;
+    }
+    const kern_return_t bookkeeping =
+        isoch_.ReserveCaptureResources(guid, irmClient, channel, bandwidthUnits);
+    if (bookkeeping != kIOReturnSuccess) {
+        reservations_.ReleaseAll();
+    }
+    return bookkeeping;
 }
 
 kern_return_t DiceIsochHostTransport::PrepareReceive(
@@ -69,8 +89,17 @@ kern_return_t DiceIsochHostTransport::StartPreparedTransmit() noexcept {
     return isoch_.StartPreparedTransmit();
 }
 
+kern_return_t DiceIsochHostTransport::StopPreparedReceive() noexcept {
+    return isoch_.StopReceive();
+}
+
+kern_return_t DiceIsochHostTransport::StopPreparedTransmit() noexcept {
+    return isoch_.StopTransmit();
+}
+
 kern_return_t DiceIsochHostTransport::StopAll() noexcept {
     isoch_.StopAll();
+    reservations_.ReleaseAll();
     return kIOReturnSuccess;
 }
 

--- a/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DiceHostTransport.hpp
@@ -8,10 +8,12 @@
 #include "../../../Common/WireFormat.hpp"
 #include "../../../Hardware/HardwareInterface.hpp"
 #include "../../../Isoch/IsochService.hpp"
+#include "DuplexIRMReservations.hpp"
 
 #include <DriverKit/IOBufferMemoryDescriptor.h>
 #include <DriverKit/IOReturn.h>
 #include <DriverKit/OSSharedPtr.h>
+
 
 namespace ASFW::IRM {
 class IRMClient;
@@ -53,6 +55,12 @@ class IIsochDuplexHostTransport {
                                                               uint8_t sourceId) noexcept = 0;
     [[nodiscard]] virtual kern_return_t StartPreparedReceive() noexcept = 0;
     [[nodiscard]] virtual kern_return_t StartPreparedTransmit() noexcept = 0;
+    [[nodiscard]] virtual kern_return_t StopPreparedReceive() noexcept {
+        return kIOReturnUnsupported;
+    }
+    [[nodiscard]] virtual kern_return_t StopPreparedTransmit() noexcept {
+        return kIOReturnUnsupported;
+    }
     [[nodiscard]] virtual kern_return_t StopAll() noexcept = 0;
 };
 
@@ -90,10 +98,13 @@ class DiceIsochHostTransport final : public IIsochDuplexHostTransport {
                                                       uint8_t sourceId) noexcept override;
     [[nodiscard]] kern_return_t StartPreparedReceive() noexcept override;
     [[nodiscard]] kern_return_t StartPreparedTransmit() noexcept override;
+    [[nodiscard]] kern_return_t StopPreparedReceive() noexcept override;
+    [[nodiscard]] kern_return_t StopPreparedTransmit() noexcept override;
     [[nodiscard]] kern_return_t StopAll() noexcept override;
 
   private:
     Driver::IsochService& isoch_;
+    Backends::DuplexIRMReservationPair reservations_{};
 };
 
 // FW-71 leaves the file move to FW-73. No production caller should use this

--- a/ASFWDriver/Audio/Protocols/Backends/DuplexIRMReservations.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DuplexIRMReservations.hpp
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 ASFireWire Project
+//
+// DuplexIRMReservations.hpp - bounded lifecycle owner for duplex IRM resources
+
+#pragma once
+
+#include "../AudioTypes.hpp"
+#include "../../../Bus/IRM/IRMClient.hpp"
+
+#include <DriverKit/IOLib.h>
+#include <DriverKit/IOReturn.h>
+
+#include <array>
+#include <atomic>
+#include <memory>
+
+namespace ASFW::Audio::Backends {
+
+class DuplexIRMReservations final {
+  public:
+    DuplexIRMReservations() = default;
+    ~DuplexIRMReservations() { ReleaseAll(); }
+
+    DuplexIRMReservations(const DuplexIRMReservations&) = delete;
+    DuplexIRMReservations& operator=(const DuplexIRMReservations&) = delete;
+
+    [[nodiscard]] kern_return_t Reserve(IRM::IRMClient& client, uint8_t channel,
+                                        uint32_t bandwidthUnits) noexcept {
+        if (count_ >= entries_.size()) {
+            return kIOReturnNoResources;
+        }
+
+        // Linux cmp.c:188-209 and iso-resources.c:91-147 reserve channel and
+        // bandwidth as one lifecycle-owned resource before establishing a PCR.
+        auto state = std::make_shared<WaitState>();
+        client.AllocateResources(channel, bandwidthUnits, [state](IRM::AllocationStatus status) {
+            state->status.store(status, std::memory_order_release);
+            state->done.store(true, std::memory_order_release);
+        });
+        const IRM::AllocationStatus status = Wait(state);
+        if (status != IRM::AllocationStatus::Success) {
+            return MapStatus(status);
+        }
+
+        entries_[count_++] = Entry{
+            .client = &client,
+            .channel = channel,
+            .bandwidthUnits = bandwidthUnits,
+        };
+        return kIOReturnSuccess;
+    }
+
+    void ReleaseAll() noexcept {
+        while (count_ > 0) {
+            Entry& entry = entries_[--count_];
+            if (entry.client == nullptr) {
+                entry = {};
+                continue;
+            }
+
+            auto state = std::make_shared<WaitState>();
+            entry.client->ReleaseResources(
+                entry.channel, entry.bandwidthUnits, [state](IRM::AllocationStatus status) {
+                    state->status.store(status, std::memory_order_release);
+                    state->done.store(true, std::memory_order_release);
+                });
+            (void)Wait(state); // teardown release is best effort, but bounded
+            entry = {};
+        }
+    }
+
+    [[nodiscard]] size_t Count() const noexcept { return count_; }
+
+  private:
+    static constexpr uint32_t kWaitTimeoutMs = 12000;
+    static constexpr uint32_t kWaitPollMs = 5;
+
+    struct Entry {
+        IRM::IRMClient* client{nullptr};
+        uint8_t channel{0};
+        uint32_t bandwidthUnits{0};
+    };
+
+    struct WaitState {
+        std::atomic<bool> done{false};
+        std::atomic<IRM::AllocationStatus> status{IRM::AllocationStatus::Failed};
+    };
+
+    [[nodiscard]] static IRM::AllocationStatus
+    Wait(const std::shared_ptr<WaitState>& state) noexcept {
+        for (uint32_t waited = 0; waited < kWaitTimeoutMs; waited += kWaitPollMs) {
+            if (state->done.load(std::memory_order_acquire)) {
+                return state->status.load(std::memory_order_acquire);
+            }
+            IOSleep(kWaitPollMs);
+        }
+        return IRM::AllocationStatus::Timeout;
+    }
+
+    [[nodiscard]] static kern_return_t MapStatus(IRM::AllocationStatus status) noexcept {
+        switch (status) {
+            case IRM::AllocationStatus::Success:
+                return kIOReturnSuccess;
+            case IRM::AllocationStatus::NoResources:
+                return kIOReturnNoResources;
+            case IRM::AllocationStatus::GenerationMismatch:
+                return kIOReturnOffline;
+            case IRM::AllocationStatus::Timeout:
+                return kIOReturnTimeout;
+            case IRM::AllocationStatus::NotFound:
+                return kIOReturnNoDevice;
+            case IRM::AllocationStatus::Failed:
+                return kIOReturnError;
+        }
+        return kIOReturnError;
+    }
+
+    // One instance owns one direction, so the bound is independently enforced
+    // for playback and capture by DiceIsochHostTransport's two instances.
+    std::array<Entry, kMaxAudioStreamsPerDirection> entries_{};
+    size_t count_{0};
+};
+
+class DuplexIRMReservationPair final {
+  public:
+    [[nodiscard]] kern_return_t ReservePlayback(IRM::IRMClient& client, uint8_t channel,
+                                                uint32_t bandwidthUnits) noexcept {
+        const kern_return_t status = playback_.Reserve(client, channel, bandwidthUnits);
+        if (status != kIOReturnSuccess) {
+            ReleaseAll();
+        }
+        return status;
+    }
+
+    [[nodiscard]] kern_return_t ReserveCapture(IRM::IRMClient& client, uint8_t channel,
+                                               uint32_t bandwidthUnits) noexcept {
+        const kern_return_t status = capture_.Reserve(client, channel, bandwidthUnits);
+        if (status != kIOReturnSuccess) {
+            ReleaseAll();
+        }
+        return status;
+    }
+
+    void ReleaseAll() noexcept {
+        capture_.ReleaseAll();
+        playback_.ReleaseAll();
+    }
+
+    [[nodiscard]] size_t PlaybackCount() const noexcept { return playback_.Count(); }
+    [[nodiscard]] size_t CaptureCount() const noexcept { return capture_.Count(); }
+
+  private:
+    DuplexIRMReservations playback_{};
+    DuplexIRMReservations capture_{};
+};
+
+} // namespace ASFW::Audio::Backends

--- a/ASFWDriver/Audio/Protocols/Backends/DuplexStreamProfile.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/DuplexStreamProfile.hpp
@@ -40,6 +40,12 @@ struct DuplexStartOrderRecipe {
     uint32_t postDeviceEnableDelayMs{2};
 };
 
+struct DuplexStopOrderRecipe {
+    // Preserve AV/C's PCR/host-context interleave. DICE leaves this false and
+    // retains its existing StopAll -> StopDuplex sequence.
+    bool disconnectPlaybackThenStopTransmitThenDisconnectCaptureThenStopReceive{false};
+};
+
 // Host receive geometry for one DICE TX stream. `pcmChannels == 0` preserves
 // the legacy single-stream full-width receive path.
 struct DuplexCaptureStreamGeometry {
@@ -67,6 +73,7 @@ struct DuplexStreamProfile {
     uint32_t playbackBandwidthUnits{320};
     uint32_t captureBandwidthUnits{576};
     DuplexStartOrderRecipe startOrder{};
+    DuplexStopOrderRecipe stopOrder{};
 };
 
 // The coordinator deliberately delegates all device identity checks and stream
@@ -125,12 +132,18 @@ class DuplexStreamProfileResolver final {
                record.modelId == DeviceProfiles::Audio::kSPro24DspModelId;
     }
 
+    [[nodiscard]] static constexpr bool
+    IsApogeeDuet(const Discovery::DeviceRecord& record) noexcept {
+        return record.vendorId == DeviceProfiles::Audio::kApogeeVendorId &&
+               record.modelId == DeviceProfiles::Audio::kApogeeDuetModelId;
+    }
+
     [[nodiscard]] static AudioDuplexChannels
     ResolveChannels(const Discovery::DeviceRecord& record,
                     const AudioStreamRuntimeCaps& caps) noexcept {
         AudioDuplexChannels channels{
-            .deviceToHostIsoChannel = kDefaultCaptureIsoChannel,
-            .hostToDeviceIsoChannel = kDefaultPlaybackIsoChannel,
+            .deviceToHostIsoChannel = IsApogeeDuet(record) ? uint8_t{0} : kDefaultCaptureIsoChannel,
+            .hostToDeviceIsoChannel = IsApogeeDuet(record) ? uint8_t{1} : kDefaultPlaybackIsoChannel,
         };
 
         channels.captureStreamCount = ClampStreamCount(caps.deviceToHostStreamCount);
@@ -159,10 +172,10 @@ class DuplexStreamProfileResolver final {
 
         channels.captureIsoChannels[0] = IsValidIsoChannel(caps.deviceToHostIsoChannel)
                                              ? caps.deviceToHostIsoChannel
-                                             : kDefaultCaptureIsoChannel;
+                                             : channels.deviceToHostIsoChannel;
         channels.playbackIsoChannels[0] = IsValidIsoChannel(caps.hostToDeviceIsoChannel)
                                               ? caps.hostToDeviceIsoChannel
-                                              : kDefaultPlaybackIsoChannel;
+                                              : channels.hostToDeviceIsoChannel;
         markUsed(channels.captureIsoChannels[0]);
         markUsed(channels.playbackIsoChannels[0]);
 
@@ -216,6 +229,17 @@ class DuplexStreamProfileResolver final {
         if (IsSPro24Dsp(record) && caps.hostOutputPcmChannels == 8 &&
             caps.hostToDeviceAm824Slots == 9) {
             profile.playbackWireFormat = Encoding::AudioWireFormat::kRawPcm24In32;
+        }
+        if (IsApogeeDuet(record)) {
+            // Preserve the prior AVCAudioBackend ordering:
+            // host IR -> CMP oPCR -> host IT -> CMP iPCR. The runner uses these
+            // profile flags to interleave host starts with the neutral device
+            // stages. CMP operations retain their adapter-owned 250 ms timeout.
+            profile.startOrder.startReceiveBeforeDeviceRx = true;
+            profile.startOrder.startTransmitBeforeDeviceTx = true;
+            profile.startOrder.postDeviceEnableDelayMs = 0;
+            profile.stopOrder
+                .disconnectPlaybackThenStopTransmitThenDisconnectCaptureThenStopReceive = true;
         }
         return profile;
     }

--- a/ASFWDriver/Audio/Protocols/DeviceProtocolFactory.cpp
+++ b/ASFWDriver/Audio/Protocols/DeviceProtocolFactory.cpp
@@ -17,7 +17,8 @@ std::unique_ptr<IDeviceProtocol> DeviceProtocolFactory::Create(
     Protocols::Ports::FireWireBusOps& busOps,
     Protocols::Ports::FireWireBusInfo& busInfo,
     uint16_t nodeId,
-    IRM::IRMClient* irmClient
+    IRM::IRMClient* irmClient,
+    CMP::CMPClient* cmpClient
 ) {
     if (vendorId == kFocusriteVendorId) {
         if (modelId == kSPro24DspModelId) {
@@ -72,7 +73,8 @@ std::unique_ptr<IDeviceProtocol> DeviceProtocolFactory::Create(
                  vendorId, modelId, nodeId);
         // Factory path intentionally does not bind FCP transport yet.
         // AVCDiscovery wires transport for live command execution.
-        return std::make_unique<Oxford::Apogee::ApogeeDuetProtocol>(busOps, busInfo, nodeId, nullptr);
+        return std::make_unique<Oxford::Apogee::ApogeeDuetProtocol>(
+            busOps, busInfo, nodeId, nullptr, irmClient, cmpClient);
     }
     
     // Unknown device

--- a/ASFWDriver/Audio/Protocols/DeviceProtocolFactory.hpp
+++ b/ASFWDriver/Audio/Protocols/DeviceProtocolFactory.hpp
@@ -15,6 +15,10 @@
 #include <memory>
 #include <optional>
 
+namespace ASFW::CMP {
+class CMPClient;
+}
+
 namespace ASFW::IRM {
 class IRMClient;
 }
@@ -148,7 +152,8 @@ public:
         Protocols::Ports::FireWireBusOps& busOps,
         Protocols::Ports::FireWireBusInfo& busInfo,
         uint16_t nodeId,
-        ::ASFW::IRM::IRMClient* irmClient = nullptr
+        ::ASFW::IRM::IRMClient* irmClient = nullptr,
+        ::ASFW::CMP::CMPClient* cmpClient = nullptr
     );
 
 private:

--- a/ASFWDriver/Audio/Protocols/Duplex/IDuplexDeviceControl.hpp
+++ b/ASFWDriver/Audio/Protocols/Duplex/IDuplexDeviceControl.hpp
@@ -43,6 +43,17 @@ public:
                                   ClockApplyCallback callback) = 0;
     virtual void ReadDuplexHealth(HealthCallback callback) = 0;
 
+    // Optional protocol-neutral staged teardown. Profiles which opt into the
+    // interleaved stop recipe call playback disconnect before host IT stop,
+    // then capture disconnect before host IR stop. Other protocols continue to
+    // use StopDuplex() as one atomic device-side stage.
+    virtual void DisconnectPlayback(VoidCallback callback) {
+        callback(kIOReturnUnsupported);
+    }
+    virtual void DisconnectCapture(VoidCallback callback) {
+        callback(kIOReturnUnsupported);
+    }
+
     virtual void SetTeardownCancelToken(const std::atomic<bool>* cancel) noexcept {
         (void)cancel;
     }

--- a/ASFWDriver/Audio/Protocols/Oxford/Apogee/ApogeeDuetProtocol.cpp
+++ b/ASFWDriver/Audio/Protocols/Oxford/Apogee/ApogeeDuetProtocol.cpp
@@ -10,6 +10,9 @@
 #include "../../../../Logging/Logging.hpp"
 #include "../../../../Protocols/AVC/AVCDefs.hpp"
 #include "../../../../Protocols/AVC/FCPTransport.hpp"
+#include "../../../../Protocols/AVC/CMP/CMPClient.hpp"
+#include "../../../../Protocols/AVC/StreamFormats/AVCUnitPlugSignalFormatCommand.hpp"
+#include "../../../../Bus/IRM/IRMClient.hpp"
 
 #include <DriverKit/IOLib.h>
 #include <algorithm>
@@ -38,6 +41,8 @@ constexpr uint8_t kCTypeStatus = 0x01;
 constexpr uint8_t kSubunitUnit = 0xFF;
 constexpr uint8_t kOpcodeVendorDependent = 0x00;
 constexpr uint32_t kControlSyncTimeoutMs = 1500;
+constexpr uint32_t kCMPTimeoutMs = 250;
+constexpr uint32_t kCMPPollMs = 5;
 constexpr uint32_t kClassIdPhaseInvert = static_cast<uint32_t>('phsi');
 
 constexpr size_t kVendorHeaderSize = 9; // OUI(3) + Prefix(3) + Code + Arg1 + Arg2.
@@ -354,11 +359,15 @@ bool ApogeeDuetProtocol::VendorCommand::ParseStatusPayload(std::span<const uint8
 ApogeeDuetProtocol::ApogeeDuetProtocol(Protocols::Ports::FireWireBusOps& busOps,
                                        Protocols::Ports::FireWireBusInfo& busInfo,
                                        uint16_t nodeId,
-                                       Protocols::AVC::FCPTransport* fcpTransport)
+                                       Protocols::AVC::FCPTransport* fcpTransport,
+                                       IRM::IRMClient* irmClient,
+                                       CMP::CMPClient* cmpClient)
     : busOps_(busOps)
     , busInfo_(busInfo)
     , nodeId_(nodeId)
-    , fcpTransport_(fcpTransport) {
+    , fcpTransport_(fcpTransport)
+    , irmClient_(irmClient)
+    , cmpClient_(cmpClient) {
 }
 
 IOReturn ApogeeDuetProtocol::Initialize() {
@@ -373,6 +382,259 @@ void ApogeeDuetProtocol::UpdateRuntimeContext(uint16_t nodeId,
                                               Protocols::AVC::FCPTransport* transport) {
     nodeId_ = nodeId;
     fcpTransport_ = transport;
+}
+
+bool ApogeeDuetProtocol::GetRuntimeAudioStreamCaps(AudioStreamRuntimeCaps& outCaps) const {
+    outCaps = AudioStreamRuntimeCaps{
+        .hostInputPcmChannels = 2,
+        .hostOutputPcmChannels = 2,
+        .deviceToHostAm824Slots = 2,
+        .hostToDeviceAm824Slots = 2,
+        .sampleRateHz = appliedClock_.sampleRateHz != 0 ? appliedClock_.sampleRateHz : 48000U,
+        .deviceToHostIsoChannel = AudioStreamRuntimeCaps::kInvalidIsoChannel,
+        .hostToDeviceIsoChannel = AudioStreamRuntimeCaps::kInvalidIsoChannel,
+        .deviceToHostStreamCount = 1,
+        .hostToDeviceStreamCount = 1,
+    };
+    return true;
+}
+
+void ApogeeDuetProtocol::PrepareDuplex(const AudioDuplexChannels& channels,
+                                       const AudioClockConfig& desiredClock,
+                                       PrepareCallback callback) {
+    if (!cmpClient_ || !irmClient_ || !fcpTransport_) {
+        callback(kIOReturnNotReady, {});
+        return;
+    }
+    if (!IsSupportedAudioClockConfig(desiredClock)) {
+        callback(kIOReturnUnsupported, {});
+        return;
+    }
+
+    duplexChannels_ = channels;
+    cmpClient_->SetDeviceNode(static_cast<uint8_t>(nodeId_),
+                              IRM::Generation{busInfo_.GetGeneration()});
+    ApplyClockConfig(
+        desiredClock,
+        [this, channels, callback = std::move(callback)](IOReturn status,
+                                                         ClockApplyResult result) mutable {
+            callback(status,
+                     DuplexPrepareResult{
+                         .generation = result.generation,
+                         .channels = channels,
+                         .appliedClock = result.appliedClock,
+                         .runtimeCaps = result.runtimeCaps,
+                     });
+        });
+}
+
+void ApogeeDuetProtocol::ApplyClockConfig(const AudioClockConfig& desiredClock,
+                                          ClockApplyCallback callback) {
+    if (!fcpTransport_) {
+        callback(kIOReturnNotReady, {});
+        return;
+    }
+    if (!IsSupportedAudioClockConfig(desiredClock)) {
+        callback(kIOReturnUnsupported, {});
+        return;
+    }
+
+    using SignalCommand = Protocols::AVC::StreamFormats::AVCUnitPlugSignalFormatCommand;
+    using SampleRate = Protocols::AVC::StreamFormats::SampleRate;
+
+    // Linux fcp.c:44-78 and oxfw-command.c:120-150 use unit-level
+    // INPUT/OUTPUT PLUG SIGNAL FORMAT with AM824 + SFC 0x02 for 48 kHz.
+    auto output = std::make_shared<SignalCommand>(*fcpTransport_, 0, false,
+                                                  SampleRate::k48000Hz);
+    output->Submit(
+        [this, desiredClock, callback = std::move(callback), output](
+            Protocols::AVC::AVCResult outputResult, const SignalCommand::SignalFormat&) mutable {
+            const IOReturn outputStatus = MapAVCResultToIOReturn(outputResult);
+            if (outputStatus != kIOReturnSuccess) {
+                callback(outputStatus, {});
+                return;
+            }
+
+            auto input = std::make_shared<SignalCommand>(*fcpTransport_, 0, true,
+                                                         SampleRate::k48000Hz);
+            input->Submit(
+                [this, desiredClock, callback = std::move(callback), input](
+                    Protocols::AVC::AVCResult inputResult,
+                    const SignalCommand::SignalFormat&) mutable {
+                    const IOReturn inputStatus = MapAVCResultToIOReturn(inputResult);
+                    if (inputStatus != kIOReturnSuccess) {
+                        callback(inputStatus, {});
+                        return;
+                    }
+
+                    appliedClock_ = desiredClock;
+                    AudioStreamRuntimeCaps caps{};
+                    (void)GetRuntimeAudioStreamCaps(caps);
+                    callback(kIOReturnSuccess,
+                             ClockApplyResult{
+                                 .generation = busInfo_.GetGeneration(),
+                                 .appliedClock = appliedClock_,
+                                 .runtimeCaps = caps,
+                             });
+                });
+        });
+}
+
+namespace {
+
+struct CMPWaitState {
+    std::atomic<bool> done{false};
+    std::atomic<CMP::CMPStatus> status{CMP::CMPStatus::Failed};
+};
+
+struct CMPWaitResult {
+    bool completed{false};
+    CMP::CMPStatus status{CMP::CMPStatus::Failed};
+};
+
+[[nodiscard]] CMPWaitResult WaitForCMP(const std::shared_ptr<CMPWaitState>& state) noexcept {
+    for (uint32_t waited = 0; waited < kCMPTimeoutMs; waited += kCMPPollMs) {
+        if (state->done.load(std::memory_order_acquire)) {
+            return CMPWaitResult{
+                .completed = true,
+                .status = state->status.load(std::memory_order_acquire),
+            };
+        }
+        IOSleep(kCMPPollMs);
+    }
+    return {};
+}
+
+} // namespace
+
+void ApogeeDuetProtocol::ProgramRx(StageCallback callback) {
+    if (!cmpClient_) {
+        callback(kIOReturnNotReady, {});
+        return;
+    }
+
+    auto state = std::make_shared<CMPWaitState>();
+    cmpClient_->ConnectOPCR(0, [state](CMP::CMPStatus status) {
+        state->status.store(status, std::memory_order_release);
+        state->done.store(true, std::memory_order_release);
+    });
+    const CMPWaitResult wait = WaitForCMP(state);
+    const bool connected = wait.completed && wait.status == CMP::CMPStatus::Success;
+    outputConnected_ = connected;
+
+    AudioStreamRuntimeCaps caps{};
+    (void)GetRuntimeAudioStreamCaps(caps);
+    callback(connected ? kIOReturnSuccess
+                       : (wait.completed ? kIOReturnError : kIOReturnTimeout),
+             DuplexStageResult{
+                 .generation = busInfo_.GetGeneration(),
+                 .channels = duplexChannels_,
+                 .phase = DuplexRestartPhase::kDeviceRxProgrammed,
+                 .runtimeCaps = caps,
+             });
+}
+
+void ApogeeDuetProtocol::ProgramTxAndEnableDuplex(StageCallback callback) {
+    if (!cmpClient_) {
+        callback(kIOReturnNotReady, {});
+        return;
+    }
+
+    auto state = std::make_shared<CMPWaitState>();
+    cmpClient_->ConnectIPCR(0, duplexChannels_.hostToDeviceIsoChannel,
+                            [state](CMP::CMPStatus status) {
+                                state->status.store(status, std::memory_order_release);
+                                state->done.store(true, std::memory_order_release);
+                            });
+    const CMPWaitResult wait = WaitForCMP(state);
+    const bool connected = wait.completed && wait.status == CMP::CMPStatus::Success;
+    inputConnected_ = connected;
+
+    AudioStreamRuntimeCaps caps{};
+    (void)GetRuntimeAudioStreamCaps(caps);
+    callback(connected ? kIOReturnSuccess
+                       : (wait.completed ? kIOReturnError : kIOReturnTimeout),
+             DuplexStageResult{
+                 .generation = busInfo_.GetGeneration(),
+                 .channels = duplexChannels_,
+                 .phase = DuplexRestartPhase::kDeviceTxArmed,
+                 .runtimeCaps = caps,
+             });
+}
+
+void ApogeeDuetProtocol::ConfirmDuplexStart(ConfirmCallback callback) {
+    AudioStreamRuntimeCaps caps{};
+    (void)GetRuntimeAudioStreamCaps(caps);
+    callback((outputConnected_ && inputConnected_) ? kIOReturnSuccess : kIOReturnNotReady,
+             DuplexConfirmResult{
+                 .generation = busInfo_.GetGeneration(),
+                 .channels = duplexChannels_,
+                 .appliedClock = appliedClock_,
+                 .runtimeCaps = caps,
+             });
+}
+
+void ApogeeDuetProtocol::ReadDuplexHealth(HealthCallback callback) {
+    AudioStreamRuntimeCaps caps{};
+    (void)GetRuntimeAudioStreamCaps(caps);
+    callback(kIOReturnSuccess,
+             DuplexHealthResult{
+                 .generation = busInfo_.GetGeneration(),
+                 .appliedClock = appliedClock_,
+                 .runtimeCaps = caps,
+                 .sourceLocked = appliedClock_.sampleRateHz != 0,
+                 .clockReferenceHealthy = true,
+                 .nominalRateHz = appliedClock_.sampleRateHz,
+             });
+}
+
+void ApogeeDuetProtocol::DisconnectPlayback(VoidCallback callback) {
+    if (!cmpClient_ || !inputConnected_) {
+        inputConnected_ = false;
+        callback(kIOReturnSuccess);
+        return;
+    }
+
+    auto state = std::make_shared<CMPWaitState>();
+    cmpClient_->DisconnectIPCR(0, [state](CMP::CMPStatus status) {
+        state->status.store(status, std::memory_order_release);
+        state->done.store(true, std::memory_order_release);
+    });
+    const CMPWaitResult wait = WaitForCMP(state);
+    const bool disconnected = wait.completed && wait.status == CMP::CMPStatus::Success;
+    inputConnected_ = false;
+    callback(disconnected ? kIOReturnSuccess : kIOReturnTimeout);
+}
+
+void ApogeeDuetProtocol::DisconnectCapture(VoidCallback callback) {
+    if (!cmpClient_ || !outputConnected_) {
+        outputConnected_ = false;
+        callback(kIOReturnSuccess);
+        return;
+    }
+
+    auto state = std::make_shared<CMPWaitState>();
+    cmpClient_->DisconnectOPCR(0, [state](CMP::CMPStatus status) {
+        state->status.store(status, std::memory_order_release);
+        state->done.store(true, std::memory_order_release);
+    });
+    const CMPWaitResult wait = WaitForCMP(state);
+    const bool disconnected = wait.completed && wait.status == CMP::CMPStatus::Success;
+    outputConnected_ = false;
+    callback(disconnected ? kIOReturnSuccess : kIOReturnTimeout);
+}
+
+IOReturn ApogeeDuetProtocol::StopDuplex() {
+    IOReturn playbackStatus = kIOReturnSuccess;
+    DisconnectPlayback([&playbackStatus](IOReturn status) { playbackStatus = status; });
+
+    IOReturn captureStatus = kIOReturnSuccess;
+    DisconnectCapture([&captureStatus](IOReturn status) { captureStatus = status; });
+
+    if (playbackStatus != kIOReturnSuccess) {
+        return playbackStatus;
+    }
+    return captureStatus;
 }
 
 bool ApogeeDuetProtocol::SupportsBooleanControl(uint32_t classIdFourCC,

--- a/ASFWDriver/Audio/Protocols/Oxford/Apogee/ApogeeDuetProtocol.hpp
+++ b/ASFWDriver/Audio/Protocols/Oxford/Apogee/ApogeeDuetProtocol.hpp
@@ -8,6 +8,7 @@
 
 #include "ApogeeTypes.hpp"
 #include "../../IDeviceProtocol.hpp"
+#include "../../Duplex/IDuplexDeviceControl.hpp"
 #include "../../../../Protocols/Ports/FireWireBusPort.hpp"
 #include <DriverKit/IOReturn.h>
 #include <vector>
@@ -19,9 +20,18 @@ namespace ASFW::Protocols::AVC {
     class FCPTransport;
 }
 
+namespace ASFW::IRM {
+class IRMClient;
+}
+
+namespace ASFW::CMP {
+class CMPClient;
+}
+
 namespace ASFW::Audio::Oxford::Apogee {
 
-class ApogeeDuetProtocol : public IDeviceProtocol {
+class ApogeeDuetProtocol final : public IDeviceProtocol,
+                                 public IDuplexDeviceControl {
 public:
     struct VendorCommand {
         enum class Code : uint8_t {
@@ -95,7 +105,9 @@ public:
     ApogeeDuetProtocol(Protocols::Ports::FireWireBusOps& busOps,
                        Protocols::Ports::FireWireBusInfo& busInfo,
                        uint16_t nodeId,
-                       Protocols::AVC::FCPTransport* fcpTransport = nullptr);
+                       Protocols::AVC::FCPTransport* fcpTransport = nullptr,
+                       IRM::IRMClient* irmClient = nullptr,
+                       CMP::CMPClient* cmpClient = nullptr);
     virtual ~ApogeeDuetProtocol() = default;
 
     // IDeviceProtocol implementation
@@ -104,6 +116,25 @@ public:
     const char* GetName() const override { return "Apogee Duet FireWire"; }
     bool HasDsp() const override { return true; } // Has mixer/DSP features
     bool HasMixer() const override { return true; }
+    bool GetRuntimeAudioStreamCaps(AudioStreamRuntimeCaps& outCaps) const override;
+    IDuplexDeviceControl* AsDuplexDeviceControl() noexcept override { return this; }
+    const IDuplexDeviceControl* AsDuplexDeviceControl() const noexcept override { return this; }
+
+    // IDuplexDeviceControl: the generic lifecycle owns IRM + host isoch;
+    // this adapter owns only AV/C signal-format and CMP/PCR operations.
+    void PrepareDuplex(const AudioDuplexChannels& channels,
+                       const AudioClockConfig& desiredClock,
+                       PrepareCallback callback) override;
+    void ProgramRx(StageCallback callback) override;
+    void ProgramTxAndEnableDuplex(StageCallback callback) override;
+    void ConfirmDuplexStart(ConfirmCallback callback) override;
+    void ApplyClockConfig(const AudioClockConfig& desiredClock,
+                          ClockApplyCallback callback) override;
+    void ReadDuplexHealth(HealthCallback callback) override;
+    void DisconnectPlayback(VoidCallback callback) override;
+    void DisconnectCapture(VoidCallback callback) override;
+    [[nodiscard]] IOReturn StopDuplex() override;
+    [[nodiscard]] IRM::IRMClient* GetIRMClient() const override { return irmClient_; }
 
     // ========================================================================
     // Parameter Access (Async)
@@ -192,6 +223,12 @@ private:
     Protocols::Ports::FireWireBusInfo& busInfo_;
     uint16_t nodeId_;
     Protocols::AVC::FCPTransport* fcpTransport_{nullptr};
+    IRM::IRMClient* irmClient_{nullptr};
+    CMP::CMPClient* cmpClient_{nullptr};
+    AudioDuplexChannels duplexChannels_{};
+    AudioClockConfig appliedClock_{};
+    bool outputConnected_{false};
+    bool inputConnected_{false};
 
     // Helpers
     using VendorResultCallback = std::function<void(IOReturn, const VendorCommand&)>;

--- a/tests/devices/ApogeeDuetVendorCmdTests.cpp
+++ b/tests/devices/ApogeeDuetVendorCmdTests.cpp
@@ -4,9 +4,13 @@
 // ApogeeDuetVendorCmdTests.cpp - Unit tests for Apogee Duet vendor command encoding/decoding
 
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <span>
+#include "Async/Interfaces/IFireWireBus.hpp"
 #include "Audio/Protocols/Oxford/Apogee/ApogeeDuetProtocol.hpp"
 #include "Audio/Protocols/Oxford/Apogee/ApogeeTypes.hpp"
+#include "Bus/IRM/IRMClient.hpp"
+#include "Protocols/AVC/CMP/CMPClient.hpp"
 #include "Protocols/AVC/FCPTransport.hpp"
 
 using namespace ASFW::Audio::Oxford::Apogee;
@@ -19,6 +23,59 @@ using DuetOutputMuteMode = OutputMuteMode;
 // Constants from ApogeeDuetProtocol
 constexpr uint8_t kBoolOn = 0x70;
 constexpr uint8_t kBoolOff = 0x60;
+
+namespace {
+
+std::vector<ASFW::Protocols::AVC::FCPFrame> gSubmittedFCPFrames;
+
+class RecordingAVCBus final : public ASFW::Async::IFireWireBus {
+  public:
+    ASFW::Async::AsyncHandle ReadBlock(
+        ASFW::FW::Generation, ASFW::FW::NodeId, ASFW::Async::FWAddress, uint32_t,
+        ASFW::FW::FwSpeed, ASFW::Async::InterfaceCompletionCallback callback) override {
+        const uint32_t pcrBE = OSSwapHostToBigInt32(0x80000000U);
+        std::array<uint8_t, 4> payload{};
+        std::memcpy(payload.data(), &pcrBE, sizeof(pcrBE));
+        callback(ASFW::Async::AsyncStatus::kSuccess, payload);
+        return {.value = ++handle_};
+    }
+
+    ASFW::Async::AsyncHandle WriteBlock(
+        ASFW::FW::Generation, ASFW::FW::NodeId, ASFW::Async::FWAddress,
+        std::span<const uint8_t>, ASFW::FW::FwSpeed,
+        ASFW::Async::InterfaceCompletionCallback callback) override {
+        callback(ASFW::Async::AsyncStatus::kSuccess, {});
+        return {.value = ++handle_};
+    }
+
+    ASFW::Async::AsyncHandle Lock(
+        ASFW::FW::Generation, ASFW::FW::NodeId, ASFW::Async::FWAddress,
+        ASFW::FW::LockOp, std::span<const uint8_t> operand, uint32_t,
+        ASFW::FW::FwSpeed, ASFW::Async::InterfaceCompletionCallback callback) override {
+        std::array<uint8_t, 4> oldValue{};
+        std::copy_n(operand.begin(), oldValue.size(), oldValue.begin());
+        if (failCompareSwap) {
+            oldValue[3] ^= 0x01U;
+        }
+        callback(ASFW::Async::AsyncStatus::kSuccess, oldValue);
+        return {.value = ++handle_};
+    }
+
+    bool Cancel(ASFW::Async::AsyncHandle) override { return false; }
+    ASFW::FW::FwSpeed GetSpeed(ASFW::FW::NodeId) const override {
+        return ASFW::FW::FwSpeed::S400;
+    }
+    uint32_t HopCount(ASFW::FW::NodeId, ASFW::FW::NodeId) const override { return 0; }
+    ASFW::FW::Generation GetGeneration() const override { return ASFW::FW::Generation{1}; }
+    ASFW::FW::NodeId GetLocalNodeID() const override { return ASFW::FW::NodeId{0}; }
+
+    bool failCompareSwap{false};
+
+  private:
+    uint32_t handle_{0};
+};
+
+} // namespace
 
 // Helper to match old BuildOperands API
 inline std::vector<uint8_t> BuildOperands(const VendorCmd& cmd) {
@@ -381,11 +438,66 @@ TEST(ApogeeDuetVendorCmd, BuildDisplayParamsQuery) {
     EXPECT_EQ(cmds.size(), 3u);  // isInput, followKnob, overhold
 }
 
+TEST(ApogeeDuetDuplexAdapter, Applies48kToOutputThenInputUnitPlugs) {
+    using namespace ASFW::Protocols::AVC;
+    RecordingAVCBus bus;
+    FCPTransport transport;
+    ApogeeDuetProtocol protocol(bus, bus, 2, &transport);
+    gSubmittedFCPFrames.clear();
+
+    IOReturn completionStatus = kIOReturnNotReady;
+    protocol.ApplyClockConfig(
+        ASFW::Audio::AudioClockConfig{.sampleRateHz = 48000U},
+        [&completionStatus](IOReturn status, ASFW::Audio::ClockApplyResult) {
+            completionStatus = status;
+        });
+
+    ASSERT_EQ(completionStatus, kIOReturnSuccess);
+    ASSERT_EQ(gSubmittedFCPFrames.size(), 2U);
+    constexpr std::array<uint8_t, 8> expectedOutput{
+        0x00, 0xFF, 0x18, 0x00, 0x90, 0x02, 0xFF, 0xFF};
+    constexpr std::array<uint8_t, 8> expectedInput{
+        0x00, 0xFF, 0x19, 0x00, 0x90, 0x02, 0xFF, 0xFF};
+    EXPECT_TRUE(std::ranges::equal(gSubmittedFCPFrames[0].Payload(), expectedOutput));
+    EXPECT_TRUE(std::ranges::equal(gSubmittedFCPFrames[1].Payload(), expectedInput));
+}
+
+TEST(ApogeeDuetDuplexAdapter, MapsCompletedCmpFailureToErrorRatherThanTimeout) {
+    RecordingAVCBus bus;
+    ASFW::IRM::IRMClient irm(bus);
+    ASFW::CMP::CMPClient cmp(bus);
+    cmp.SetDeviceNode(2, ASFW::IRM::Generation{1});
+    ApogeeDuetProtocol protocol(bus, bus, 2, nullptr, &irm, &cmp);
+
+    IOReturn rxStatus = kIOReturnNotReady;
+    protocol.ProgramRx([&rxStatus](IOReturn status, ASFW::Audio::DuplexStageResult) {
+        rxStatus = status;
+    });
+    EXPECT_EQ(rxStatus, kIOReturnSuccess);
+
+    bus.failCompareSwap = true;
+    IOReturn txStatus = kIOReturnNotReady;
+    protocol.ProgramTxAndEnableDuplex(
+        [&txStatus](IOReturn status, ASFW::Audio::DuplexStageResult) { txStatus = status; });
+    EXPECT_EQ(txStatus, kIOReturnError);
+}
+
 // Linker stub for FCPTransport::SubmitCommand (not invoked by tests)
 namespace ASFW::Protocols::AVC {
+bool FCPTransport::init(Protocols::Ports::FireWireBusOps*,
+                        Protocols::Ports::FireWireBusInfo*,
+                        Discovery::FWDevice*,
+                        const FCPTransportConfig&) {
+    return true;
+}
+
+void FCPTransport::free() {}
+
 FCPHandle FCPTransport::SubmitCommand(const FCPFrame& command, FCPCompletion completion) {
-    (void)command;
-    (void)completion;
-    return FCPHandle{};
+    gSubmittedFCPFrames.push_back(command);
+    FCPFrame response = command;
+    response.data[0] = static_cast<uint8_t>(AVCResponseType::kAccepted);
+    completion(FCPStatus::kOk, response);
+    return FCPHandle{.transactionID = static_cast<uint32_t>(gSubmittedFCPFrames.size())};
 }
 }

--- a/tests/devices/CMakeLists.txt
+++ b/tests/devices/CMakeLists.txt
@@ -99,5 +99,6 @@ add_device_test(ApogeeBooleanControlMappingTests
 add_device_test(ApogeeDuetVendorCmdTests
     ApogeeDuetVendorCmdTests.cpp
     "${ASFW_DRIVER_DIR}/Audio/Protocols/Oxford/Apogee/ApogeeDuetProtocol.cpp"
+    "${ASFW_DRIVER_DIR}/Bus/IRM/IRMClient.cpp"
+    "${ASFW_DRIVER_DIR}/Protocols/AVC/CMP/CMPClient.cpp"
 )
-

--- a/tests/devices/DICEDuplexBringupControllerTests.cpp
+++ b/tests/devices/DICEDuplexBringupControllerTests.cpp
@@ -8,6 +8,7 @@
 #include "Audio/Protocols/DICE/Core/DICENotificationMailbox.hpp"
 #include "Audio/Protocols/DICE/Core/DICETransaction.hpp"
 #include "Audio/Protocols/DICE/Core/DICEDuplexBringupController.hpp"
+#include "Audio/Protocols/Backends/DuplexIRMReservations.hpp"
 #include "Protocols/Ports/ProtocolRegisterIO.hpp"
 
 #include <algorithm>
@@ -1514,6 +1515,77 @@ TEST(DICEDuplexBringupControllerTests, IRMAllocateResourcesReturnsGenerationMism
 
     ASSERT_TRUE(status.has_value());
     EXPECT_EQ(*status, ASFW::IRM::AllocationStatus::GenerationMismatch);
+}
+
+TEST(DICEDuplexBringupControllerTests,
+     DuplexIRMReservationsAllocatesAndReleasesBothDirections) {
+    RecordingFireWireBus bus;
+    bus.SetIRMResourceState(4915U, 0xFFFFFFFFU, 0xFFFFFFFFU);
+    IRMClient irm(bus);
+    irm.SetIRMNode(0x03, Generation{1});
+    ASFW::Audio::Backends::DuplexIRMReservations reservations;
+
+    ASSERT_EQ(reservations.Reserve(irm, 0, 320U), kIOReturnSuccess);
+    ASSERT_EQ(reservations.Reserve(irm, 1, 576U), kIOReturnSuccess);
+    EXPECT_EQ(reservations.Count(), 2U);
+    EXPECT_EQ(bus.BandwidthAvailable(), 4019U);
+    EXPECT_EQ(bus.ChannelsAvailable31_0(), 0x3FFFFFFFU);
+
+    reservations.ReleaseAll();
+    EXPECT_EQ(reservations.Count(), 0U);
+    EXPECT_EQ(bus.BandwidthAvailable(), 4915U);
+    EXPECT_EQ(bus.ChannelsAvailable31_0(), 0xFFFFFFFFU);
+}
+
+TEST(DICEDuplexBringupControllerTests,
+     DuplexIRMReservationsTracksAndReleasesEveryMultistreamAllocation) {
+    RecordingFireWireBus bus;
+    bus.SetIRMResourceState(4915U, 0xFFFFFFFFU, 0xFFFFFFFFU);
+    IRMClient irm(bus);
+    irm.SetIRMNode(0x03, Generation{1});
+    ASFW::Audio::Backends::DuplexIRMReservations reservations;
+
+    for (uint8_t channel = 0; channel < 4; ++channel) {
+        ASSERT_EQ(reservations.Reserve(irm, channel, 100U), kIOReturnSuccess);
+    }
+    EXPECT_EQ(reservations.Count(), 4U);
+    EXPECT_EQ(reservations.Reserve(irm, 4, 100U), kIOReturnNoResources);
+    EXPECT_EQ(bus.BandwidthAvailable(), 4515U);
+    EXPECT_EQ(bus.ChannelsAvailable31_0(), 0x0FFFFFFFU);
+
+    reservations.ReleaseAll();
+    EXPECT_EQ(bus.BandwidthAvailable(), 4915U);
+    EXPECT_EQ(bus.ChannelsAvailable31_0(), 0xFFFFFFFFU);
+}
+
+TEST(DICEDuplexBringupControllerTests,
+     DuplexIRMReservationsRollsBackPriorSuccessAfterLaterFailure) {
+    RecordingFireWireBus bus;
+    bus.SetIRMResourceState(500U, 0xFFFFFFFFU, 0xFFFFFFFFU);
+    IRMClient irm(bus);
+    irm.SetIRMNode(0x03, Generation{1});
+    ASFW::Audio::Backends::DuplexIRMReservationPair reservations;
+
+    ASSERT_EQ(reservations.ReservePlayback(irm, 0, 320U), kIOReturnSuccess);
+    EXPECT_EQ(reservations.ReserveCapture(irm, 1, 320U), kIOReturnNoResources);
+    EXPECT_EQ(reservations.PlaybackCount(), 0U);
+    EXPECT_EQ(reservations.CaptureCount(), 0U);
+
+    reservations.ReleaseAll();
+    EXPECT_EQ(bus.BandwidthAvailable(), 500U);
+    EXPECT_EQ(bus.ChannelsAvailable31_0(), 0xFFFFFFFFU);
+}
+
+TEST(DICEDuplexBringupControllerTests,
+     DuplexIRMReservationsPropagatesGenerationMismatchWithoutTrackingEntry) {
+    RecordingFireWireBus bus;
+    IRMClient irm(bus);
+    irm.SetIRMNode(0x03, Generation{1});
+    bus.SetGeneration(Generation{2});
+    ASFW::Audio::Backends::DuplexIRMReservations reservations;
+
+    EXPECT_EQ(reservations.Reserve(irm, 0, 320U), kIOReturnOffline);
+    EXPECT_EQ(reservations.Count(), 0U);
 }
 
 // AudioDuplexChannels invariant: stream[0] resolves to the legacy scalar field so

--- a/tests/devices/DiceDuplexRestartCoordinatorTests.cpp
+++ b/tests/devices/DiceDuplexRestartCoordinatorTests.cpp
@@ -70,6 +70,8 @@ constexpr uint64_t kTestGuid = 0x00130E0402004713ULL;
 constexpr uint32_t kQueueBytes = 4096;
 constexpr uint32_t kFocusriteVendorId = ASFW::Audio::DeviceProtocolFactory::kFocusriteVendorId;
 constexpr uint32_t kSPro24DspModelId = ASFW::Audio::DeviceProtocolFactory::kSPro24DspModelId;
+constexpr uint32_t kApogeeVendorId = ASFW::Audio::DeviceProtocolFactory::kApogeeVendorId;
+constexpr uint32_t kApogeeDuetModelId = ASFW::Audio::DeviceProtocolFactory::kApogeeDuetModelId;
 constexpr AudioClockConfig kSupportedClock{
     .sampleRateHz = 48000U,
 };
@@ -244,6 +246,18 @@ class FakeDiceHostTransport final : public IIsochDuplexHostTransport {
         return startTransmitStatus;
     }
 
+    kern_return_t StopPreparedReceive() noexcept override {
+        log_.Add("host.stop_receive");
+        ++stopReceiveCalls;
+        return stopReceiveStatus;
+    }
+
+    kern_return_t StopPreparedTransmit() noexcept override {
+        log_.Add("host.stop_transmit");
+        ++stopTransmitCalls;
+        return stopTransmitStatus;
+    }
+
     kern_return_t StopAll() noexcept override {
         log_.Add("host.stop");
         ++stopCalls;
@@ -258,6 +272,8 @@ class FakeDiceHostTransport final : public IIsochDuplexHostTransport {
     kern_return_t startReceiveStatus{kIOReturnSuccess};
     kern_return_t startTransmitStatus{kIOReturnSuccess};
     kern_return_t stopStatus{kIOReturnSuccess};
+    kern_return_t stopReceiveStatus{kIOReturnSuccess};
+    kern_return_t stopTransmitStatus{kIOReturnSuccess};
 
     uint64_t lastGuid{0};
     uint8_t lastPlaybackChannel{0};
@@ -295,6 +311,8 @@ class FakeDiceHostTransport final : public IIsochDuplexHostTransport {
     int startReceiveCalls{0};
     int startTransmitCalls{0};
     int stopCalls{0};
+    int stopReceiveCalls{0};
+    int stopTransmitCalls{0};
 
   private:
     SharedCallLog& log_;
@@ -438,6 +456,18 @@ class FakeDiceProtocol final : public IDeviceProtocol, public IDuplexDeviceContr
                                });
     }
 
+    void DisconnectPlayback(VoidCallback callback) override {
+        log_.Add("device.disconnect_playback");
+        ++disconnectPlaybackCalls;
+        callback(disconnectPlaybackStatus);
+    }
+
+    void DisconnectCapture(VoidCallback callback) override {
+        log_.Add("device.disconnect_capture");
+        ++disconnectCaptureCalls;
+        callback(disconnectCaptureStatus);
+    }
+
     IOReturn StopDuplex() override {
         log_.Add("device.stop");
         ++stopCalls;
@@ -488,6 +518,8 @@ class FakeDiceProtocol final : public IDeviceProtocol, public IDuplexDeviceContr
     IOReturn applyClockStatus{kIOReturnSuccess};
     IOReturn healthStatus{kIOReturnSuccess};
     IOReturn stopStatus{kIOReturnSuccess};
+    IOReturn disconnectPlaybackStatus{kIOReturnSuccess};
+    IOReturn disconnectCaptureStatus{kIOReturnSuccess};
 
     uint32_t healthNotification{0x20};
     uint32_t healthStatusValue{0x201};
@@ -502,6 +534,8 @@ class FakeDiceProtocol final : public IDeviceProtocol, public IDuplexDeviceContr
     int applyClockCalls{0};
     int healthReadCalls{0};
     int stopCalls{0};
+    int disconnectPlaybackCalls{0};
+    int disconnectCaptureCalls{0};
 
   private:
     SharedCallLog& log_;
@@ -641,6 +675,51 @@ TEST_F(DiceDuplexRestartCoordinatorTests, ColdStartTransitionsIdleToRunning) {
                                  "host.start_transmit",
                                  "device.confirm",
                              }));
+}
+
+TEST_F(DiceDuplexRestartCoordinatorTests,
+       AvcProfileReservesBothDirectionsAndInterleavesHostStartsWithDeviceStages) {
+    registry_.UpsertFromROM(
+        MakeConfigRom(kTestGuid, kApogeeVendorId, kApogeeDuetModelId), LinkPolicy{});
+    ClearLog();
+
+    ASSERT_EQ(coordinator_.StartStreaming(kTestGuid), kIOReturnSuccess);
+
+    EXPECT_EQ(hostTransport_.reservePlaybackCalls, 1);
+    EXPECT_EQ(hostTransport_.reserveCaptureCalls, 1);
+    EXPECT_EQ(hostTransport_.lastPlaybackChannel, 1U);
+    EXPECT_EQ(hostTransport_.lastCaptureChannel, 0U);
+    EXPECT_EQ(LogSnapshot(), (std::vector<std::string>{
+                                 "host.begin",
+                                 "device.prepare",
+                                 "host.reserve_playback",
+                                 "host.reserve_capture",
+                                 "host.prepare_receive",
+                                 "host.prepare_transmit",
+                                 "device.health",
+                                 "device.health",
+                                 "device.health",
+                                 "host.start_receive",
+                                 "device.program_rx",
+                                 "host.start_transmit",
+                                 "device.program_tx",
+                                 "device.confirm",
+                             }));
+
+    ClearLog();
+    protocol_->disconnectPlaybackStatus = kIOReturnTimeout;
+    protocol_->disconnectCaptureStatus = kIOReturnError;
+    hostTransport_.stopTransmitStatus = kIOReturnError;
+    hostTransport_.stopReceiveStatus = kIOReturnTimeout;
+    ASSERT_EQ(coordinator_.StopStreaming(kTestGuid), kIOReturnSuccess);
+    EXPECT_EQ(LogSnapshot(), (std::vector<std::string>{
+                                 "device.disconnect_playback",
+                                 "host.stop_transmit",
+                                 "device.disconnect_capture",
+                                 "host.stop_receive",
+                                 "host.stop",
+                             }));
+    EXPECT_EQ(protocol_->stopCalls, 0);
 }
 
 TEST_F(DiceDuplexRestartCoordinatorTests, TeardownCancelAbortsInFlightPrepare) {

--- a/tests/devices/DuplexStreamProfileTests.cpp
+++ b/tests/devices/DuplexStreamProfileTests.cpp
@@ -9,6 +9,8 @@ using ASFW::Audio::Backends::DuplexHostDirection;
 using ASFW::Audio::Backends::DuplexStreamProfile;
 using ASFW::Audio::Backends::DuplexStreamProfileResolver;
 using ASFW::DeviceProfiles::Audio::kAlesisVendorId;
+using ASFW::DeviceProfiles::Audio::kApogeeDuetModelId;
+using ASFW::DeviceProfiles::Audio::kApogeeVendorId;
 using ASFW::DeviceProfiles::Audio::kFocusriteVendorId;
 using ASFW::DeviceProfiles::Audio::kSPro24DspModelId;
 using ASFW::Discovery::DeviceRecord;
@@ -66,6 +68,23 @@ TEST(DuplexStreamProfileTests, SPro24DspResolvesRawPcmOnBothDirectionsWhenGeomet
     EXPECT_EQ(profile.captureWireFormat, AudioWireFormat::kRawPcm24In32);
     EXPECT_EQ(profile.playbackWireFormat, AudioWireFormat::kRawPcm24In32);
     EXPECT_EQ(profile.captureStreams[0].am824Slots, 9U);
+}
+
+TEST(DuplexStreamProfileTests, ApogeeDuetPreservesLegacyChannelsAndCmpInterleave) {
+    DeviceRecord record{
+        .vendorId = kApogeeVendorId,
+        .modelId = kApogeeDuetModelId,
+    };
+
+    const DuplexStreamProfile profile = DuplexStreamProfileResolver::Resolve(record, {});
+
+    EXPECT_EQ(profile.channels.deviceToHostIsoChannel, 0U);
+    EXPECT_EQ(profile.channels.hostToDeviceIsoChannel, 1U);
+    EXPECT_TRUE(profile.startOrder.startReceiveBeforeDeviceRx);
+    EXPECT_TRUE(profile.startOrder.startTransmitBeforeDeviceTx);
+    EXPECT_EQ(profile.startOrder.postDeviceEnableDelayMs, 0U);
+    EXPECT_TRUE(profile.stopOrder
+                    .disconnectPlaybackThenStopTransmitThenDisconnectCaptureThenStopReceive);
 }
 
 TEST(DuplexStreamProfileTests, AlesisModelsClampAdvertisedCaptureStreamsToOne) {


### PR DESCRIPTION
## Summary

- converge the AV/C (Apogee Duet) audio path onto FW-71's neutral duplex seams: `AVCAudioBackend` now delegates to `AudioDuplexCoordinator` + `DiceIsochHostTransport` instead of its own hand-rolled `StartReceive`/`ConnectOPCR`/`StartTransmit`/`ConnectIPCR` sequence
- `ApogeeDuetProtocol` implements `IDuplexDeviceControl` — AV/C unit-plug signal format (output `0x18` / input `0x19`, AM824, SFC `0x02` = 48 kHz) plus CMP/PCR connect/disconnect, with `oPCR → host RX`, `iPCR → host TX` and staged `DisconnectPlayback`/`DisconnectCapture`
- add `DuplexIRMReservations` — a bounded, RAII lifecycle owner for isoch channel/bandwidth reservation, now shared by DICE and AV/C through `DiceIsochHostTransport`
- give the Apogee Duet a `DuplexStreamProfile` (iso ch 0/1) whose start/stop-order recipe flags preserve the historical AV/C interleave; **DICE keeps its `StopAll → StopDuplex` contract unchanged** (recipe flags default `false`)
- thread `CMPClient` through `DeviceProtocolFactory → AudioRuntimeRegistry → ApogeeDuetProtocol`

Implements the AV/C half of [`DEVICE_BACKEND_UNIFICATION.md`](../blob/main/documentation/DEVICE_BACKEND_UNIFICATION.md) and consumes the seams promoted in FW-71 (#63).

## Why

FW-71 made the duplex lifecycle protocol-neutral but only DICE flowed through it; the "universal" backend was effectively "DICE with a vtable." This PR forces a second, *unrelated* protocol (AV/C + CMP) through the same neutral methods (the two-protocol rule from the design note), which is what keeps the interface honest. The old `AVCAudioBackend` carried a parallel, bespoke CMP/isoch state machine that duplicated the coordinator — that path is now deleted rather than left alongside.

## Behavior

Supported-rate policy remains **48 kHz-only**; no 44.1/88.2/96 kHz handling is added. DICE start/teardown ordering is byte-for-byte unchanged — the interleaved host-context-before-PCR start and disconnect-before-stop teardown are gated behind per-profile recipe flags that only the Apogee profile sets.

## Wire cross-checks

- AV/C signal-format opcodes `0x18`/`0x19` validated against libffado `avc_signal_format.cpp` and Linux `oxfw/oxfw-command.c` / `fcp.c`
- IRM channel + bandwidth reservation lifecycle cross-checked with Linux `cmp.c` / `iso-resources.c`

## Validation

- `./build.sh --test-only --no-bump` — **1,263 C++ tests passed** (incl. new `ApogeeDuetDuplexAdapter` signal-format and CMP-failure-mapping tests); reference-fixture tests skipped where `references/` is absent
- `./build.sh --no-bump` — Debug Xcode dext build **succeeded** (existing repository warnings only)
- `git diff --check`

## Hardware gate

This draft does **not** claim FW-72 complete. The "Duet validation" half of the ticket is unverified: Apogee Duet enumeration, 48 kHz duplex playback/capture, CMP connection management on the wire, teardown, and bus-reset/reconnect recovery all still require the physical device on the bench.

## Blocks

- **FW-73** (mechanical rename) — the downstream join point, which waits on this and FW-75 (#64).
