### PR TITLE
FW-64: AV/C RX stream-health recovery — timing-loss debounce + restart

### DIFF
--- a/ASFWDriver/Audio/DriverKit/ASFWAudioDriverZts.cpp
+++ b/ASFWDriver/Audio/DriverKit/ASFWAudioDriverZts.cpp
@@ -643,8 +643,12 @@ void IMPL(ASFWAudioDriver, TxPreparationReady)
         if (stoppedShort || frameShort) {
             const uint64_t frameDeficit =
                 frameShort ? (targetFrameEnd - exposedFrameEndAfter) : 0;
-            ASFW_LOG(
-                DirectAudio,
+            // stoppedShort is rare and precedes an IT FATAL -> always log (interval
+            // 0). A frameShort-only wake is a persistent stall (e.g. RX outage
+            // NO-DATA) that otherwise floods at ~1 kHz -> rate-limit to ~1/s, with
+            // the suppressed-count preserving burst visibility. (doc §6)
+            ASFW_LOG_RL(
+                DirectAudio, "tx/prep-range", stoppedShort ? 0u : 1000u, OS_LOG_TYPE_DEFAULT,
                 "[TxPrepRange] retiredAbs=%llu prepareBaseAbs=%llu "
                 "prepareUntilAbs=%llu coverageTargetAbs=%llu limitTargetAbs=%llu reqSpan=%llu "
                 "prepared=%u short=%d firstMissingAbs=%lld marginAfter=%llu "

--- a/ASFWDriver/Audio/Protocols/Backends/AVCAudioBackend.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/AVCAudioBackend.cpp
@@ -46,9 +46,15 @@ AVCAudioBackend::AVCAudioBackend(AudioNubPublisher& publisher,
                        "AVCAudioBackend: Failed to create recovery queue (0x%x)",
                        queueStatus);
     }
+
+    // Subscribe to RX timing loss. Unlike DICE (which health-gates on a register
+    // probe), AV/C has no health register — HandleTimingLoss reads the RX replay
+    // cadence itself after a debounce. See AVC_STREAM_HEALTH_AND_RECOVERY.md §6.
+    hostTransport_.SetTimingLossCallback([this](uint64_t guid) { HandleTimingLoss(guid); });
 }
 
 AVCAudioBackend::~AVCAudioBackend() noexcept {
+    hostTransport_.SetTimingLossCallback({});
     if (lock_) {
         IOLockFree(lock_);
         lock_ = nullptr;
@@ -91,6 +97,7 @@ void AVCAudioBackend::OnDeviceRemoved(uint64_t guid) noexcept {
         IOLockLock(lock_);
         configByGuid_.erase(guid);
         recoveringGuids_.erase(guid);
+        timingLossAttempts_.erase(guid);
         if (activeGuid_ == guid) {
             activeGuid_ = 0;
         }
@@ -155,12 +162,139 @@ void AVCAudioBackend::OnDeviceResumed(uint64_t guid) noexcept {
     }
 }
 
+void AVCAudioBackend::FinishRecovery(uint64_t guid) noexcept {
+    if (lock_) {
+        IOLockLock(lock_);
+        recoveringGuids_.erase(guid);
+        IOLockUnlock(lock_);
+    }
+}
+
+void AVCAudioBackend::HandleTimingLoss(uint64_t guid) noexcept {
+    if (guid == 0 || stopping_.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    // Only the active CMP stream is recoverable. IsochService reports the duplex
+    // GUID it claimed; a mismatch means the loss belongs to no stream we own.
+    // recoveringGuids_ dedups against a bus-reset recovery already in flight
+    // (OnDeviceResumed) and against a second timing-loss for the same GUID.
+    bool armed = false;
+    if (lock_) {
+        IOLockLock(lock_);
+        if (activeGuid_ == guid) {
+            armed = recoveringGuids_.insert(guid).second;
+        }
+        IOLockUnlock(lock_);
+    }
+    if (!armed) {
+        return;
+    }
+
+    // A duplex operation already running (start/stop/recovery) is itself the
+    // transition that tripped the replay-discontinuity detector; let it settle.
+    if (duplexCoordinator_.IsOperationInFlight(guid)) {
+        ASFW_LOG(Audio,
+                 "AVCAudioBackend: timing-loss dropped (duplex op in flight) GUID=0x%016llx",
+                 guid);
+        FinishRecovery(guid);
+        return;
+    }
+
+    auto recover = ^{
+        // FW-61: a block enqueued just before BeginTeardown's drain bails here
+        // before any PCR/MMIO work, so it cannot run after hardware detaches.
+        // Debounce off the RX queue: give the [TxAlign] self-heal its transient
+        // window. Poll stopping_ so teardown aborts within one tick.
+        for (uint32_t waited = 0; waited < kTimingLossSettleMs;
+             waited += kTimingLossPollMs) {
+            if (stopping_.load(std::memory_order_acquire)) {
+                FinishRecovery(guid);
+                return;
+            }
+            IOSleep(kTimingLossPollMs);
+        }
+        if (stopping_.load(std::memory_order_acquire)) {
+            FinishRecovery(guid);
+            return;
+        }
+
+        // AV/C health verdict = RX cadence (no register probe, doc §5/§6). If
+        // replay re-established during the settle window the gap was host-side
+        // (StartIO/StopIO churn, a brief RX gap) and already self-healed;
+        // suppress and reset the escalation budget.
+        if (hostTransport_.IsReceiveReplayEstablished()) {
+            if (lock_) {
+                IOLockLock(lock_);
+                timingLossAttempts_.erase(guid);
+                IOLockUnlock(lock_);
+            }
+            ASFW_LOG(Audio,
+                     "AVCAudioBackend: timing-loss self-healed (RX replay re-established) "
+                     "GUID=0x%016llx",
+                     guid);
+            FinishRecovery(guid);
+            return;
+        }
+
+        // Still stalled: a genuine device outage. Bound the escalations so a
+        // device that only partially returns cannot restart-loop forever.
+        uint8_t attempt = 0;
+        if (lock_) {
+            IOLockLock(lock_);
+            attempt = ++timingLossAttempts_[guid];
+            IOLockUnlock(lock_);
+        }
+        if (attempt > kTimingLossMaxAttempts) {
+            ASFW_LOG_ERROR(Audio,
+                           "AVCAudioBackend: timing-loss escalation budget exhausted "
+                           "(attempt=%u); leaving stream stopped GUID=0x%016llx",
+                           attempt, guid);
+            FinishRecovery(guid);
+            return;
+        }
+
+        // Escalate: coordinator restart re-establishes CMP/PCR (the wire-observable
+        // recovery — bebob break_both_connections + cmp_connection_establish; doc §2/§7).
+        ASFW_LOG_WARNING(Audio,
+                         "AVCAudioBackend: RX replay stalled past settle; restarting duplex "
+                         "attempt=%u GUID=0x%016llx",
+                         attempt, guid);
+        const IOReturn status = duplexCoordinator_.RecoverStreaming(
+            guid, DICE::DiceRestartReason::kRecoverAfterTimingLoss);
+        if (status == kIOReturnSuccess) {
+            if (lock_) {
+                IOLockLock(lock_);
+                timingLossAttempts_.erase(guid); // fresh session; reset budget
+                IOLockUnlock(lock_);
+            }
+            ASFW_LOG(Audio,
+                     "AVCAudioBackend: timing-loss recovery succeeded GUID=0x%016llx",
+                     guid);
+        } else {
+            ASFW_LOG_ERROR(Audio,
+                           "AVCAudioBackend: timing-loss recovery failed GUID=0x%016llx kr=0x%x",
+                           guid, status);
+        }
+        FinishRecovery(guid);
+    };
+
+    if (workQueue_) {
+        workQueue_->DispatchAsync(recover);
+        return;
+    }
+    recover();
+}
+
 void AVCAudioBackend::BeginTeardown() noexcept {
     if (stopping_.load(std::memory_order_acquire)) {
         return;
     }
 
     const bool wasStopping = stopping_.exchange(true, std::memory_order_acq_rel);
+    // Stop new timing-loss escalations from being queued during teardown; any
+    // block already queued bails on the stopping_ latch below.
+    hostTransport_.SetTimingLossCallback({});
     // Drain queued recovery before hardware detaches. Each queued block checks
     // stopping_ before it can re-establish PCRs in the teardown window.
     if (workQueue_) {
@@ -298,6 +432,7 @@ IOReturn AVCAudioBackend::StopStreaming(uint64_t guid) noexcept {
         if (activeGuid_ == guid) {
             activeGuid_ = 0;
         }
+        timingLossAttempts_.erase(guid);
         IOLockUnlock(lock_);
     }
 

--- a/ASFWDriver/Audio/Protocols/Backends/AVCAudioBackend.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/AVCAudioBackend.hpp
@@ -51,6 +51,17 @@ public:
     [[nodiscard]] IOReturn StopStreaming(uint64_t guid) noexcept override;
 
 private:
+    // RX timing-loss escalation (doc AVC_STREAM_HEALTH_AND_RECOVERY.md §6). The
+    // transport fires this once when an established replay cadence dies. AV/C has
+    // no health register, so the verdict is the RX cadence itself: debounce a
+    // settle window (let the [TxAlign] self-heal absorb host-side StartIO/StopIO
+    // gaps), then if replay has NOT re-established, escalate to a coordinator
+    // restart (CMP break/re-establish) — matching bebob/FFADO/AppleFWAudio.
+    void HandleTimingLoss(uint64_t guid) noexcept;
+    // Clears the per-GUID in-flight recovery flag (recoveringGuids_). Shared exit
+    // point for the timing-loss escalation block.
+    void FinishRecovery(uint64_t guid) noexcept;
+
     AudioNubPublisher& publisher_;
     Discovery::DeviceRegistry& registry_;
     AudioRuntimeRegistry& runtime_;
@@ -63,7 +74,21 @@ private:
     OSSharedPtr<IODispatchQueue> workQueue_{};
     std::unordered_map<uint64_t, Model::ASFWAudioDevice> configByGuid_{};
     std::unordered_set<uint64_t> recoveringGuids_{};
+    // Consecutive timing-loss escalations without an observed recovery, per GUID.
+    // Reset on self-heal or a successful restart; bounds a restart-loop against a
+    // genuinely gone device. Guarded by lock_.
+    std::unordered_map<uint64_t, uint8_t> timingLossAttempts_{};
     uint64_t activeGuid_{0};
+
+    // Debounce before escalating an RX timing-loss to a restart. AppleFWAudio
+    // uses 80 ms × 2 consecutive late RX callbacks; we settle ~256 ms (≥ several
+    // IO windows) so a host-side StartIO/StopIO gap that the RX epoch reset
+    // self-heals is not mistaken for a device outage.
+    static constexpr uint32_t kTimingLossSettleMs = 256;
+    static constexpr uint32_t kTimingLossPollMs = 32;
+    // Cap consecutive failed escalations so a device that comes back only
+    // partially (re-establishes then dies) cannot restart-loop forever.
+    static constexpr uint8_t kTimingLossMaxAttempts = 4;
 };
 
 } // namespace ASFW::Audio

--- a/ASFWDriver/Audio/Protocols/Backends/IsochDuplexHostTransport.cpp
+++ b/ASFWDriver/Audio/Protocols/Backends/IsochDuplexHostTransport.cpp
@@ -110,4 +110,8 @@ kern_return_t IsochDuplexHostTransport::StopAll() noexcept {
     return kIOReturnSuccess;
 }
 
+bool IsochDuplexHostTransport::IsReceiveReplayEstablished() const noexcept {
+    return isoch_.IsReceiveReplayEstablished();
+}
+
 } // namespace ASFW::Audio

--- a/ASFWDriver/Audio/Protocols/Backends/IsochDuplexHostTransport.hpp
+++ b/ASFWDriver/Audio/Protocols/Backends/IsochDuplexHostTransport.hpp
@@ -64,6 +64,10 @@ class IIsochDuplexHostTransport {
         return kIOReturnUnsupported;
     }
     [[nodiscard]] virtual kern_return_t StopAll() noexcept = 0;
+
+    // AV/C stream-health signal: is the master RX replay cadence established?
+    // Default false for mocks that don't model the RX layer.
+    [[nodiscard]] virtual bool IsReceiveReplayEstablished() const noexcept { return false; }
 };
 
 class IsochDuplexHostTransport final : public IIsochDuplexHostTransport {
@@ -105,6 +109,7 @@ class IsochDuplexHostTransport final : public IIsochDuplexHostTransport {
     [[nodiscard]] kern_return_t StopPreparedReceive() noexcept override;
     [[nodiscard]] kern_return_t StopPreparedTransmit() noexcept override;
     [[nodiscard]] kern_return_t StopAll() noexcept override;
+    [[nodiscard]] bool IsReceiveReplayEstablished() const noexcept override;
 
   private:
     Driver::IsochService& isoch_;

--- a/ASFWDriver/Isoch/IsochService.cpp
+++ b/ASFWDriver/Isoch/IsochService.cpp
@@ -493,6 +493,10 @@ void IsochService::SetTimingLossCallback(TimingLossCallback callback) noexcept {
     timingLossCallback_ = std::move(callback);
 }
 
+bool IsochService::IsReceiveReplayEstablished() const noexcept {
+    return isochReceiveContext_ && isochReceiveContext_->IsReplayEstablished();
+}
+
 void IsochService::SetTxPreparationCallback(TxPreparationCallback callback) noexcept {
     txPreparationCallback_ = std::move(callback);
     if (isochTransmitContext_) {

--- a/ASFWDriver/Isoch/IsochService.hpp
+++ b/ASFWDriver/Isoch/IsochService.hpp
@@ -100,6 +100,14 @@ class IsochService {
 
     void StopAll();
     void SetTimingLossCallback(TimingLossCallback callback) noexcept;
+
+    // AV/C stream-health signal (no device registers): is the master RX replay
+    // cadence currently established? False right after a discontinuity reset;
+    // returns to true once packets resume and Poll re-establishes cadence. Safe
+    // to call off the RX queue (IsReplayEstablished snapshots .control). Used by
+    // the audio backend's timing-loss debounce to tell a host-side gap that
+    // self-healed from a genuine device outage that must escalate to a restart.
+    [[nodiscard]] bool IsReceiveReplayEstablished() const noexcept;
     void SetTxPreparationCallback(TxPreparationCallback callback) noexcept;
     void SetZtsAnchorReadyCallback(ZtsAnchorReadyCallback callback) noexcept;
 


### PR DESCRIPTION
## Why this exists

On the AV/C backend, a persistent RX replay outage had **no floor**. RX fires a timing-loss
callback when an *established* replay cadence dies (`IsochReceiveContext::ResetReplayEpochForDiscontinuity`
→ `IsochService` → the transport callback). `DiceAudioBackend` subscribes to that callback and
escalates; **`AVCAudioBackend` never did** — it only had bus-reset recovery.

So when replay died mid-session (e.g. an RX gap reset the replay ring), TX legally degraded to
NO-DATA and the content-frame cursor froze while CoreAudio kept writing. The designed transient
exit — the `[TxAlign]` self-heal re-projecting the cursor once replay recovers — works, but if the
outage *persisted*, nothing escalated: the wire stayed NO-DATA/stale and audio stayed dropped until
the device stream spontaneously returned. The motivating incident showed the content-frame frontier
stranded ~1 s behind CoreAudio (`deficitMax≈50712`, `writtenDelta=0`) with a **full** packet ring —
proving it is not a buffer-size problem; no ring size bridges a stranded cursor.

Full doctrine + three-stack (Linux bebob/oxfw, libffado, Apple `AppleFWAudio`) analysis is in
`AVC_STREAM_HEALTH_AND_RECOVERY.md`. This PR implements the §6 design at **AV/C-local scope**
(structured to lift into the shared coordinator later per FW-64).

## How it works

**The health signal for AV/C is the RX packet cadence — not a device register.** All three reference
stacks read cadence/continuity, never device state, to decide stream liveness (doc §5). So:

1. **`IsochService::IsReceiveReplayEstablished()`** forwards the master RX replay state
   (`IsochReceiveContext::IsReplayEstablished()`, already cross-queue-safe — it snapshots `.control`).
   Surfaced through `IIsochDuplexHostTransport` (added as a **non-pure** virtual defaulting to `false`,
   so the coordinator test fake keeps compiling) with a concrete override.

2. **`AVCAudioBackend` subscribes `SetTimingLossCallback(HandleTimingLoss)`** in the ctor; the
   callback is cleared in the dtor and in `BeginTeardown` **before** the queue drain (FW-61 teardown
   discipline). `HandleTimingLoss`:
   - guards on `stopping_`, `activeGuid_ == guid`, and `IsOperationInFlight` (a start/stop/recovery
     already running is itself the transition that tripped the detector — let it settle);
   - dedups via the existing `recoveringGuids_` set, shared with the bus-reset path so a bus-reset
     rebind supersedes;
   - then, on the `com.asfw.audio.avc` queue:
     1. **Settle ~256 ms** (Apple's 80 ms × 2 analog, ≥ several IO windows), polling `stopping_`.
     2. **Verdict = RX cadence:** if `IsReceiveReplayEstablished()` is true, the gap was a host-side
        StartIO/StopIO discontinuity that the `[TxAlign]` self-heal already absorbed → **suppress**
        and reset the escalation budget.
     3. Otherwise → **escalate** via the existing `AudioDuplexCoordinator::RecoverStreaming(guid,
        kRecoverAfterTimingLoss)` — the wire-observable CMP break/re-establish (matches bebob's
        `break_both_connections` + `cmp_connection_establish`, doc §2/§7).
   - **Bounded** by a per-GUID `timingLossAttempts_` budget (max 4, guarded by `lock_`), reset on
     self-heal / restart-success / stop / removal, so a device that only partially returns cannot
     restart-loop forever.

### Why the settle is a *debounce*, not bebob's 1 s warm-up

The 256 ms window is a **pre-restart debounce** — the transient-tolerance every reference stack has
(Apple 2×, FFADO 2 s, Linux jumbo-cycle). It is **not** bebob's ~1 s *post-CMP* NO-DATA warm-up.
Warm-up cannot cause a restart loop here because timing-loss fires only when a **previously
established** replay dies (`wasEstablished` guard); during warm-up replay was never established, so it
never re-fires.

## How this differs from DICE

Same trigger (`SetTimingLossCallback`), same escalation vehicle (`RecoverStreaming`), same
`DiceRestartReason` enum — but a **different health verdict**, because the two device classes expose
different ground truth:

| | DICE (`DiceAudioBackend`) | AV/C (`AVCAudioBackend`, this PR) |
|---|---|---|
| Health probe | **Register read** — DICE GLOBAL/STATUS/EXT_STATUS clock lock + rate (`ReadDuplexHealth`) | **RX cadence** — `IsReceiveReplayEstablished()` after a settle window |
| Why | TCAT exposes a clean lock/rate block | AV/C has **no** such register; the packet stream *is* the signal (doc §5) |
| Debounce | health-gate at event time (locked+healthy ⇒ suppress) | ~256 ms settle, then re-check cadence |
| Escalation | `RecoverStreaming` | `RecoverStreaming` (same) |
| Retry bound | coordinator policy + `recoveringGuids_` | + per-GUID attempt budget (max 4) |

The DICE register probe is a **TCAT-specific luxury and must not be assumed portable** — that is the
whole reason AV/C uses cadence instead. Both paths converge on the same shared coordinator restart.

## Secondary: `[TxPrepRange]` log flood

The `[TxPrepRange]` anomaly line (`ASFWAudioDriverZts.cpp`) flooded at ~1 kHz during the incident
because the persistent `frameShort` stall tripped the gate every wake. It now uses `ASFW_LOG_RL` with
a **runtime** interval of `stoppedShort ? 0 : 1000` ms: `stoppedShort` still logs every wake (rare,
precedes an IT FATAL — kept for diagnosis), while a `frameShort`-only stall throttles to ~1/s with a
suppressed-count. The `[TxPrepRange]` grep tag is preserved.

## Safety / invariants respected

- **No new blocking CMP wait** — only *triggers* the existing coordinator recovery, so FW-94's
  CMP-as-CPS discipline is untouched.
- **FW-61 teardown** — callback cleared before the drain; every queued block re-checks `stopping_`.
- **Cross-queue** — `IsReplayEstablished()` snapshots `.control` (FW-62 pattern); the debounce runs on
  the dedicated `com.asfw.audio.avc` queue.

## Testing

- Xcode dext build: **succeeds** (only pre-existing retain-count analyzer warnings in an untouched
  function).
- Full C++ suite: **1335/1335 pass**, including `AudioDuplexCoordinatorTests.TimingLossRecoveryRestartsRunningSession`.
- **Unverified on hardware** — an actual RX-outage → restart cycle still needs to be observed on a
  device. No unit test for the backend debounce path (needs `IOSleep`/`DispatchAsync`/DriverKit
  mocking; `AVCAudioBackend` has no test file); the coordinator-level recovery is already covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)