### PR TITLE
fix(lifecycle): recreate the ROM scanner across runtime rebuilds instead of reusing it against a freed bus

### DIFF
--- a/ASFW.xcodeproj/project.pbxproj
+++ b/ASFW.xcodeproj/project.pbxproj
@@ -2926,8 +2926,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				EE5A446B3669D0171F9606EE /* ASFW */,
 				0EB9A8DA75D08971084A440A /* ASFWDriver */,
+				EE5A446B3669D0171F9606EE /* ASFW */,
 				348672D607701677ABCB567C /* ASFWTests */,
 			);
 		};

--- a/ASFWDriver/Service/DriverContext.cpp
+++ b/ASFWDriver/Service/DriverContext.cpp
@@ -70,6 +70,15 @@ void ServiceContext::Reset(ResetMode mode) {
         sbp2Bridge.reset();
     }
     (void)isoch.StopAll();
+    // The ROM scanner holds a bare IFireWireBus& into the controller-owned
+    // FireWireBusImpl, fixed at construction. Destroy it while the bus is still
+    // alive (the controller's own shared_ptr copy is dropped first) so the
+    // rebuild path in EnsureRomScanner creates a fresh scanner against the new
+    // controller's bus, instead of reusing one bound to freed memory.
+    if (controller) {
+        controller->AttachROMScanner(nullptr);
+    }
+    deps.romScanner.reset();
     controller.reset();
     audioCoordinator.reset();
     // Tear down the runtime audio protocols while the services they were built from


### PR DESCRIPTION
## What

`ServiceContext::Reset` destroys the controller (and with it the controller-owned `FireWireBusImpl`), but never dropped `deps.romScanner`. `ROMScanner`, `ROMReader` and `ROMScanSession` hold a bare `Async::IFireWireBus&` fixed at construction, so `EnsureRomScanner` reused the stale scanner after every internal runtime rebuild ("Reusing existing ROMScanner instance") and the next scan dereferenced freed memory in the `ReadQuad` path — fault offset 0x10 = `FireWireBusImpl::async_`. Deterministic on every scan after the first rebuild.

Observed on real hardware (2026-07-29, during HW validation of #61): dext SIGSEGV when scanner power-on triggered a bus reset during a runtime rebuild. Crash report available on request.

## Fix

In `Reset`, detach the controller's attached `shared_ptr` copy and drop `deps.romScanner` **before** `controller.reset()`, so `~ROMScanner` runs while the bus is still alive. `EnsureRomScanner` (re-entered from `StartRuntime` on wake/recovery) then takes its existing rebuild branch, binding the fresh scanner to the new controller's `Bus()` and the new scheduler queue (equally stale on reuse before this fix).

Teardown safety: `~ROMScanner` → `ROMScanSession::Abort()` only sets the `aborted_` flag and queues weak_ptr cleanup — no bus IO — and every queued FSM entry point checks `aborted_` before touching the bus.

## Scope

This implements only the safety floor: *a scanner must not retain a borrowed bus reference after that bus is destroyed*. It does **not** touch the `ConfigROMStore` cache or device identity, and does not change what gets rescanned. Fingerprint-validated rediscovery (preserve cached ROM identity across a reset, revalidate a BIB/root-directory fingerprint before resuming, full rescan only on change — the Apple/Linux model) is deliberately left as the follow-up design it belongs to; nothing here precludes it.

Split out of #61 per review feedback (HBA and Config ROM work kept separate). Same bug class as the `IRMClient` teardown fix — but the scanner was never rebuilt at all.

## Testing

- Host suite: 1375/1375 green
- `./build.sh --scsi` build green
- **HW-verified 2026-07-31** (MacBook Pro / macOS Tahoe + Nikon CoolScan 9000 over FireWire): power-cycling the device across two sleep/wake runtime rebuilds produced clean full ROM scans + SBP-2 login both times. The log shows `✅ ROMScanner created` on the post-wake rebuild (never "Reusing existing ROMScanner instance"), wake-verify alive, and no dext crash. On main this exact sequence SIGSEGVs deterministically.

