### PR TITLE
feat(app): streamline local install workflow and activation feedback

### DIFF
--- a/ASFW.xcodeproj/project.pbxproj
+++ b/ASFW.xcodeproj/project.pbxproj
@@ -3017,8 +3017,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				EE5A446B3669D0171F9606EE /* ASFW */,
 				0EB9A8DA75D08971084A440A /* ASFWDriver */,
+				EE5A446B3669D0171F9606EE /* ASFW */,
 				348672D607701677ABCB567C /* ASFWTests */,
 			);
 		};

--- a/ASFW.xcodeproj/project.pbxproj
+++ b/ASFW.xcodeproj/project.pbxproj
@@ -261,6 +261,7 @@
 		AFC2E3AB6C936BA99AE2EA14 /* BeBoBProtocol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3287F0F488601696A613BF7E /* BeBoBProtocol.cpp */; };
 		B07CDAE71C02447EAFF0D87F /* MCPSbp2ToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D052AC7D4757845AB77B75B1 /* MCPSbp2ToolsTests.swift */; };
 		B0F2BC5D0380C0A6C5D22E96 /* IsochTxDmaRing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 94EF7FD118B54788C8319EFE /* IsochTxDmaRing.cpp */; };
+		B1B039506A55599CAB9BD7F4 /* DriverInstallErrorFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034B69484ACD3D09EF6D4A5F /* DriverInstallErrorFormatterTests.swift */; };
 		B20580E11D942850F1B8C005 /* ModernContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736A4C5A335E4750AF418976 /* ModernContentView.swift */; };
 		B2065E363F1AC2D5DB5EF5DA /* PhyDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98670FC8D8008C5956DED82 /* PhyDiagnostics.swift */; };
 		B48FA948465DEDE30BA18B47 /* AVCUnitWireParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF378D7A8CBF72942CB67F13 /* AVCUnitWireParsingTests.swift */; };
@@ -418,6 +419,7 @@
 		0305E1A8A4D9799CD3CB2887 /* ASFWAudioDriverGraph.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ASFWAudioDriverGraph.cpp; sourceTree = "<group>"; };
 		030DE44371FB8109F515F09E /* MCPTransactionSchemaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPTransactionSchemaTests.swift; sourceTree = "<group>"; };
 		032CA480750A71DDD179CE7D /* AlesisMultiMixProfile.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = AlesisMultiMixProfile.hpp; sourceTree = "<group>"; };
+		034B69484ACD3D09EF6D4A5F /* DriverInstallErrorFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DriverInstallErrorFormatterTests.swift; sourceTree = "<group>"; };
 		03627F2DBAE568BDFB6E1E7F /* IRMCSRConstants.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = IRMCSRConstants.hpp; sourceTree = "<group>"; };
 		037576E0DAB3B87F0D80A8B3 /* BusResetPacketDiagram.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusResetPacketDiagram.swift; sourceTree = "<group>"; };
 		040E3246E90734BBE6ED2380 /* MCPConsoleLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPConsoleLogTests.swift; sourceTree = "<group>"; };
@@ -1700,6 +1702,7 @@
 				AB92C50A509F45F51EFD3F03 /* AVCNestedChannelTests.swift */,
 				8AC380D7BBAE68986EC3385C /* AVCSampleRateMappingTests.swift */,
 				DF378D7A8CBF72942CB67F13 /* AVCUnitWireParsingTests.swift */,
+				034B69484ACD3D09EF6D4A5F /* DriverInstallErrorFormatterTests.swift */,
 				C3C3C0A53557FD4630647F63 /* DuetCodecTests.swift */,
 				51751F4E2707BF3956287D1F /* DuetViewModelLogicTests.swift */,
 				AA63228416151FD72A8A9C49 /* MCP */,
@@ -3300,6 +3303,7 @@
 				47C7D2797F3974490450A45A /* AVCNestedChannelTests.swift in Sources */,
 				BFA67B801CE2FD081CFA4BF5 /* AVCSampleRateMappingTests.swift in Sources */,
 				B48FA948465DEDE30BA18B47 /* AVCUnitWireParsingTests.swift in Sources */,
+				B1B039506A55599CAB9BD7F4 /* DriverInstallErrorFormatterTests.swift in Sources */,
 				38FE60619DFBA6ECB035BE64 /* DuetCodecTests.swift in Sources */,
 				BBC4374CAF02DA7A26022E78 /* DuetViewModelLogicTests.swift in Sources */,
 				AB26C52B22F65434EA8E93A7 /* MCPAvcFcpToolsTests.swift in Sources */,

--- a/ASFW/ASFWApp.swift
+++ b/ASFW/ASFWApp.swift
@@ -5,12 +5,19 @@
 //  Created by Alexander Shabelnikov on 21.09.2025.
 //
 
+import Foundation
 import SwiftUI
+
 @main
 struct ASFWApp: App {
+    private let autoActivateDriverOnLaunch =
+        ProcessInfo.processInfo.arguments.contains("--activate-driver")
+
     var body: some Scene {
         WindowGroup {
-            ModernContentView()
+            ModernContentView(
+                autoActivateDriverOnLaunch: autoActivateDriverOnLaunch
+            )
         }
         .defaultSize(width: 1000, height: 700)
     }

--- a/ASFW/DriverInstallManager.swift
+++ b/ASFW/DriverInstallManager.swift
@@ -48,6 +48,22 @@ enum DriverInstallErrorFormatter {
     }
 }
 
+enum DriverInstallResultFormatter {
+    static func describe(
+        operation: String,
+        result: OSSystemExtensionRequest.Result
+    ) -> String {
+        switch result {
+        case .completed:
+            return "\(operation) completed"
+        case .willCompleteAfterReboot:
+            return "\(operation) accepted. Restart macOS to complete the system extension change."
+        @unknown default:
+            return "\(operation) finished with unknown result \(result.rawValue)"
+        }
+    }
+}
+
 final class DriverInstallManager: NSObject, OSSystemExtensionRequestDelegate {
     static let shared = DriverInstallManager()
     private override init() {}
@@ -78,7 +94,7 @@ final class DriverInstallManager: NSObject, OSSystemExtensionRequestDelegate {
     // MARK: OSSystemExtensionRequestDelegate
     func request(_ request: OSSystemExtensionRequest, didFinishWithResult result: OSSystemExtensionRequest.Result) {
         let op = (currentOp == .activation ? "Activation" : "Deactivation")
-        completion?(.success("\(op) finished with result: \(result.rawValue)"))
+        completion?(.success(DriverInstallResultFormatter.describe(operation: op, result: result)))
         completion = nil
     }
 

--- a/ASFW/DriverInstallManager.swift
+++ b/ASFW/DriverInstallManager.swift
@@ -1,6 +1,53 @@
 import Foundation
 import SystemExtensions
 
+enum DriverInstallErrorFormatter {
+    static func describe(error: Error) -> NSError {
+        let nsError = error as NSError
+        guard nsError.domain == OSSystemExtensionErrorDomain,
+              let code = OSSystemExtensionError.Code(rawValue: nsError.code) else {
+            return nsError
+        }
+
+        let message: String
+        switch code {
+        case .unknown:
+            message = "Unknown system extension error"
+        case .missingEntitlement:
+            message = "Missing required system extension entitlement"
+        case .unsupportedParentBundleLocation:
+            message = "App must be launched from a supported bundle location"
+        case .extensionNotFound:
+            message = "System extension not found inside the running app bundle"
+        case .extensionMissingIdentifier:
+            message = "System extension bundle identifier is missing"
+        case .duplicateExtensionIdentifer:
+            message = "Duplicate system extension identifier found in app bundle"
+        case .unknownExtensionCategory:
+            message = "Unknown system extension category"
+        case .codeSignatureInvalid:
+            message = "System extension code signature is invalid"
+        case .validationFailed:
+            message = "System extension validation failed"
+        case .forbiddenBySystemPolicy:
+            message = "System policy blocked the system extension"
+        case .requestCanceled:
+            message = "System extension request was canceled"
+        case .requestSuperseded:
+            message = "System extension request was superseded by a newer request"
+        case .authorizationRequired:
+            message = "System extension authorization is required"
+        @unknown default:
+            message = nsError.localizedDescription
+        }
+
+        var userInfo = nsError.userInfo
+        userInfo[NSLocalizedDescriptionKey] =
+            "\(message) (\(nsError.domain) error \(nsError.code))"
+        return NSError(domain: nsError.domain, code: nsError.code, userInfo: userInfo)
+    }
+}
+
 final class DriverInstallManager: NSObject, OSSystemExtensionRequestDelegate {
     static let shared = DriverInstallManager()
     private override init() {}
@@ -14,7 +61,6 @@ final class DriverInstallManager: NSObject, OSSystemExtensionRequestDelegate {
 
     func activate(completion: @escaping (Result<String, Error>) -> Void) {
         submit(kind: .activation, request: OSSystemExtensionRequest.activationRequest(forExtensionWithIdentifier: extensionIdentifier, queue: .main), completion: completion)
-        logBundleScan()
     }
 
     func deactivate(completion: @escaping (Result<String, Error>) -> Void) {
@@ -25,6 +71,7 @@ final class DriverInstallManager: NSObject, OSSystemExtensionRequestDelegate {
         currentOp = kind
         request.delegate = self
         self.completion = completion
+        logBundleScan()
         OSSystemExtensionManager.shared.submitRequest(request)
     }
 
@@ -36,7 +83,7 @@ final class DriverInstallManager: NSObject, OSSystemExtensionRequestDelegate {
     }
 
     func request(_ request: OSSystemExtensionRequest, didFailWithError error: Error) {
-        completion?(.failure(error))
+        completion?(.failure(DriverInstallErrorFormatter.describe(error: error)))
         completion = nil
     }
 

--- a/ASFW/Views/ModernContentView.swift
+++ b/ASFW/Views/ModernContentView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import Foundation
 
 struct ModernContentView: View {
+    let autoActivateDriverOnLaunch: Bool
     @StateObject private var driverVM = DriverViewModel()
     @StateObject private var debugVM = DebugViewModel()
     @StateObject private var topologyVM: TopologyViewModel
@@ -17,8 +18,10 @@ struct ModernContentView: View {
     @StateObject private var mcpVM: ASFWMCPControlViewModel
     @State private var selectedSection: SidebarSection? = .overview
     @State private var loggingPreset: LoggingPreset = .standard
+    @State private var didTriggerAutoDriverActivation = false
 
-    init() {
+    init(autoActivateDriverOnLaunch: Bool = false) {
+        self.autoActivateDriverOnLaunch = autoActivateDriverOnLaunch
         let driverViewModel = DriverViewModel()
         let debugViewModel = DebugViewModel()
         let topologyViewModel = TopologyViewModel(connector: debugViewModel.connector)
@@ -183,7 +186,12 @@ struct ModernContentView: View {
         }
         .onAppear {
             debugVM.setDriverViewModel(driverVM)
-            debugVM.connect()
+            if autoActivateDriverOnLaunch && !didTriggerAutoDriverActivation {
+                didTriggerAutoDriverActivation = true
+                activateDriverOnLaunch()
+            } else {
+                debugVM.connect()
+            }
             topologyVM.startAutoRefresh()
             romExplorerVM.setConnector(debugVM.connector, topologyViewModel: topologyVM)
             loadLoggingPreset()
@@ -200,6 +208,12 @@ struct ModernContentView: View {
             // Update available nodes when topology generation changes
             romExplorerVM.refreshAvailableNodes()
         }
+    }
+
+    private func activateDriverOnLaunch() {
+        debugVM.disconnect()
+        driverVM.driverVersion = nil
+        driverVM.installDriver()
     }
     
     enum LoggingPreset: String, CaseIterable, Identifiable {

--- a/ASFW/Views/OverviewView.swift
+++ b/ASFW/Views/OverviewView.swift
@@ -43,6 +43,7 @@ struct OverviewView: View {
                         statusIndicator
                         Text(viewModel.activationStatus)
                             .font(.system(.body, design: .monospaced))
+                            .textSelection(.enabled)
                         Spacer()
                     }
                     .padding()

--- a/ASFWTests/DriverInstallErrorFormatterTests.swift
+++ b/ASFWTests/DriverInstallErrorFormatterTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import SystemExtensions
+import Testing
+@testable import ASFW
+
+struct DriverInstallErrorFormatterTests {
+    @Test func describesInvalidSignatureWithActionableContext() {
+        let error = NSError(
+            domain: OSSystemExtensionErrorDomain,
+            code: OSSystemExtensionError.Code.codeSignatureInvalid.rawValue
+        )
+
+        let described = DriverInstallErrorFormatter.describe(error: error)
+
+        #expect(described.domain == OSSystemExtensionErrorDomain)
+        #expect(described.code == OSSystemExtensionError.Code.codeSignatureInvalid.rawValue)
+        #expect(described.localizedDescription.contains("code signature is invalid"))
+        #expect(described.localizedDescription.contains("OSSystemExtensionErrorDomain"))
+    }
+
+    @Test func preservesErrorsOutsideSystemExtensionDomain() {
+        let error = NSError(
+            domain: NSCocoaErrorDomain,
+            code: NSFileReadNoSuchFileError,
+            userInfo: [NSLocalizedDescriptionKey: "Missing bundle"]
+        )
+
+        let described = DriverInstallErrorFormatter.describe(error: error)
+
+        #expect(described === error)
+        #expect(described.localizedDescription == "Missing bundle")
+    }
+}

--- a/ASFWTests/DriverInstallErrorFormatterTests.swift
+++ b/ASFWTests/DriverInstallErrorFormatterTests.swift
@@ -31,3 +31,24 @@ struct DriverInstallErrorFormatterTests {
         #expect(described.localizedDescription == "Missing bundle")
     }
 }
+
+struct DriverInstallResultFormatterTests {
+    @Test func describesCompletedActivation() {
+        let description = DriverInstallResultFormatter.describe(
+            operation: "Activation",
+            result: .completed
+        )
+
+        #expect(description == "Activation completed")
+    }
+
+    @Test func tellsTheUserToRestartForDeferredActivation() {
+        let description = DriverInstallResultFormatter.describe(
+            operation: "Activation",
+            result: .willCompleteAfterReboot
+        )
+
+        #expect(description.contains("Activation accepted"))
+        #expect(description.contains("Restart macOS"))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -492,8 +492,9 @@ boot normally, uninstall the extension
 
 Use `install-asfw.sh` to follow the development build, ad-hoc signing, artifact
 verification, and `/Applications` staging flow in one command. The script does
-not submit the system-extension activation request itself. It opens the installed
-app so you can review the visible state and use the **Install** button.
+not submit the system-extension activation request by default. It opens the
+installed app so you can review the visible state and use the **Install**
+button.
 
 The script never opens a password prompt. If `/Applications` or the uninstall
 operation needs administrator access, prime a short-lived credential first:
@@ -503,22 +504,29 @@ sudo -v
 ./install-asfw.sh --config Debug
 ```
 
-Pass `--fresh` when replacing an active dext or clearing a pending ASFW
-upgrade or uninstall. The script closes the installed app, asks
-`systemextensionsctl` to remove the existing ASFW state, and waits for all old
-dext entries to disappear before it replaces the app. Pass `--no-build` to reuse
-the current build product. The experimental SCSI HBA and bundled Codex MCP
-skill remain explicit:
+For a one-command development replacement, pass `--activate`. The script opens
+the installed app with an explicit automatic activation request, waits for the
+active dext hash to match the installed build, and fails if macOS doesn't
+complete the replacement. `--refresh` is a compatibility alias for
+`--activate`.
 
 ```bash
 sudo -v
-./install-asfw.sh --config Debug --scsi --fresh --install-mcp-skill
+./install-asfw.sh --config Debug --scsi --activate
 ```
 
-Without `--fresh`, the script stops when it finds an ASFW upgrade or uninstall
-in progress and tells you to rerun with `--fresh`. A restart is only required
-if `systemextensionsctl uninstall` succeeds but macOS still retains the old
-dext state after the unload timeout.
+Pass `--fresh` only when you need to clear an existing or pending ASFW system
+extension state. The script closes the installed app, asks
+`systemextensionsctl` to remove the existing ASFW state, and waits for all old
+dext entries to disappear before it replaces the app. Start routine
+development replacements without `--fresh`; use it when the script reports a
+pending transition.
+
+Pass `--no-build` to reuse the current build product. Without `--fresh`, the
+script stops when it finds an ASFW upgrade or uninstall in progress and tells
+you to rerun with `--fresh`. A restart is only required if
+`systemextensionsctl uninstall` succeeds but macOS still retains the old dext
+state after the unload timeout.
 
 Keep an SBP-2 device powered on before installing or testing a `--scsi` build.
 The cold-boot and teardown warning in the preceding section still applies.

--- a/README.md
+++ b/README.md
@@ -503,18 +503,22 @@ sudo -v
 ./install-asfw.sh --config Debug
 ```
 
-Pass `--fresh` when replacing an active dext, or `--no-build` to reuse the
-current build product. The experimental SCSI HBA and bundled Codex MCP skill
-remain explicit:
+Pass `--fresh` when replacing an active dext or clearing a pending ASFW
+upgrade or uninstall. The script closes the installed app, asks
+`systemextensionsctl` to remove the existing ASFW state, and waits for all old
+dext entries to disappear before it replaces the app. Pass `--no-build` to reuse
+the current build product. The experimental SCSI HBA and bundled Codex MCP
+skill remain explicit:
 
 ```bash
 sudo -v
 ./install-asfw.sh --config Debug --scsi --fresh --install-mcp-skill
 ```
 
-If macOS reports that an ASFW upgrade or uninstall is waiting for a reboot, the
-script stops before building or replacing the app. Restart macOS to complete the
-pending system-extension change, then run the command again.
+Without `--fresh`, the script stops when it finds an ASFW upgrade or uninstall
+in progress and tells you to rerun with `--fresh`. A restart is only required
+if `systemextensionsctl uninstall` succeeds but macOS still retains the old
+dext state after the unload timeout.
 
 Keep an SBP-2 device powered on before installing or testing a `--scsi` build.
 The cold-boot and teardown warning in the preceding section still applies.

--- a/README.md
+++ b/README.md
@@ -512,6 +512,10 @@ sudo -v
 ./install-asfw.sh --config Debug --scsi --fresh --install-mcp-skill
 ```
 
+If macOS reports that an ASFW upgrade or uninstall is waiting for a reboot, the
+script stops before building or replacing the app. Restart macOS to complete the
+pending system-extension change, then run the command again.
+
 Keep an SBP-2 device powered on before installing or testing a `--scsi` build.
 The cold-boot and teardown warning in the preceding section still applies.
 

--- a/README.md
+++ b/README.md
@@ -488,6 +488,33 @@ If a machine ever ends up in a panic loop: boot into Recovery, `csrutil disable`
 boot normally, uninstall the extension
 (`systemextensionsctl uninstall - net.mrmidi.ASFW.ASFWDriver`), then re-enable SIP.
 
+### Reinstalling a local development build
+
+Use `install-asfw.sh` to follow the development build, ad-hoc signing, artifact
+verification, and `/Applications` staging flow in one command. The script does
+not submit the system-extension activation request itself. It opens the installed
+app so you can review the visible state and use the **Install** button.
+
+The script never opens a password prompt. If `/Applications` or the uninstall
+operation needs administrator access, prime a short-lived credential first:
+
+```bash
+sudo -v
+./install-asfw.sh --config Debug
+```
+
+Pass `--fresh` when replacing an active dext, or `--no-build` to reuse the
+current build product. The experimental SCSI HBA and bundled Codex MCP skill
+remain explicit:
+
+```bash
+sudo -v
+./install-asfw.sh --config Debug --scsi --fresh --install-mcp-skill
+```
+
+Keep an SBP-2 device powered on before installing or testing a `--scsi` build.
+The cold-boot and teardown warning in the preceding section still applies.
+
 ## Installing a prebuilt build (testers)
 
 If you want to test ASFireWire without building it yourself, tagged releases attach a

--- a/install-asfw.sh
+++ b/install-asfw.sh
@@ -338,7 +338,11 @@ if ${AUTO_ACTIVATE} && ! ${LAUNCH_APP}; then
   die "--activate cannot be combined with --no-launch"
 fi
 
-csrutil status | grep -qi 'disabled' \
+# Match the status line only. Under a Custom Configuration csrutil prints a
+# per-protection breakdown, and a bare 'disabled' search matches any single
+# disabled entry (e.g. "Apple Internal: disabled") on a machine where SIP is
+# otherwise on — letting the install proceed and fail later in a confusing way.
+csrutil status | head -n 1 | grep -qi 'status: disabled' \
   || die "SIP must be disabled for the README ad-hoc install workflow"
 systemextensionsctl developer 2>&1 | grep -qi 'developer mode is on' \
   || die "Enable system-extension developer mode before installing"

--- a/install-asfw.sh
+++ b/install-asfw.sh
@@ -152,9 +152,15 @@ print_active_dext_status() {
 wait_for_active_dext_hash() {
   local expected_hash="$1"
   local attempts="${2:-30}"
+  # macOS parks the extension in "activated waiting for user" until someone
+  # approves it in System Settings and authenticates. That is a human step, not
+  # machine progress the installer can wait out, so it draws on its own much
+  # larger budget instead of consuming the transition budget.
+  local approval_attempts="${3:-300}"
   local extension_lines
+  local prompted=false
 
-  while (( attempts > 0 )); do
+  while (( attempts > 0 && approval_attempts > 0 )); do
     extension_lines="$(system_extension_lines)" \
       || die "Unable to query the current system-extension state"
     if [[ -n "${extension_lines}" ]] \
@@ -163,11 +169,29 @@ wait_for_active_dext_hash() {
       log "Active dext matches the installed build: ${expected_hash}"
       return 0
     fi
+
+    if grep -Eq '\[activated waiting for user' <<<"${extension_lines}"; then
+      if ! ${prompted}; then
+        prompted=true
+        log "macOS is waiting for you to approve the extension."
+        log "  System Settings > General > Login Items & Extensions >"
+        log "  Driver Extensions > enable ASFW, then authenticate."
+        log "Waiting up to ${approval_attempts}s for that approval..."
+      fi
+      sleep 1
+      ((approval_attempts--))
+      continue
+    fi
+
     sleep 1
     ((attempts--))
   done
 
-  log "The active dext did not switch to the installed build."
+  if ${prompted}; then
+    log "The extension was never approved, so activation did not complete."
+  else
+    log "The active dext did not switch to the installed build."
+  fi
   print_active_dext_status
   return 1
 }
@@ -370,9 +394,15 @@ EXPECTED_DEXT_HASH="$(sha256_file "${APP_DEST}/${DEXT_BINARY_REL}")"
 if ${LAUNCH_APP}; then
   launch_installed_app
   if ${AUTO_ACTIVATE}; then
-    wait_for_active_dext_hash "${EXPECTED_DEXT_HASH}" 30 \
-      || die "Automatic activation did not produce the expected active dext"
+    activation_ok=true
+    wait_for_active_dext_hash "${EXPECTED_DEXT_HASH}" || activation_ok=false
+    # Reopen either way. The instance launched with --activate-driver stays on
+    # the activation path and never connects its debug client, so returning
+    # without this leaves the app running but disconnected — including when the
+    # approval simply took longer than the wait above.
     reopen_installed_app_for_debugging
+    ${activation_ok} \
+      || die "Automatic activation did not produce the expected active dext"
   else
     log "Use the visible Install button to submit the extension replacement."
   fi

--- a/install-asfw.sh
+++ b/install-asfw.sh
@@ -31,7 +31,7 @@ Options:
   --scsi                  Include the experimental SCSI HBA
   --no-build              Reuse an existing build product
   --install-mcp-skill     Install or refresh the bundled Codex MCP skill
-  --fresh, --replace      Uninstall the active dext before staging the new app
+  --fresh, --replace      Uninstall existing dext state before staging the app
   --no-launch             Do not open ASFW.app after installation
   -h, --help              Show this help
 
@@ -104,19 +104,13 @@ close_existing_app() {
   die "ASFW.app is still running; close it manually and rerun the installer"
 }
 
-has_active_system_extension() {
-  local extension_lines
-  extension_lines="$(system_extension_lines)" || return $?
-  grep -qF '[activated enabled]' <<<"${extension_lines}"
-}
-
 system_extension_lines() {
   local extension_list
   extension_list="$(systemextensionsctl list 2>/dev/null)" || return 2
   grep -F "${SYSTEM_EXTENSION_ID}" <<<"${extension_list}" || true
 }
 
-ensure_no_pending_system_extension_transition() {
+ensure_replace_mode_for_pending_transition() {
   local extension_lines
   extension_lines="$(system_extension_lines)" \
     || die "Unable to query the current system-extension state"
@@ -125,42 +119,40 @@ ensure_no_pending_system_extension_transition() {
       <<<"${extension_lines}"; then
     log "ASFW has a pending system-extension transition:"
     printf '%s\n' "${extension_lines}"
-    die "Restart macOS to finish the pending change before reinstalling ASFW"
+    ${FRESH_REPLACE} && return 0
+    die "Rerun with --fresh to uninstall the pending dext state before replacement"
   fi
 }
 
-uninstall_active_system_extension() {
-  local query_status
-  if has_active_system_extension; then
-    :
-  else
-    query_status=$?
-    [[ ${query_status} -eq 1 ]] \
-      || die "Unable to query the current system-extension state"
-    log "No active ASFW system extension needs to be uninstalled."
+uninstall_existing_system_extension() {
+  local extension_lines
+  extension_lines="$(system_extension_lines)" \
+    || die "Unable to query the current system-extension state"
+  if [[ -z "${extension_lines}" ]]; then
+    log "No existing ASFW system extension needs to be uninstalled."
     return 0
   fi
 
   close_existing_app
-  log "Uninstalling the active ASFW dext before replacement..."
+  log "Uninstalling existing ASFW dext state before replacement..."
   run_maybe_sudo systemextensionsctl uninstall - "${SYSTEM_EXTENSION_ID}" \
     || die "Failed to uninstall ${SYSTEM_EXTENSION_ID}"
 
   local attempts=30
   while (( attempts > 0 )); do
-    if has_active_system_extension; then
-      :
-    else
-      query_status=$?
-      [[ ${query_status} -eq 1 ]] \
-        || die "Unable to verify the system-extension uninstall"
-      log "The previous ASFW dext is no longer active."
+    extension_lines="$(system_extension_lines)" \
+      || die "Unable to verify the system-extension uninstall"
+    if [[ -z "${extension_lines}" ]]; then
+      log "The previous ASFW dext state has been removed."
       return 0
     fi
     sleep 1
     ((attempts--))
   done
-  die "The previous ASFW dext is still active; close its clients and retry"
+
+  log "ASFW system-extension state still present after uninstall:"
+  printf '%s\n' "${extension_lines}"
+  die "macOS could not unload the previous dext; restart macOS before retrying"
 }
 
 verify_artifact() {
@@ -282,7 +274,7 @@ csrutil status | grep -qi 'disabled' \
   || die "SIP must be disabled for the README ad-hoc install workflow"
 systemextensionsctl developer 2>&1 | grep -qi 'developer mode is on' \
   || die "Enable system-extension developer mode before installing"
-ensure_no_pending_system_extension_transition
+ensure_replace_mode_for_pending_transition
 
 if ${DO_BUILD}; then
   build_args=(--no-bump --config "${CONFIGURATION}")
@@ -299,7 +291,7 @@ CONFIGURATION="${CONFIGURATION}" ./sign.sh "${APP_SOURCE}"
 verify_artifact "${APP_SOURCE}"
 
 ${INSTALL_MCP_SKILL} && install_mcp_skill
-${FRESH_REPLACE} && uninstall_active_system_extension
+${FRESH_REPLACE} && uninstall_existing_system_extension
 install_app_atomically "${APP_SOURCE}"
 
 if ${LAUNCH_APP}; then

--- a/install-asfw.sh
+++ b/install-asfw.sh
@@ -105,10 +105,28 @@ close_existing_app() {
 }
 
 has_active_system_extension() {
+  local extension_lines
+  extension_lines="$(system_extension_lines)" || return $?
+  grep -qF '[activated enabled]' <<<"${extension_lines}"
+}
+
+system_extension_lines() {
   local extension_list
   extension_list="$(systemextensionsctl list 2>/dev/null)" || return 2
-  grep -F "${SYSTEM_EXTENSION_ID}" <<<"${extension_list}" \
-    | grep -qF '[activated enabled]'
+  grep -F "${SYSTEM_EXTENSION_ID}" <<<"${extension_list}" || true
+}
+
+ensure_no_pending_system_extension_transition() {
+  local extension_lines
+  extension_lines="$(system_extension_lines)" \
+    || die "Unable to query the current system-extension state"
+
+  if grep -Eq '\[(activated waiting .*reboot|terminating )' \
+      <<<"${extension_lines}"; then
+    log "ASFW has a pending system-extension transition:"
+    printf '%s\n' "${extension_lines}"
+    die "Restart macOS to finish the pending change before reinstalling ASFW"
+  fi
 }
 
 uninstall_active_system_extension() {
@@ -264,6 +282,7 @@ csrutil status | grep -qi 'disabled' \
   || die "SIP must be disabled for the README ad-hoc install workflow"
 systemextensionsctl developer 2>&1 | grep -qi 'developer mode is on' \
   || die "Enable system-extension developer mode before installing"
+ensure_no_pending_system_extension_transition
 
 if ${DO_BUILD}; then
   build_args=(--no-bump --config "${CONFIGURATION}")

--- a/install-asfw.sh
+++ b/install-asfw.sh
@@ -20,6 +20,10 @@ SYSTEM_EXTENSION_ID="net.mrmidi.ASFW.ASFWDriver"
 DEXT_REL="Contents/Library/SystemExtensions/${SYSTEM_EXTENSION_ID}.dext"
 DEXT_BINARY_REL="${DEXT_REL}/${SYSTEM_EXTENSION_ID}"
 SYSTEM_EXTENSION_ROOT="/Library/SystemExtensions"
+# Every install keeps the app it replaced so a bad build can be rolled back by
+# hand. Without pruning, a day of iterating leaves a pile of app bundles in
+# /Applications. Keep the most recent few and drop the rest.
+BACKUP_KEEP_COUNT=3
 
 usage() {
   cat <<'EOF'
@@ -281,6 +285,42 @@ reject_test_host_artifacts() {
     "Build product contains ${test_bundle}; rerun without --no-build after testing"
 }
 
+prune_old_app_backups() {
+  local keep="${BACKUP_KEEP_COUNT}"
+  local backups=()
+  local candidate
+  local index
+
+  # Match the exact shape install_app_atomically writes (%Y%m%d-%H%M%S), not a
+  # bare backup-* glob: an unrelated directory would sort above the timestamps
+  # and take a slot that should have kept a real backup. Zero-padded timestamps
+  # make a reverse name sort newest-first, and -maxdepth 1 keeps find from ever
+  # descending into a bundle.
+  local stamp_glob='[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]'
+  while IFS= read -r candidate; do
+    [[ -n "${candidate}" ]] || continue
+    backups+=("${candidate}")
+  done < <(
+    find /Applications -maxdepth 1 -type d -name "ASFW.app.backup-${stamp_glob}" \
+      -print 2>/dev/null | sort -r
+  )
+
+  (( ${#backups[@]} > keep )) || return 0
+
+  for (( index = keep; index < ${#backups[@]}; index++ )); do
+    candidate="${backups[index]}"
+    # Re-check the shape immediately before removing. This function only ever
+    # deletes paths it just enumerated out of /Applications, and only ones that
+    # still match the backup name exactly.
+    if [[ "${candidate}" != /Applications/ASFW.app.backup-* || ! -d "${candidate}" ]]; then
+      continue
+    fi
+    log "Pruning old backup ${candidate}..."
+    run_maybe_sudo rm -rf "${candidate}" \
+      || log "Could not remove ${candidate}; leaving it in place."
+  done
+}
+
 install_app_atomically() {
   local source_app="$1"
   local timestamp
@@ -317,6 +357,10 @@ install_app_atomically() {
   verify_artifact "${APP_DEST}"
   log "Installed dext hash: $(sha256_file "${APP_DEST}/${DEXT_BINARY_REL}")"
   [[ -z "${backup}" ]] || log "Previous app backup: ${backup}"
+
+  # Only after the freshly installed app verifies. A failed install must keep
+  # every backup it might have to roll back to.
+  prune_old_app_backups
 }
 
 launch_installed_app() {

--- a/install-asfw.sh
+++ b/install-asfw.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# Build, sign, and stage ASFW.app using the workflow documented in README.md.
-# System-extension activation remains an explicit action in ASFW.app.
+# Build, sign, stage, and optionally activate ASFW.app using the workflow
+# documented in README.md.
 
 set -Eeuo pipefail
 
@@ -11,16 +11,15 @@ cd "${SCRIPT_DIR}"
 CONFIGURATION="Release"
 DO_BUILD=true
 ENABLE_SCSI=false
-INSTALL_MCP_SKILL=false
 LAUNCH_APP=true
 FRESH_REPLACE=false
+AUTO_ACTIVATE=false
 
 APP_DEST="/Applications/ASFW.app"
 SYSTEM_EXTENSION_ID="net.mrmidi.ASFW.ASFWDriver"
 DEXT_REL="Contents/Library/SystemExtensions/${SYSTEM_EXTENSION_ID}.dext"
 DEXT_BINARY_REL="${DEXT_REL}/${SYSTEM_EXTENSION_ID}"
-MCP_SKILL_SOURCE="${SCRIPT_DIR}/skills/asfw-mcp-control-plane"
-CODEX_ROOT="${CODEX_HOME:-${HOME}/.codex}"
+SYSTEM_EXTENSION_ROOT="/Library/SystemExtensions"
 
 usage() {
   cat <<'EOF'
@@ -30,8 +29,8 @@ Options:
   --config Debug|Release  Build configuration (default: Release)
   --scsi                  Include the experimental SCSI HBA
   --no-build              Reuse an existing build product
-  --install-mcp-skill     Install or refresh the bundled Codex MCP skill
   --fresh, --replace      Uninstall existing dext state before staging the app
+  --activate, --refresh   Submit activation after install and verify the active dext
   --no-launch             Do not open ASFW.app after installation
   -h, --help              Show this help
 
@@ -40,8 +39,8 @@ app or dext requires administrator access.
 
 Examples:
   ./install-asfw.sh
-  ./install-asfw.sh --scsi --install-mcp-skill
-  ./install-asfw.sh --config Debug --scsi --fresh
+  ./install-asfw.sh --config Debug --scsi --activate
+  ./install-asfw.sh --config Debug --scsi --fresh --activate
   ./install-asfw.sh --config Release --scsi --no-build
 EOF
 }
@@ -108,6 +107,69 @@ system_extension_lines() {
   local extension_list
   extension_list="$(systemextensionsctl list 2>/dev/null)" || return 2
   grep -F "${SYSTEM_EXTENSION_ID}" <<<"${extension_list}" || true
+}
+
+system_dext_binary_paths() {
+  find "${SYSTEM_EXTENSION_ROOT}" -maxdepth 3 -type f \
+    -path "*/${SYSTEM_EXTENSION_ID}.dext/${SYSTEM_EXTENSION_ID}" \
+    -print 2>/dev/null
+}
+
+system_dext_hashes_match() {
+  local expected_hash="$1"
+  local binary_path
+  local installed_hash
+  local found_binary=false
+
+  while IFS= read -r binary_path; do
+    [[ -n "${binary_path}" ]] || continue
+    found_binary=true
+    installed_hash="$(sha256_file "${binary_path}")"
+    [[ "${installed_hash}" == "${expected_hash}" ]] || return 1
+  done < <(system_dext_binary_paths)
+
+  ${found_binary}
+}
+
+print_active_dext_status() {
+  local extension_lines
+  local binary_path
+
+  extension_lines="$(system_extension_lines)" \
+    || die "Unable to query the current system-extension state"
+  if [[ -n "${extension_lines}" ]]; then
+    printf '%s\n' "${extension_lines}"
+  else
+    log "No ASFW system-extension entry is visible."
+  fi
+
+  while IFS= read -r binary_path; do
+    [[ -n "${binary_path}" ]] || continue
+    log "Installed system dext hash: $(sha256_file "${binary_path}")"
+  done < <(system_dext_binary_paths)
+}
+
+wait_for_active_dext_hash() {
+  local expected_hash="$1"
+  local attempts="${2:-30}"
+  local extension_lines
+
+  while (( attempts > 0 )); do
+    extension_lines="$(system_extension_lines)" \
+      || die "Unable to query the current system-extension state"
+    if [[ -n "${extension_lines}" ]] \
+      && ! grep -Fqv '[activated enabled]' <<<"${extension_lines}" \
+      && system_dext_hashes_match "${expected_hash}"; then
+      log "Active dext matches the installed build: ${expected_hash}"
+      return 0
+    fi
+    sleep 1
+    ((attempts--))
+  done
+
+  log "The active dext did not switch to the installed build."
+  print_active_dext_status
+  return 1
 }
 
 ensure_replace_mode_for_pending_transition() {
@@ -181,6 +243,20 @@ verify_artifact() {
   fi
 }
 
+reject_test_host_artifacts() {
+  local app_path="$1"
+  local plugins_path="${app_path}/Contents/PlugIns"
+  local test_bundle
+
+  [[ -d "${plugins_path}" ]] || return 0
+  test_bundle="$(
+    find "${plugins_path}" -maxdepth 1 -type d \
+      -name '*.xctest' -print -quit 2>/dev/null
+  )"
+  [[ -z "${test_bundle}" ]] || die \
+    "Build product contains ${test_bundle}; rerun without --no-build after testing"
+}
+
 install_app_atomically() {
   local source_app="$1"
   local timestamp
@@ -219,33 +295,21 @@ install_app_atomically() {
   [[ -z "${backup}" ]] || log "Previous app backup: ${backup}"
 }
 
-install_mcp_skill() {
-  [[ -f "${MCP_SKILL_SOURCE}/SKILL.md" ]] \
-    || die "Bundled MCP skill not found: ${MCP_SKILL_SOURCE}"
-
-  local skill_parent="${CODEX_ROOT}/skills"
-  local skill_target="${skill_parent}/asfw-mcp-control-plane"
-  local timestamp
-  local backup=""
-  timestamp="$(date '+%Y%m%d-%H%M%S')"
-
-  mkdir -p "${skill_parent}" \
-    || die "Failed to create Codex skills directory: ${skill_parent}"
-  if [[ -e "${skill_target}" ]]; then
-    backup="${skill_target}.backup-${timestamp}"
-    mv "${skill_target}" "${backup}" \
-      || die "Failed to back up the existing Codex MCP skill"
+launch_installed_app() {
+  if ${AUTO_ACTIVATE}; then
+    log "Opening ${APP_DEST} and submitting the activation request..."
+    open "${APP_DEST}" --args --activate-driver \
+      || die "Failed to open ASFW.app for automatic activation"
+  else
+    log "Opening ${APP_DEST}..."
+    open "${APP_DEST}" || die "Failed to open ASFW.app"
   fi
+}
 
-  if ! cp -R "${MCP_SKILL_SOURCE}" "${skill_target}" \
-    || ! diff -qr "${MCP_SKILL_SOURCE}" "${skill_target}" >/dev/null; then
-    [[ ! -e "${skill_target}" ]] \
-      || mv "${skill_target}" "${skill_target}.failed-${timestamp}"
-    [[ -z "${backup}" ]] || mv "${backup}" "${skill_target}"
-    die "Failed to install the Codex MCP skill"
-  fi
-  log "Installed MCP skill: ${skill_target}"
-  [[ -z "${backup}" ]] || log "Previous MCP skill backup: ${backup}"
+reopen_installed_app_for_debugging() {
+  close_existing_app
+  log "Reopening ${APP_DEST} for debugging..."
+  open "${APP_DEST}" || die "Failed to reopen ASFW.app"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -257,8 +321,8 @@ while [[ $# -gt 0 ]]; do
       ;;
     --scsi) ENABLE_SCSI=true; shift ;;
     --no-build) DO_BUILD=false; shift ;;
-    --install-mcp-skill) INSTALL_MCP_SKILL=true; shift ;;
     --fresh|--replace) FRESH_REPLACE=true; shift ;;
+    --activate|--refresh) AUTO_ACTIVATE=true; shift ;;
     --no-launch) LAUNCH_APP=false; shift ;;
     -h|--help) usage; exit 0 ;;
     *) die "Unknown option: $1" ;;
@@ -269,6 +333,10 @@ case "${CONFIGURATION}" in
   Debug|Release) ;;
   *) die "--config must be Debug or Release" ;;
 esac
+
+if ${AUTO_ACTIVATE} && ! ${LAUNCH_APP}; then
+  die "--activate cannot be combined with --no-launch"
+fi
 
 csrutil status | grep -qi 'disabled' \
   || die "SIP must be disabled for the README ad-hoc install workflow"
@@ -285,19 +353,25 @@ fi
 
 APP_SOURCE="${SCRIPT_DIR}/build/DerivedData/Build/Products/${CONFIGURATION}/ASFW.app"
 [[ -d "${APP_SOURCE}" ]] || die "Build product not found: ${APP_SOURCE}"
+reject_test_host_artifacts "${APP_SOURCE}"
 
 log "Signing the app and its bundled dext..."
 CONFIGURATION="${CONFIGURATION}" ./sign.sh "${APP_SOURCE}"
 verify_artifact "${APP_SOURCE}"
 
-${INSTALL_MCP_SKILL} && install_mcp_skill
 ${FRESH_REPLACE} && uninstall_existing_system_extension
 install_app_atomically "${APP_SOURCE}"
+EXPECTED_DEXT_HASH="$(sha256_file "${APP_DEST}/${DEXT_BINARY_REL}")"
 
 if ${LAUNCH_APP}; then
-  log "Opening ${APP_DEST}..."
-  open "${APP_DEST}"
-  log "Use the visible Install button to submit the extension replacement."
+  launch_installed_app
+  if ${AUTO_ACTIVATE}; then
+    wait_for_active_dext_hash "${EXPECTED_DEXT_HASH}" 30 \
+      || die "Automatic activation did not produce the expected active dext"
+    reopen_installed_app_for_debugging
+  else
+    log "Use the visible Install button to submit the extension replacement."
+  fi
 fi
 
 systemextensionsctl list 2>/dev/null \

--- a/install-asfw.sh
+++ b/install-asfw.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+#
+# Build, sign, and stage ASFW.app using the workflow documented in README.md.
+# System-extension activation remains an explicit action in ASFW.app.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+CONFIGURATION="Release"
+DO_BUILD=true
+ENABLE_SCSI=false
+INSTALL_MCP_SKILL=false
+LAUNCH_APP=true
+FRESH_REPLACE=false
+
+APP_DEST="/Applications/ASFW.app"
+SYSTEM_EXTENSION_ID="net.mrmidi.ASFW.ASFWDriver"
+DEXT_REL="Contents/Library/SystemExtensions/${SYSTEM_EXTENSION_ID}.dext"
+DEXT_BINARY_REL="${DEXT_REL}/${SYSTEM_EXTENSION_ID}"
+MCP_SKILL_SOURCE="${SCRIPT_DIR}/skills/asfw-mcp-control-plane"
+CODEX_ROOT="${CODEX_HOME:-${HOME}/.codex}"
+
+usage() {
+  cat <<'EOF'
+Usage: ./install-asfw.sh [options]
+
+Options:
+  --config Debug|Release  Build configuration (default: Release)
+  --scsi                  Include the experimental SCSI HBA
+  --no-build              Reuse an existing build product
+  --install-mcp-skill     Install or refresh the bundled Codex MCP skill
+  --fresh, --replace      Uninstall the active dext before staging the new app
+  --no-launch             Do not open ASFW.app after installation
+  -h, --help              Show this help
+
+This script never prompts for a password. Run "sudo -v" first when an existing
+app or dext requires administrator access.
+
+Examples:
+  ./install-asfw.sh
+  ./install-asfw.sh --scsi --install-mcp-skill
+  ./install-asfw.sh --config Debug --scsi --fresh
+  ./install-asfw.sh --config Release --scsi --no-build
+EOF
+}
+
+log() { printf '[%s] %s\n' "$(date '+%H:%M:%S')" "$*"; }
+die() { printf '[ERROR] %s\n' "$*" >&2; exit 1; }
+
+run_maybe_sudo() {
+  if "$@"; then
+    return 0
+  else
+    local command_status=$?
+  fi
+
+  if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+    sudo -n "$@"
+    return $?
+  fi
+  log 'Administrator access may be required; run "sudo -v" and retry.'
+  return "${command_status}"
+}
+
+sha256_file() {
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+entitlements_xml() {
+  codesign -d --entitlements - --xml "$1" 2>/dev/null
+}
+
+has_entitlement() {
+  local artifact="$1"
+  local key="$2"
+  entitlements_xml "${artifact}" | grep -q "<key>${key}</key>"
+}
+
+has_scsi_personality() {
+  /usr/libexec/PlistBuddy \
+    -c "Print :IOKitPersonalities:ASFWSCSIControllerService" \
+    "$1/Info.plist" >/dev/null 2>&1
+}
+
+asfw_app_pids() {
+  local pattern="${APP_DEST//./\\.}/Contents/MacOS/ASFW"
+  pgrep -f "^${pattern}([[:space:]]|$)" 2>/dev/null || true
+}
+
+close_existing_app() {
+  [[ -z "$(asfw_app_pids)" ]] && return 0
+  log "Requesting the existing ASFW.app to quit..."
+  osascript -e 'tell application id "net.mrmidi.ASFW" to quit' \
+    >/dev/null 2>&1 || true
+
+  local attempts=10
+  while (( attempts > 0 )); do
+    [[ -z "$(asfw_app_pids)" ]] && return 0
+    sleep 1
+    ((attempts--))
+  done
+  die "ASFW.app is still running; close it manually and rerun the installer"
+}
+
+has_active_system_extension() {
+  local extension_list
+  extension_list="$(systemextensionsctl list 2>/dev/null)" || return 2
+  grep -F "${SYSTEM_EXTENSION_ID}" <<<"${extension_list}" \
+    | grep -qF '[activated enabled]'
+}
+
+uninstall_active_system_extension() {
+  local query_status
+  if has_active_system_extension; then
+    :
+  else
+    query_status=$?
+    [[ ${query_status} -eq 1 ]] \
+      || die "Unable to query the current system-extension state"
+    log "No active ASFW system extension needs to be uninstalled."
+    return 0
+  fi
+
+  close_existing_app
+  log "Uninstalling the active ASFW dext before replacement..."
+  run_maybe_sudo systemextensionsctl uninstall - "${SYSTEM_EXTENSION_ID}" \
+    || die "Failed to uninstall ${SYSTEM_EXTENSION_ID}"
+
+  local attempts=30
+  while (( attempts > 0 )); do
+    if has_active_system_extension; then
+      :
+    else
+      query_status=$?
+      [[ ${query_status} -eq 1 ]] \
+        || die "Unable to verify the system-extension uninstall"
+      log "The previous ASFW dext is no longer active."
+      return 0
+    fi
+    sleep 1
+    ((attempts--))
+  done
+  die "The previous ASFW dext is still active; close its clients and retry"
+}
+
+verify_artifact() {
+  local app_path="$1"
+  local dext_path="${app_path}/${DEXT_REL}"
+
+  [[ -d "${app_path}" ]] || die "App bundle not found: ${app_path}"
+  [[ -d "${dext_path}" ]] || die "Bundled dext not found: ${dext_path}"
+  codesign --verify --deep --strict "${app_path}" \
+    || die "codesign verification failed: ${app_path}"
+  has_entitlement "${app_path}" "com.apple.developer.system-extension.install" \
+    || die "App is missing com.apple.developer.system-extension.install"
+  has_entitlement "${dext_path}" "com.apple.developer.driverkit" \
+    || die "Dext is missing com.apple.developer.driverkit"
+
+  if ${ENABLE_SCSI}; then
+    has_scsi_personality "${dext_path}" \
+      || die "--scsi requested, but ASFWSCSIControllerService is absent"
+    has_entitlement "${dext_path}" \
+      "com.apple.developer.driverkit.family.scsicontroller" \
+      || die "--scsi requested, but the SCSIController entitlement is absent"
+  elif has_scsi_personality "${dext_path}" \
+    || has_entitlement "${dext_path}" \
+      "com.apple.developer.driverkit.family.scsicontroller"; then
+    die "Build contains the SCSI HBA; rerun with --scsi to acknowledge it"
+  fi
+}
+
+install_app_atomically() {
+  local source_app="$1"
+  local timestamp
+  local staging
+  local backup=""
+
+  timestamp="$(date '+%Y%m%d-%H%M%S')"
+  staging="/Applications/.ASFW.app.staging-${timestamp}"
+  [[ ! -e "${staging}" ]] || die "Staging path already exists: ${staging}"
+
+  log "Staging the new app at ${staging}..."
+  run_maybe_sudo ditto "${source_app}" "${staging}" \
+    || die "Failed to stage ASFW.app"
+  run_maybe_sudo xattr -dr com.apple.quarantine "${staging}" \
+    || die "Failed to clear quarantine from staged app"
+  verify_artifact "${staging}"
+  close_existing_app
+
+  if [[ -e "${APP_DEST}" ]]; then
+    backup="/Applications/ASFW.app.backup-${timestamp}"
+    log "Backing up the current app to ${backup}..."
+    run_maybe_sudo mv "${APP_DEST}" "${backup}" \
+      || die "Failed to back up the existing ASFW.app"
+  fi
+
+  log "Activating the staged app at ${APP_DEST}..."
+  if ! run_maybe_sudo mv "${staging}" "${APP_DEST}"; then
+    if [[ -n "${backup}" && ! -e "${APP_DEST}" ]]; then
+      run_maybe_sudo mv "${backup}" "${APP_DEST}" || true
+    fi
+    die "Failed to install ASFW.app"
+  fi
+
+  verify_artifact "${APP_DEST}"
+  log "Installed dext hash: $(sha256_file "${APP_DEST}/${DEXT_BINARY_REL}")"
+  [[ -z "${backup}" ]] || log "Previous app backup: ${backup}"
+}
+
+install_mcp_skill() {
+  [[ -f "${MCP_SKILL_SOURCE}/SKILL.md" ]] \
+    || die "Bundled MCP skill not found: ${MCP_SKILL_SOURCE}"
+
+  local skill_parent="${CODEX_ROOT}/skills"
+  local skill_target="${skill_parent}/asfw-mcp-control-plane"
+  local timestamp
+  local backup=""
+  timestamp="$(date '+%Y%m%d-%H%M%S')"
+
+  mkdir -p "${skill_parent}" \
+    || die "Failed to create Codex skills directory: ${skill_parent}"
+  if [[ -e "${skill_target}" ]]; then
+    backup="${skill_target}.backup-${timestamp}"
+    mv "${skill_target}" "${backup}" \
+      || die "Failed to back up the existing Codex MCP skill"
+  fi
+
+  if ! cp -R "${MCP_SKILL_SOURCE}" "${skill_target}" \
+    || ! diff -qr "${MCP_SKILL_SOURCE}" "${skill_target}" >/dev/null; then
+    [[ ! -e "${skill_target}" ]] \
+      || mv "${skill_target}" "${skill_target}.failed-${timestamp}"
+    [[ -z "${backup}" ]] || mv "${backup}" "${skill_target}"
+    die "Failed to install the Codex MCP skill"
+  fi
+  log "Installed MCP skill: ${skill_target}"
+  [[ -z "${backup}" ]] || log "Previous MCP skill backup: ${backup}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --config)
+      [[ $# -ge 2 ]] || die "Missing value after --config"
+      CONFIGURATION="$2"
+      shift 2
+      ;;
+    --scsi) ENABLE_SCSI=true; shift ;;
+    --no-build) DO_BUILD=false; shift ;;
+    --install-mcp-skill) INSTALL_MCP_SKILL=true; shift ;;
+    --fresh|--replace) FRESH_REPLACE=true; shift ;;
+    --no-launch) LAUNCH_APP=false; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "Unknown option: $1" ;;
+  esac
+done
+
+case "${CONFIGURATION}" in
+  Debug|Release) ;;
+  *) die "--config must be Debug or Release" ;;
+esac
+
+csrutil status | grep -qi 'disabled' \
+  || die "SIP must be disabled for the README ad-hoc install workflow"
+systemextensionsctl developer 2>&1 | grep -qi 'developer mode is on' \
+  || die "Enable system-extension developer mode before installing"
+
+if ${DO_BUILD}; then
+  build_args=(--no-bump --config "${CONFIGURATION}")
+  ${ENABLE_SCSI} && build_args+=(--scsi)
+  log "Building ASFW.app (${CONFIGURATION})..."
+  ./build.sh "${build_args[@]}"
+fi
+
+APP_SOURCE="${SCRIPT_DIR}/build/DerivedData/Build/Products/${CONFIGURATION}/ASFW.app"
+[[ -d "${APP_SOURCE}" ]] || die "Build product not found: ${APP_SOURCE}"
+
+log "Signing the app and its bundled dext..."
+CONFIGURATION="${CONFIGURATION}" ./sign.sh "${APP_SOURCE}"
+verify_artifact "${APP_SOURCE}"
+
+${INSTALL_MCP_SKILL} && install_mcp_skill
+${FRESH_REPLACE} && uninstall_active_system_extension
+install_app_atomically "${APP_SOURCE}"
+
+if ${LAUNCH_APP}; then
+  log "Opening ${APP_DEST}..."
+  open "${APP_DEST}"
+  log "Use the visible Install button to submit the extension replacement."
+fi
+
+systemextensionsctl list 2>/dev/null \
+  | grep "${SYSTEM_EXTENSION_ID}" \
+  || log "No active ASFW system-extension entry is visible yet."
+
+if ${ENABLE_SCSI}; then
+  log "SCSI HBA is present in the staged app. Keep an SBP-2 device powered on;"
+  log "do not cold boot until runtime enumeration and teardown tests pass."
+fi


### PR DESCRIPTION
## Summary

- add `install-asfw.sh`: build, ad-hoc sign, verify entitlements, replace the app atomically, and optionally drive activation to completion
- gate the SCSI HBA and fresh dext replacement behind explicit flags, and refuse a build whose SCSI state does not match the flag
- detect a pending system-extension transition before building, so a run that cannot succeed stops in seconds instead of after a full build
- translate `OSSystemExtensionErrorDomain` failures, including the reboot-required state, into copyable activation status text

## Relationship to the older fork PR

This carries forward the app feedback changes from gly11/ASFireWire#10 and combines them with a local reinstall script for the current app layout. No user home path is hard-coded. The unrelated controller, bus-reset, and old SBP-2 connector changes from that fork branch are excluded.

## Changes since the last push

The branch previously carried three commits that also exist in #88 — the XcodeGen pin, the GoogleTest discovery change, and the Swift quiet-mode exit-status fix. Worse, its copy of the pin was the superseded one (hardcoded 2.45.4), which would have failed this PR's own drift check against a pbxproj generated with 2.46.0. All three are dropped; `.github/workflows/` and `tests/CMakeLists.txt` are no longer touched here.

Four defects found during review and hardware validation are fixed:

- the SIP gate matched `disabled` anywhere in `csrutil status`, so a Custom Configuration with any single protection off (`Apple Internal: disabled`) passed and the install failed later for an unrelated-looking reason
- activation waited 30s total, but macOS parks the extension in `activated waiting for user` until someone approves it in System Settings and authenticates — a successful install was reported as a failure because the budget was spent on a human step
- that timeout also skipped the app reopen, leaving the instance launched with `--activate-driver` running but never connected, with no indication why
- replaced apps accumulated in `/Applications` forever; the three most recent backups are now kept and older ones pruned after the new install verifies

## Validation

### Host

- `ASFWTests`: 195 passed, 0 failed, including 4 new activation-formatter tests
- `bash -n install-asfw.sh`
- SIP gate checked against fully disabled, fully enabled, and Custom Configuration output
- backup pruning checked in an isolated tree: unrelated bundles and non-conforming names are left alone

ShellCheck was not available locally.

### Hardware

Exercised end to end on the test Mac (SIP off, developer mode on):

- a stuck `terminating for uninstall but still running` dext was detected before the build, and the run stopped with the reboot instruction rather than continuing into a partial replacement
- after reboot, a full `--fresh --activate` run built, signed, verified, installed, and activated; the active dext hash matched the installed build
- the approval wait and the reopen were then confirmed on a second run, and pruning was confirmed by driving the backup count past the limit

`run_maybe_sudo` attempts each command unprivileged first. Every privileged step here — `ditto`, `mv`, `systemextensionsctl uninstall` — succeeded without escalating, so that path stayed unused.

## Dependency

Retargeted from `main` to `dev`. Independent of the other open PRs now that the duplicated CI commits are gone.
