### PR TITLE
fix(config-rom): reject suspended generation exports

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,10 +29,10 @@ jobs:
       # after the pinned xcodegen version changes, regenerate locally with the
       # same version and commit.
       - name: Verify ASFW.xcodeproj matches project.yml (XcodeGen)
-        env:
-          XCODEGEN_VERSION: 2.45.4
-          XCODEGEN_SHA256: 090ec29491aad50aec10631bf6e62253fed733c50f3aab0f5ffc86bc170bdbef
         run: |
+          # Single source of truth, shared with build.sh, so a contributor's
+          # locally installed xcodegen can never disagree with this check.
+          . ./.xcodegen-version
           XCODEGEN_ARCHIVE="$RUNNER_TEMP/xcodegen.zip"
           XCODEGEN_ROOT="$RUNNER_TEMP/xcodegen-release"
           curl --fail --location --retry 3 \

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,19 +26,29 @@ jobs:
       # ASFW.xcodeproj is generated from project.yml (XcodeGen) and committed.
       # Fail if they drifted apart — someone edited project.yml or added source
       # files without regenerating, or hand-edited the pbxproj. If this fails
-      # after an xcodegen version bump changed the output format, regenerate
-      # locally with the new version and commit.
+      # after the pinned xcodegen version changes, regenerate locally with the
+      # same version and commit.
       - name: Verify ASFW.xcodeproj matches project.yml (XcodeGen)
+        env:
+          XCODEGEN_VERSION: 2.45.4
+          XCODEGEN_SHA256: 090ec29491aad50aec10631bf6e62253fed733c50f3aab0f5ffc86bc170bdbef
         run: |
-          brew install xcodegen
-          xcodegen --version
-          xcodegen generate --quiet
+          XCODEGEN_ARCHIVE="$RUNNER_TEMP/xcodegen.zip"
+          XCODEGEN_ROOT="$RUNNER_TEMP/xcodegen-release"
+          curl --fail --location --retry 3 \
+            --output "$XCODEGEN_ARCHIVE" \
+            "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip"
+          echo "${XCODEGEN_SHA256}  ${XCODEGEN_ARCHIVE}" | shasum -a 256 -c -
+          ditto -x -k "$XCODEGEN_ARCHIVE" "$XCODEGEN_ROOT"
+          XCODEGEN_BIN="$XCODEGEN_ROOT/xcodegen/bin/xcodegen"
+          "$XCODEGEN_BIN" --version
+          "$XCODEGEN_BIN" generate --quiet
           # Diff only the pbxproj: scheme files are cosmetically rewritten by
           # any open Xcode (version attr, BuildableName flavor, empty blocks),
           # so they flip-flop between xcodegen and Xcode styles; their semantic
           # content comes from project.yml either way.
           if ! git diff --exit-code --stat -- ASFW.xcodeproj/project.pbxproj project.yml; then
-            echo "::error::ASFW.xcodeproj is out of sync with project.yml. Run 'xcodegen generate' locally and commit the regenerated project (see README → Building)."
+            echo "::error::ASFW.xcodeproj is out of sync with project.yml. Regenerate it with XcodeGen ${XCODEGEN_VERSION} and commit the result (see README → Building)."
             exit 1
           fi
 

--- a/.xcodegen-version
+++ b/.xcodegen-version
@@ -1,0 +1,18 @@
+# XcodeGen release pinned for generating ASFW.xcodeproj from project.yml.
+#
+# Both CI (.github/workflows/build-and-test.yml) and build.sh read this file, so
+# the version that regenerates the committed project is the same everywhere.
+# Homebrew's xcodegen floats and its output is NOT byte-identical across
+# releases (2.45.4 -> 2.46.0 reorders the pbxproj `targets` list), which is why
+# the pin exists and why build.sh refuses to regenerate with a different one.
+#
+# Upgrading — do all three steps together, or CI's drift check will fail:
+#   1. bump XCODEGEN_VERSION below
+#   2. curl the release zip, put its `shasum -a 256` in XCODEGEN_SHA256
+#        curl -fL -o /tmp/xcodegen.zip \
+#          https://github.com/yonaskolb/XcodeGen/releases/download/<ver>/xcodegen.zip
+#        shasum -a 256 /tmp/xcodegen.zip
+#   3. regenerate ASFW.xcodeproj with that exact version and commit it alongside
+#
+XCODEGEN_VERSION=2.46.0
+XCODEGEN_SHA256=4d9e34b62172d645eed6457cac13fc222569974098ef4ee9c3368bedf0196806

--- a/ASFW.xcodeproj/project.pbxproj
+++ b/ASFW.xcodeproj/project.pbxproj
@@ -3000,8 +3000,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				EE5A446B3669D0171F9606EE /* ASFW */,
 				0EB9A8DA75D08971084A440A /* ASFWDriver */,
+				EE5A446B3669D0171F9606EE /* ASFW */,
 				348672D607701677ABCB567C /* ASFWTests */,
 			);
 		};

--- a/ASFW.xcodeproj/xcshareddata/xcschemes/ASFWDriver.xcscheme
+++ b/ASFW.xcodeproj/xcshareddata/xcschemes/ASFWDriver.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2600"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -15,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "0EB9A8DA75D08971084A440A"
-               BuildableName = "net.mrmidi.ASFW.ASFWDriver.dext"
+               BuildableName = "ASFWDriver.dext"
                BlueprintName = "ASFWDriver"
                ReferencedContainer = "container:ASFW.xcodeproj">
             </BuildableReference>
@@ -26,18 +27,21 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "0EB9A8DA75D08971084A440A"
-            BuildableName = "net.mrmidi.ASFW.ASFWDriver.dext"
+            BuildableName = "ASFWDriver.dext"
             BlueprintName = "ASFWDriver"
             ReferencedContainer = "container:ASFW.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <Testables>
       </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -54,11 +58,13 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "0EB9A8DA75D08971084A440A"
-            BuildableName = "net.mrmidi.ASFW.ASFWDriver.dext"
+            BuildableName = "ASFWDriver.dext"
             BlueprintName = "ASFWDriver"
             ReferencedContainer = "container:ASFW.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -71,11 +77,13 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "0EB9A8DA75D08971084A440A"
-            BuildableName = "net.mrmidi.ASFW.ASFWDriver.dext"
+            BuildableName = "ASFWDriver.dext"
             BlueprintName = "ASFWDriver"
             ReferencedContainer = "container:ASFW.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/ASFWDriver/ConfigROM/ConfigROMStore.hpp
+++ b/ASFWDriver/ConfigROM/ConfigROMStore.hpp
@@ -113,15 +113,6 @@ class ConfigROMStore {
     void SuspendAll(Generation newGen);
 
     /**
-     * @brief Validates a ROM after a bus reset (device reappeared).
-     *
-     * @param guid The 64-bit GUID.
-     * @param gen The current generation.
-     * @param nodeId The new node ID of the device.
-     */
-    void ValidateROM(Guid64 guid, Generation gen, uint8_t nodeId);
-
-    /**
      * @brief Marks a ROM as invalid (device disappeared or ROM content changed).
      *
      * @param guid The 64-bit GUID to invalidate.

--- a/ASFWDriver/ConfigROM/README.md
+++ b/ASFWDriver/ConfigROM/README.md
@@ -88,8 +88,9 @@ A persistent, thread-safe registry for all discovered ROMs.
 - **Generation-Aware**: Tracks which ROMs are valid for the current topology.
 - **GUID Deduplication**: Ensures only one entry exists per unique EUI-64.
 - **Lifecycle Management**: 
-  - **Suspended**: ROMs from a previous generation waiting for validation.
-  - **Validated**: ROMs confirmed to still exist after a bus reset.
+  - **Suspended**: ROMs from a previous generation. A device that reappears is
+    re-entered through `Insert()`, which overwrites the entry; suspended entries
+    are keyed to a stale generation and are never looked up again.
   - **Invalid**: Devices that have disappeared from the bus.
 
 ---

--- a/ASFWDriver/ConfigROM/Store/ConfigROMStore.cpp
+++ b/ASFWDriver/ConfigROM/Store/ConfigROMStore.cpp
@@ -248,56 +248,20 @@ void ConfigROMStore::SuspendAll(Generation newGen) {
     uint32_t suspendedCount = 0;
 
     for (auto& [key, rom] : romsByGenNode_) {
-        if (rom.state == Fresh || rom.state == Validated) {
+        if (rom.state == Fresh) {
             rom.state = Suspended;
             suspendedCount++;
         }
     }
 
     for (auto& [guid, rom] : romsByGuid_) {
-        if (rom.state == Fresh || rom.state == Validated) {
+        if (rom.state == Fresh) {
             rom.state = Suspended;
         }
     }
 
     ASFW_LOG(ConfigROM, "ConfigROMStore::SuspendAll: Suspended %u ROMs for generation %u",
              suspendedCount, newGen.value);
-}
-
-void ConfigROMStore::ValidateROM(Guid64 guid, Generation gen, uint8_t nodeId) {
-    LockGuard guard(lock_);
-
-    auto guidIt = romsByGuid_.find(guid);
-    if (guidIt == romsByGuid_.end()) {
-        ASFW_LOG(ConfigROM, "ConfigROMStore::ValidateROM: GUID 0x%016llx not found", guid);
-        return;
-    }
-
-    auto& rom = guidIt->second;
-
-    if (rom.state != ROMState::Suspended) {
-        ASFW_LOG(ConfigROM,
-                 "ConfigROMStore::ValidateROM: GUID 0x%016llx not in suspended state (state=%u)",
-                 guid, static_cast<uint8_t>(rom.state));
-        return;
-    }
-
-    if (rom.nodeId != nodeId) {
-        ASFW_LOG(ConfigROM,
-                 "ConfigROMStore::ValidateROM: GUID 0x%016llx moved node %u→%u in gen %u", guid,
-                 rom.nodeId, nodeId, gen.value);
-        rom.nodeId = nodeId;
-    }
-
-    rom.gen = gen;
-    rom.state = ROMState::Validated;
-    rom.lastValidated = gen;
-
-    const GenNodeKey newKey = MakeKey(gen, nodeId);
-    romsByGenNode_[newKey] = rom;
-
-    ASFW_LOG(ConfigROM, "ConfigROMStore::ValidateROM: Validated GUID 0x%016llx at node %u gen %u",
-             guid, nodeId, gen.value);
 }
 
 void ConfigROMStore::InvalidateROM(Guid64 guid) {

--- a/ASFWDriver/Controller/ControllerCoreInterrupts.cpp
+++ b/ASFWDriver/Controller/ControllerCoreInterrupts.cpp
@@ -79,6 +79,9 @@ void ControllerCore::HandleInterrupt(const InterruptSnapshot& snapshot) {
         if (deps_.cmpClient) {
             deps_.cmpClient->InvalidateAllLeasesForBusReset();
         }
+        if (deps_.romStore) {
+            deps_.romStore->SuspendAll(Discovery::Generation{generation});
+        }
         if (deps_.avcDiscovery) {
             deps_.avcDiscovery->OnBusReset(generation);
         }

--- a/ASFWDriver/Discovery/DiscoveryTypes.hpp
+++ b/ASFWDriver/Discovery/DiscoveryTypes.hpp
@@ -130,10 +130,15 @@ struct UnitDirectory {
 };
 
 // ROM lifecycle state (matching Apple IOFireWireROMCache patterns)
+//
+// A device that reappears after a bus reset is re-entered through
+// ConfigROMStore::Insert(), which overwrites the whole entry — including this
+// field — rather than transitioning a suspended one back in place. There is
+// therefore no separate "validated" state; Suspended entries are keyed to the
+// generation that is now stale and are simply never looked up again.
 enum class ROMState : uint8_t {
     Fresh,      // Just read in current generation
-    Validated,  // Confirmed valid across bus reset (device reappeared)
-    Suspended,  // From previous generation, not yet validated (bus reset occurred)
+    Suspended,  // From previous generation (bus reset occurred)
     Invalid     // Marked for removal (device disappeared or ROM changed)
 };
 

--- a/ASFWDriver/UserClient/Handlers/ConfigROMHandler.cpp
+++ b/ASFWDriver/UserClient/Handlers/ConfigROMHandler.cpp
@@ -62,7 +62,7 @@ kern_return_t ConfigROMHandler::ExportConfigROM(IOUserClientMethodArguments* arg
         return kIOReturnNotReady;
     }
 
-    const auto* rom = romStore->FindByNode(requestedGen, nodeId);
+    const auto* rom = romStore->FindByNode(requestedGen, nodeId, false);
 
     if (rom == nullptr) {
         ASFW_LOG(UserClient,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,10 +14,12 @@ Two components:
 
 **`ASFW.xcodeproj` is GENERATED from the root `project.yml` (XcodeGen).** Never
 edit the pbxproj or hand-tune settings in Xcode — change `project.yml` and run
-`xcodegen generate` (`./build.sh` does it automatically when xcodegen is
-installed). After adding/removing/renaming source files, regenerate and commit
-the updated `ASFW.xcodeproj` together with `project.yml`. Output is
-deterministic; the generated project stays committed so CI builds without
+`xcodegen generate` with the version pinned in `.xcodegen-version`
+(`./build.sh` checks an installed xcodegen automatically; use
+`--no-xcodegen` only to build the committed project as-is). After
+adding/removing/renaming source files, regenerate and commit the updated
+`ASFW.xcodeproj` together with `project.yml`. Output is deterministic for the
+pinned version; the generated project stays committed so CI builds without
 xcodegen. (`ADKVirtualAudioLab/` has its own separate `project.yml`.)
 
 **Primary build (Xcode — required for signing and producing `.dext`):**

--- a/README.md
+++ b/README.md
@@ -441,14 +441,23 @@ and checksum CI uses:
 
 ```bash
 . ./.xcodegen-version
-curl --fail --location --retry 3 --output /tmp/xcodegen.zip \
+XCODEGEN_TMP="$(mktemp -d)"
+XCODEGEN_PREFIX="$HOME/.local"
+curl --fail --location --retry 3 \
+  --output "$XCODEGEN_TMP/xcodegen.zip" \
   "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip"
-echo "${XCODEGEN_SHA256}  /tmp/xcodegen.zip" | shasum -a 256 -c -
-ditto -x -k /tmp/xcodegen.zip /tmp/xcodegen-release
-sudo /tmp/xcodegen-release/xcodegen/install.sh          # -> /usr/local/bin/xcodegen
-# no-sudo variant: install.sh takes a prefix, e.g.
-#   /tmp/xcodegen-release/xcodegen/install.sh "$HOME/.local"
+echo "${XCODEGEN_SHA256}  ${XCODEGEN_TMP}/xcodegen.zip" | shasum -a 256 -c -
+ditto -x -k "$XCODEGEN_TMP/xcodegen.zip" "$XCODEGEN_TMP/release"
+mkdir -p "$XCODEGEN_PREFIX"
+"$XCODEGEN_TMP/release/xcodegen/install.sh" "$XCODEGEN_PREFIX"
+export PATH="$XCODEGEN_PREFIX/bin:$PATH"
+hash -r
+xcodegen --version
 ```
+
+The `PATH` update deliberately places the pinned binary before a Homebrew
+installation. Add the same `export` command to your shell startup file if you
+want future terminal sessions to use the pinned version.
 
 If `xcodegen` isn't on your `PATH` at all, nothing above applies — `build.sh`
 skips regeneration entirely and builds the committed project. The pin only

--- a/README.md
+++ b/README.md
@@ -427,20 +427,48 @@ Build scripts or CMakeLists are for quick testing and creating compile_commands.
 ### Xcode project is generated (XcodeGen)
 
 `ASFW.xcodeproj` is generated from the root [`project.yml`](project.yml) with
-[XcodeGen](https://github.com/yonaskolb/XcodeGen) (`brew install xcodegen`).
-The generated project is committed, so plain checkouts (and CI) build without
-XcodeGen installed — but **never edit the pbxproj or project settings in the
-Xcode UI**; change `project.yml` instead.
+[XcodeGen](https://github.com/yonaskolb/XcodeGen). The generated project is
+committed, so plain checkouts (and CI) build without XcodeGen installed — but
+**never edit the pbxproj or project settings in the Xcode UI**; change
+`project.yml` instead.
+
+**The XcodeGen version is pinned** in [`.xcodegen-version`](.xcodegen-version),
+because its output is *not* byte-identical across releases (2.45.4 → 2.46.0
+reorders the pbxproj `targets` list) and CI diffs the regenerated project
+against the committed one. Homebrew's `xcodegen` floats, so install the pinned
+release rather than `brew install xcodegen` — this is the same download, pin,
+and checksum CI uses:
+
+```bash
+. ./.xcodegen-version
+curl --fail --location --retry 3 --output /tmp/xcodegen.zip \
+  "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip"
+echo "${XCODEGEN_SHA256}  /tmp/xcodegen.zip" | shasum -a 256 -c -
+ditto -x -k /tmp/xcodegen.zip /tmp/xcodegen-release
+sudo /tmp/xcodegen-release/xcodegen/install.sh          # -> /usr/local/bin/xcodegen
+# no-sudo variant: install.sh takes a prefix, e.g.
+#   /tmp/xcodegen-release/xcodegen/install.sh "$HOME/.local"
+```
+
+If `xcodegen` isn't on your `PATH` at all, nothing above applies — `build.sh`
+skips regeneration entirely and builds the committed project. The pin only
+matters once you have *some* `xcodegen` installed, because `build.sh`
+regenerates on every build; if that version doesn't match the pin it stops with
+an error rather than writing a pbxproj CI would reject. Use `--no-xcodegen` to
+build anyway.
 
 After **adding, removing, or renaming source files**, regenerate the project
 and commit it together with your change:
 
 ```bash
-xcodegen generate     # ./build.sh does this automatically when xcodegen is installed
+xcodegen generate     # ./build.sh does this automatically, and refuses to run
+                      # if your xcodegen doesn't match the pin
 ```
 
-Output is deterministic — regenerating with no changes produces an identical
-pbxproj.
+Output is deterministic *for a given XcodeGen version* — regenerating with no
+changes produces an identical pbxproj. If your machine has a different version
+and you only need to build, pass `./build.sh --no-xcodegen` to use the committed
+project as-is (added or removed sources will not be picked up).
 
 NOTE: You need an Apple Developer account (paid) and appropriate entitlements — or a free account plus SIP disabled — to build/load the driver on your machine. See Apple's documentation for details: https://developer.apple.com/documentation/driverkit/debugging-and-testing-system-extensions
 

--- a/build.sh
+++ b/build.sh
@@ -136,19 +136,28 @@ preflight() {
       # unpinned version silently produces a project that CI will reject, so
       # stop here instead — a build missing a newly added source file is much
       # harder to diagnose than this message.
-      if [[ -f ".xcodegen-version" ]]; then
-        . ./.xcodegen-version
-        xcodegen_actual="$(xcodegen --version 2>/dev/null | awk '{print $NF}')"
-        if [[ -n "${XCODEGEN_VERSION:-}" && "$xcodegen_actual" != "$XCODEGEN_VERSION" ]]; then
-          err "xcodegen ${xcodegen_actual:-<unknown>} is installed, but this repo pins ${XCODEGEN_VERSION}."
-          err "Regenerating would produce a pbxproj that CI's drift check rejects."
-          err "Either:"
-          err "  - install the pinned release (copy-paste block in README -> Building ->"
-          err "    'Xcode project is generated (XcodeGen)'), or"
-          err "  - re-run with --no-xcodegen to build the committed project as-is"
-          err "    (added/removed source files will NOT be picked up)."
-          exit 1
-        fi
+      if [[ ! -r ".xcodegen-version" ]]; then
+        err "xcodegen is installed, but the required .xcodegen-version pin is missing or unreadable."
+        err "Refusing to regenerate ${PROJECT_NAME}.xcodeproj with an unpinned version."
+        exit 1
+      fi
+      unset XCODEGEN_VERSION
+      . ./.xcodegen-version
+      if [[ -z "${XCODEGEN_VERSION:-}" ]]; then
+        err ".xcodegen-version does not define XCODEGEN_VERSION."
+        err "Refusing to regenerate ${PROJECT_NAME}.xcodeproj with an unpinned version."
+        exit 1
+      fi
+      xcodegen_actual="$(xcodegen --version 2>/dev/null | awk '{print $NF}')"
+      if [[ "$xcodegen_actual" != "$XCODEGEN_VERSION" ]]; then
+        err "xcodegen ${xcodegen_actual:-<unknown>} is installed, but this repo pins ${XCODEGEN_VERSION}."
+        err "Regenerating would produce a pbxproj that CI's drift check rejects."
+        err "Either:"
+        err "  - install the pinned release (copy-paste block in README -> Building ->"
+        err "    'Xcode project is generated (XcodeGen)'), or"
+        err "  - re-run with --no-xcodegen to build the committed project as-is"
+        err "    (added/removed source files will NOT be picked up)."
+        exit 1
       fi
       log "Regenerating ${PROJECT_NAME}.xcodeproj from project.yml..."
       xcodegen generate --quiet || { err "xcodegen generate failed"; exit 1; }

--- a/build.sh
+++ b/build.sh
@@ -231,7 +231,7 @@ run_swift_tests() {
   if $VERBOSE; then
     xcodebuild "${XCODEBUILD_ARGS[@]}" 2>&1
   else
-    xcodebuild "${XCODEBUILD_ARGS[@]}" 2>&1 | grep -E '(Test Case|passed|failed|error:)' || true
+    xcodebuild "${XCODEBUILD_ARGS[@]}" 2>&1 | grep -E '(Test Case|passed|failed|error:)'
   fi
   local test_status=${PIPESTATUS[0]}
   set -e

--- a/build.sh
+++ b/build.sh
@@ -60,6 +60,10 @@ SWIFT_COVERAGE_LCOV="${BUILD_DIR}/swift_coverage.lcov"
 # See README "SCSI HBA — opt-in".
 ENABLE_SCSI=false
 
+# Skip the XcodeGen regeneration in preflight() and build the committed project
+# as-is. Escape hatch for a machine whose xcodegen differs from the pin.
+NO_XCODEGEN=false
+
 usage() {
   cat <<EOF
 Usage: $0 [--verbose] [--no-bump] [--scheme NAME] [--config CONFIG] [--arch ARCH] [--derived PATH]
@@ -74,6 +78,11 @@ Usage: $0 [--verbose] [--no-bump] [--scheme NAME] [--config CONFIG] [--arch ARCH
   --scsi             Include the SCSI HBA (personality + restricted entitlement);
                      requires SIP disabled, and is NOT cold-boot-safe without a
                      powered-on SBP-2 device attached — see README
+  --no-xcodegen      Build against the committed ASFW.xcodeproj without
+                     regenerating it (escape hatch when the locally installed
+                     xcodegen differs from the version pinned in
+                     .xcodegen-version; added/removed sources will NOT be
+                     picked up)
   --scheme NAME      Override scheme (default: ${SCHEME_NAME})
   --config CONFIG    Override configuration (default: ${CONFIGURATION})
   --arch ARCH        Override architecture passed to xcodebuild (default: ${ARCH_NAME})
@@ -93,6 +102,7 @@ while [[ $# -gt 0 ]]; do
     --commands) GENERATE_COMMANDS=true; shift;;
     --analyze) RUN_ANALYZER=true; shift;;
     --scsi) ENABLE_SCSI=true; shift;;
+    --no-xcodegen) NO_XCODEGEN=true; shift;;
     --scheme) SCHEME_NAME="$2"; shift 2;;
     --config) CONFIGURATION="$2"; shift 2;;
     --arch) ARCH_NAME="$2"; shift 2;;
@@ -116,10 +126,30 @@ preflight() {
   if ! $TEST_ONLY; then
     require_cmd xcodebuild
     # The Xcode project is generated from project.yml (XcodeGen). Regenerate so
-    # source globs pick up added/removed files; output is deterministic, so this
-    # is a no-op when nothing changed. Falls through to the committed project
-    # when xcodegen isn't installed (e.g. CI runners).
-    if [[ -f "project.yml" ]] && command -v xcodegen >/dev/null 2>&1; then
+    # source globs pick up added/removed files; output is deterministic *for a
+    # given xcodegen version*, so this is a no-op when nothing changed. Falls
+    # through to the committed project when xcodegen isn't installed (e.g. CI
+    # runners, which use the pinned release directly).
+    if [[ -f "project.yml" ]] && ! $NO_XCODEGEN && command -v xcodegen >/dev/null 2>&1; then
+      # XcodeGen output is not byte-identical across releases, and CI diffs the
+      # regenerated pbxproj against the committed one. Regenerating with an
+      # unpinned version silently produces a project that CI will reject, so
+      # stop here instead — a build missing a newly added source file is much
+      # harder to diagnose than this message.
+      if [[ -f ".xcodegen-version" ]]; then
+        . ./.xcodegen-version
+        xcodegen_actual="$(xcodegen --version 2>/dev/null | awk '{print $NF}')"
+        if [[ -n "${XCODEGEN_VERSION:-}" && "$xcodegen_actual" != "$XCODEGEN_VERSION" ]]; then
+          err "xcodegen ${xcodegen_actual:-<unknown>} is installed, but this repo pins ${XCODEGEN_VERSION}."
+          err "Regenerating would produce a pbxproj that CI's drift check rejects."
+          err "Either:"
+          err "  - install the pinned release (copy-paste block in README -> Building ->"
+          err "    'Xcode project is generated (XcodeGen)'), or"
+          err "  - re-run with --no-xcodegen to build the committed project as-is"
+          err "    (added/removed source files will NOT be picked up)."
+          exit 1
+        fi
+      fi
       log "Regenerating ${PROJECT_NAME}.xcodeproj from project.yml..."
       xcodegen generate --quiet || { err "xcodegen generate failed"; exit 1; }
     fi

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,8 @@ if (NOT GTest_FOUND)
 endif()
 
 include(GoogleTest)
+# Avoid parallel post-build discovery racing on empty GoogleTest JSON output.
+set(CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE PRE_TEST)
 
 # Define common test settings interface library
 add_library(asfw_test_common_interface INTERFACE)

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -140,6 +140,13 @@ add_core_test(InterruptMaskShadowTests
 )
 target_link_libraries(InterruptMaskShadowTests PRIVATE GTest::gmock)
 
+# ControllerCore bus-reset liveness boundary tests
+add_core_test(ControllerCoreBusResetTests
+    ControllerCoreBusResetTests.cpp
+    "${ASFW_DRIVER_DIR}/Controller/ControllerCoreInterrupts.cpp"
+)
+target_link_libraries(ControllerCoreBusResetTests PRIVATE asfw_configrom_host)
+
 # Topology Map Builder Tests
 add_core_test(TopologyMapBuilderTests
     TopologyMapBuilderTests.cpp

--- a/tests/core/ControllerCoreBusResetTests.cpp
+++ b/tests/core/ControllerCoreBusResetTests.cpp
@@ -1,0 +1,185 @@
+#include <gtest/gtest.h>
+
+#include "ASFWDriver/Async/DMAMemoryImpl.hpp"
+#include "ASFWDriver/Async/FireWireBusImpl.hpp"
+#include "ASFWDriver/Bus/BusManager/BusManagerPolicyCoordinator.hpp"
+#include "ASFWDriver/Bus/BusManager/CyclePolicyCoordinator.hpp"
+#include "ASFWDriver/Bus/BusManager/GapPolicyCoordinator.hpp"
+#include "ASFWDriver/Bus/BusManager/PowerLinkPolicyCoordinator.hpp"
+#include "ASFWDriver/Bus/BusManager/RootSelectionCoordinator.hpp"
+#include "ASFWDriver/Bus/BusResetCoordinator.hpp"
+#include "ASFWDriver/Bus/CSR/BroadcastChannelCSR.hpp"
+#include "ASFWDriver/Bus/CSR/SpeedMapService.hpp"
+#include "ASFWDriver/Bus/IRM/IRMFallbackCoordinator.hpp"
+#include "ASFWDriver/Bus/IRM/LocalIRMResourceController.hpp"
+#include "ASFWDriver/ConfigROM/ConfigROMStore.hpp"
+#include "ASFWDriver/Controller/ControllerCore.hpp"
+#include "ASFWDriver/Controller/ControllerStateMachine.hpp"
+#include "ASFWDriver/Diagnostics/DiagnosticLogger.hpp"
+#include "ASFWDriver/Discovery/DeviceManager.hpp"
+#include "ASFWDriver/Discovery/DeviceRegistry.hpp"
+#include "ASFWDriver/Hardware/HardwareInterface.hpp"
+#include "ASFWDriver/Hardware/InterruptManager.hpp"
+#include "ASFWDriver/Hardware/OHCIEventCodes.hpp"
+#include "ASFWDriver/Protocols/AVC/AVCDiscovery.hpp"
+#include "ASFWDriver/Protocols/AVC/CMP/CMPClient.hpp"
+#include "ASFWDriver/Protocols/SBP2/Session/SessionRegistry.hpp"
+
+#include <utility>
+
+namespace {
+
+ASFW::Discovery::ConfigROM MakeROM(ASFW::Discovery::Generation generation,
+                                   uint8_t nodeId,
+                                   ASFW::Discovery::Guid64 guid) {
+    ASFW::Discovery::ConfigROM rom{};
+    rom.gen = generation;
+    rom.nodeId = nodeId;
+    rom.bib.guid = guid;
+    rom.rawQuadlets = {0x31333934u};
+    return rom;
+}
+
+} // namespace
+
+// This target links the production ControllerCore::HandleInterrupt
+// implementation without the DriverKit lifecycle. These narrow host definitions
+// keep every unrelated dependency absent while preserving the real bus-reset
+// dispatch path under test.
+namespace ASFW::Driver {
+
+ControllerCore::ControllerCore(ControllerConfig config, RolePolicy initialPolicy,
+                               Dependencies deps)
+    : config_(std::move(config)),
+      rolePolicy_(initialPolicy),
+      deps_(std::move(deps)),
+      running_(true) {}
+
+ControllerCore::~ControllerCore() = default;
+
+ControllerStateMachine::ControllerStateMachine() = default;
+ControllerStateMachine::~ControllerStateMachine() = default;
+ControllerState ControllerStateMachine::CurrentState() const {
+    return ControllerState::kRunning;
+}
+std::string_view ToString(ControllerState) { return "Running"; }
+
+const ControllerStateMachine& ControllerCore::StateMachine() const {
+    static ControllerStateMachine stateMachine;
+    return stateMachine;
+}
+
+void ControllerCore::EvaluateCyclePolicy() noexcept {}
+void ControllerCore::HandleCycle64Seconds() {}
+void ControllerCore::CompleteRootCycleLostWindow(uint32_t, uint32_t, bool) {}
+void ControllerCore::DiagnoseUnrecoverableError() const {}
+
+void ControllerCore::ForceRootAndReset(uint8_t, Role::RoleResetFlavor, uint8_t, uint32_t) {}
+void ControllerCore::EnableRemoteCycleMaster(uint8_t, uint32_t) {}
+void ControllerCore::EnableLocalCycleMaster(uint32_t) {}
+void ControllerCore::ClearLocalContenderAndDelegate(uint8_t, uint32_t) {}
+void ControllerCore::OnLocalWonBM(uint32_t, uint8_t) {}
+void ControllerCore::OnRemoteBM(uint32_t, uint8_t) {}
+void ControllerCore::OnBMElectionFailed(uint32_t, Async::AsyncStatus) {}
+void ControllerCore::SendRemoteCmstr(uint8_t, uint32_t) {}
+bool ControllerCore::EnableLocalCycleMasterMutation(uint32_t) { return false; }
+bool ControllerCore::ClearLocalCycleMasterMutation(uint32_t) { return false; }
+Async::AsyncHandle ControllerCore::WriteRemoteStateSetCmstr(uint32_t, uint16_t, uint8_t) {
+    return {};
+}
+bool ControllerCore::ForceRootAndResetForBMPolicy(uint32_t, uint8_t, bool,
+                                                  std::optional<uint8_t>) {
+    return false;
+}
+bool ControllerCore::ForceRootAndGapResetForBMPolicy(uint32_t, uint8_t, bool, uint8_t) {
+    return false;
+}
+bool ControllerCore::SendLinkOnPacket(uint32_t, uint16_t, uint8_t) { return false; }
+
+uint32_t InterruptManager::EnabledMask() const { return 0xFFFFFFFFu; }
+
+std::string DiagnosticLogger::DecodeInterruptEvents(uint32_t) { return {}; }
+
+void BusResetCoordinator::OnIrq(uint32_t, uint64_t) {}
+
+namespace Role {
+
+RoleAction EvaluateRolePolicy(const RoleInputs&) noexcept { return {}; }
+bool CycleObserver::OnInterrupt(uint32_t, uint32_t) noexcept { return false; }
+void RoleCoordinator::OnCycleStartEvidence(uint32_t, CycleObservation) {}
+
+} // namespace Role
+
+} // namespace ASFW::Driver
+
+namespace ASFW::CMP {
+
+void CMPClient::InvalidateAllLeasesForBusReset() {}
+
+} // namespace ASFW::CMP
+
+namespace ASFW::Bus {
+
+void SpeedMapService::Invalidate(uint32_t) noexcept {}
+void GapPolicyCoordinator::OnBusResetStarted(uint32_t) noexcept {}
+void CyclePolicyCoordinator::OnBusResetStarted(uint32_t) noexcept {}
+void IRMFallbackCoordinator::OnBusResetStarted(uint32_t) noexcept {}
+void BusManagerElectionDriver::OnBusReset() noexcept {}
+void RootSelectionCoordinator::OnBusResetStarted(uint32_t) noexcept {}
+void LocalIRMResourceController::OnBusResetStarted(uint32_t) noexcept {}
+void PowerLinkPolicyCoordinator::OnBusResetStarted(uint32_t) noexcept {}
+
+} // namespace ASFW::Bus
+
+namespace ASFW::Discovery {
+
+void DeviceManager::SuspendAllForBusReset() {}
+void DeviceRegistry::InvalidateLiveMappingsForBusReset() {}
+
+} // namespace ASFW::Discovery
+
+namespace ASFW::Protocols::AVC {
+
+void AVCDiscovery::OnBusReset(uint32_t) {}
+
+} // namespace ASFW::Protocols::AVC
+
+namespace ASFW::Protocols::SBP2 {
+
+void SessionRegistry::OnBusReset(uint16_t) {}
+
+} // namespace ASFW::Protocols::SBP2
+
+TEST(ControllerCoreBusResetTests, InterruptSuspendsCachedROMBeforeRediscovery) {
+    using ASFW::Discovery::Generation;
+
+    auto hardware = std::make_shared<ASFW::Driver::HardwareInterface>();
+    auto romStore = std::make_shared<ASFW::Discovery::ConfigROMStore>();
+
+    constexpr Generation kCachedGeneration{2};
+    constexpr uint32_t kResetGeneration = 3;
+    constexpr uint8_t kNodeId = 2;
+    constexpr ASFW::Discovery::Guid64 kGuid = 0x00130e0402004713ULL;
+
+    romStore->Insert(MakeROM(kCachedGeneration, kNodeId, kGuid));
+    ASSERT_NE(romStore->FindByNode(kCachedGeneration, kNodeId, false), nullptr);
+
+    hardware->SetTestRegister(ASFW::Driver::Register32::kSelfIDGeneration,
+                              kResetGeneration);
+
+    ASFW::Driver::ControllerCore::Dependencies deps{};
+    deps.hardware = hardware;
+    deps.romStore = romStore;
+    ASFW::Driver::ControllerCore core(ASFW::Driver::ControllerConfig{},
+                                      ASFW::Driver::RolePolicy{}, std::move(deps));
+
+    core.HandleInterrupt(ASFW::Driver::InterruptSnapshot{
+        .intEvent = ASFW::Driver::IntEventBits::kBusReset,
+        .timestamp = 1,
+    });
+
+    // The unfiltered lookup remains available to rediscovery lifecycle code,
+    // while selector 14's filtered lookup cannot export stale ROM bytes.
+    ASSERT_NE(romStore->FindByNode(kCachedGeneration, kNodeId, true), nullptr);
+    EXPECT_EQ(romStore->FindByNode(kCachedGeneration, kNodeId, false), nullptr);
+}

--- a/tests/discovery/ConfigROMStoreConcurrencyTests.cpp
+++ b/tests/discovery/ConfigROMStoreConcurrencyTests.cpp
@@ -145,6 +145,25 @@ TEST(ConfigROMStoreConcurrencyTests, InvalidateRemovesGenerationNodeReachability
     EXPECT_EQ(store.FindByGuid(kGuid)->state, ASFW::Discovery::ROMState::Invalid);
 }
 
+TEST(ConfigROMStoreConcurrencyTests, FilteredExactGenerationLookupRejectsSuspendedROM) {
+    ASFW::Discovery::ConfigROMStore store;
+
+    constexpr ASFW::Discovery::Guid64 kGuid = 0x00130e0402004713ULL;
+    const ASFW::Discovery::Generation kCachedGeneration{2};
+    constexpr uint8_t kNodeId = 2;
+
+    store.Insert(MakeROM(kCachedGeneration, kNodeId, kGuid));
+    store.SuspendAll(ASFW::Discovery::Generation{3});
+
+    // Lifecycle code can still inspect the suspended cache entry explicitly.
+    ASSERT_NE(store.FindByNode(kCachedGeneration, kNodeId), nullptr);
+    ASSERT_NE(store.FindByNode(kCachedGeneration, kNodeId, true), nullptr);
+
+    // Selector 14 uses the filtered exact-generation lookup so its existing
+    // not-cached path exports empty data instead of stale ROM bytes.
+    EXPECT_EQ(store.FindByNode(kCachedGeneration, kNodeId, false), nullptr);
+}
+
 TEST(ConfigROMStoreConcurrencyTests, LatestLookupDoesNotReuseProfileAcrossDifferentGuid) {
     ASFW::Discovery::ConfigROMStore store;
     constexpr ASFW::Discovery::Guid64 kOldGuid = 0x0090b54001ffffffULL;

--- a/tests/discovery/ConfigROMStoreConcurrencyTests.cpp
+++ b/tests/discovery/ConfigROMStoreConcurrencyTests.cpp
@@ -145,7 +145,7 @@ TEST(ConfigROMStoreConcurrencyTests, InvalidateRemovesGenerationNodeReachability
     EXPECT_EQ(store.FindByGuid(kGuid)->state, ASFW::Discovery::ROMState::Invalid);
 }
 
-TEST(ConfigROMStoreConcurrencyTests, FilteredExactGenerationLookupRejectsSuspendedROM) {
+TEST(ConfigROMStoreConcurrencyTests, BusResetSuspensionRejectsExactGenerationExport) {
     ASFW::Discovery::ConfigROMStore store;
 
     constexpr ASFW::Discovery::Guid64 kGuid = 0x00130e0402004713ULL;
@@ -159,8 +159,9 @@ TEST(ConfigROMStoreConcurrencyTests, FilteredExactGenerationLookupRejectsSuspend
     ASSERT_NE(store.FindByNode(kCachedGeneration, kNodeId), nullptr);
     ASSERT_NE(store.FindByNode(kCachedGeneration, kNodeId, true), nullptr);
 
-    // Selector 14 uses the filtered exact-generation lookup so its existing
-    // not-cached path exports empty data instead of stale ROM bytes.
+    // The live reset edge suspends this store before selector 14 can perform
+    // its filtered exact-generation lookup. The existing not-cached path must
+    // then export empty data instead of stale ROM bytes.
     EXPECT_EQ(store.FindByNode(kCachedGeneration, kNodeId, false), nullptr);
 }
 


### PR DESCRIPTION
## Summary

- make ConfigROM selector 14 reject suspended cache entries
- suspend cached ROM visibility on the bus-reset edge while preserving internal lifecycle access
- add regression coverage for exact-generation exports and controller reset dispatch

## Problem

`ExportConfigROM` documents exact-generation lookup with no stale fallback, but it called the `ConfigROMStore` overload that returns suspended entries. A bus reset between a client generation read and selector 14 could therefore return a complete ROM from the previous generation and let the client reuse stale node routing information.

The cache also remained export-visible until later rediscovery work updated it, leaving a reset window in which stale bytes could still be returned.

## Fix

Use `FindByNode(generation, node, false)` in the user-client handler. The existing not-cached path then returns empty data for suspended entries, while internal callers can still opt into suspended cache access.

On the controller's bus-reset edge, suspend the ROM cache alongside the existing route and lease invalidation, before protocol producers are notified. The migration preserves `dev`'s current reset ordering.

## Verification

- `ConfigROMStoreConcurrencyTests`: 8/8 passed
- `ControllerCoreBusResetTests`: 1/1 passed
- full C++ host suite: 1,542/1,542 passed, 6 conditional skips
- pinned XcodeGen regeneration produced no tracked project drift
- `git diff --check`
- GitHub Build and Test: passed on the stacked `dev` head
- no dext install or hardware mutation was required

## Dependency and merge order

Depends on #88. This PR targets `dev` and is stacked directly on the current #88 head.

This PR is a sibling of #84, not a child of it: #84 and #87 have no code dependency and may be reviewed or merged in either order after #88.

Until #88 merges, GitHub's **Files changed** view will also include #88's CI/project-generation changes. The #87-specific review scope is the top three Config ROM commits and these five files:

- `ASFWDriver/Controller/ControllerCoreInterrupts.cpp`
- `ASFWDriver/UserClient/Handlers/ConfigROMHandler.cpp`
- `tests/core/CMakeLists.txt`
- `tests/core/ControllerCoreBusResetTests.cpp`
- `tests/discovery/ConfigROMStoreConcurrencyTests.cpp`

Intended merge order:

1. merge #88 into `dev`;
2. update #87 onto the resulting `dev` tip if GitHub does not collapse the stacked diff automatically, retaining only the three Config ROM commits;
3. merge #84 and #87 in either order after their checks pass.
