### PR TITLE
ci: build the SCSI-enabled variant on every PR

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -163,3 +163,50 @@ jobs:
       # - name: Build Driver
       #   run: |
       #     ./build.sh
+
+  # The SCSI HBA is opt-in (ASFW_ENABLE_SCSI, ./build.sh --scsi) and OFF in the
+  # default build above, so the Info.plist personality preprocessing and the
+  # SCSI entitlement selection are never exercised by the main job. Build the
+  # variant here so the gated configuration cannot rot while the flag stays
+  # default-off — a malformed personality only surfaces on an opt-in user's
+  # machine otherwise, and the failure mode there is a boot panic (#54).
+  build-scsi:
+    name: Build (SCSI HBA enabled)
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build Driver (ASFW_ENABLE_SCSI=YES)
+        run: |
+          set -o pipefail
+          xcodebuild -project ASFW.xcodeproj \
+            -scheme ASFW \
+            -configuration Debug \
+            -arch arm64 \
+            -derivedDataPath build/DerivedData \
+            build \
+            ASFW_ENABLE_SCSI=YES \
+            CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO \
+            > xcodebuild-scsi.log 2>&1 || {
+              echo "::error::SCSI-enabled build failed! Showing last 100 lines of log:"
+              tail -n 100 xcodebuild-scsi.log
+              exit 1
+            }
+
+      # The personality is injected by Info.plist preprocessing; assert it
+      # actually landed in the built dext so a silent preprocessor regression
+      # cannot pass CI.
+      - name: Verify SCSI personality in built dext
+        run: |
+          PLIST=$(find build/DerivedData/Build/Products -path "*net.mrmidi.ASFW.ASFWDriver.dext/Info.plist" | head -1)
+          if [[ -z "$PLIST" ]]; then
+            echo "::error::Built dext Info.plist not found"
+            exit 1
+          fi
+          plutil -lint "$PLIST"
+          if ! /usr/libexec/PlistBuddy -c "Print :IOKitPersonalities:ASFWSCSIControllerService:IOClass" "$PLIST" >/dev/null 2>&1; then
+            echo "::error::ASFWSCSIControllerService personality missing from built dext Info.plist despite ASFW_ENABLE_SCSI=YES"
+            exit 1
+          fi
+          echo "SCSI personality present:"
+          /usr/libexec/PlistBuddy -c "Print :IOKitPersonalities:ASFWSCSIControllerService" "$PLIST" | head -20

--- a/ASFW.xcodeproj/project.pbxproj
+++ b/ASFW.xcodeproj/project.pbxproj
@@ -2926,8 +2926,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				EE5A446B3669D0171F9606EE /* ASFW */,
 				0EB9A8DA75D08971084A440A /* ASFWDriver */,
+				EE5A446B3669D0171F9606EE /* ASFW */,
 				348672D607701677ABCB567C /* ASFWTests */,
 			);
 		};


### PR DESCRIPTION
## What

Adds a parallel CI job that builds the driver with `ASFW_ENABLE_SCSI=YES` (unsigned) and asserts the `ASFWSCSIControllerService` personality actually landed in the built dext's `Info.plist`.

## Why

The SCSI HBA is opt-in (`./build.sh --scsi`, #55) and OFF in the default CI build, so the two things the flag controls — the `Info.plist` personality preprocessing and the SCSI entitlement selection — are never exercised by CI today. A regression there only surfaces on an opt-in user's machine, where the failure mode is the #54 boot panic. With this job the gated configuration can't silently rot while the flag stays default-off (and if SCSI ever becomes default-on, the coverage is already in place).

The personality assertion uses `PlistBuddy` against the built dext, so a silent preprocessor regression (personality quietly missing) fails CI rather than passing as a "successful" build.

## Housekeeping

First commit regenerates `ASFW.xcodeproj` with xcodegen 2.46.0 (Homebrew's current version, which changed the emitted group order). Without it the existing "Verify ASFW.xcodeproj matches project.yml" gate fails for **every** PR against main — #61 and #90 already carry the same one-line regen on their branches.