### PR TITLE
scsi: match HBA personality on ASFWSBP2Nub — makes the #54 boot panic impossible by construction

### DIFF
--- a/ASFW.xcodeproj/project.pbxproj
+++ b/ASFW.xcodeproj/project.pbxproj
@@ -226,7 +226,9 @@
 		9939EA3C38D005D2B1706109 /* LockCommand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 647BC02DDA3AE383EBFED56E /* LockCommand.cpp */; };
 		9A00ED30A11DABC7DD49E7BC /* DriverConnector+Isoch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88363EE0072BC820ECBB6C1D /* DriverConnector+Isoch.swift */; };
 		9B8E94EA1F0A961CD016D197 /* DriverViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7892E16293D409FFB4F00710 /* DriverViewModel.swift */; };
+		9BD95333AF99D4D79CD5A3DF /* DriverConnector+SCSIMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DEF4DDB2D9566CAEAFFAAB7 /* DriverConnector+SCSIMapper.swift */; };
 		9BFABEBFD4EE64F02ADFBBF1 /* AsyncSubsystemInterrupts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B3F76378A96EF757865E11C4 /* AsyncSubsystemInterrupts.cpp */; };
+		9C590D10F760AFC85C707998 /* DARTCandidateSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0CE0102B0AEA2853C383FA /* DARTCandidateSelectionTests.swift */; };
 		9C87DF69A89E62030306D1FB /* DiagnosticsTextFormatter+Topology.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F0E726223068E61ED92CE8 /* DiagnosticsTextFormatter+Topology.swift */; };
 		9EDB35B4B0F9F503A82DB7A8 /* AddressSpaceManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27D4308D539CCEC3A5EBCFF7 /* AddressSpaceManager.cpp */; };
 		A040141317C828BDF58DB6A6 /* IsochHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0AC0E4BEE81FF4834F182189 /* IsochHandler.cpp */; };
@@ -641,6 +643,7 @@
 		4D671C398E07E582F14F5A56 /* ControllerCoreAccess.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ControllerCoreAccess.hpp; sourceTree = "<group>"; };
 		4D994BDB948D370E6F61467F /* DuetControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuetControlView.swift; sourceTree = "<group>"; };
 		4DB5C96A84E71BA9F2E5835A /* PreSonusStudioLiveProfile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PreSonusStudioLiveProfile.cpp; sourceTree = "<group>"; };
+		4DEF4DDB2D9566CAEAFFAAB7 /* DriverConnector+SCSIMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DriverConnector+SCSIMapper.swift"; sourceTree = "<group>"; };
 		4DFC5D271E3484233BD1B0D2 /* TopologyHandler.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = TopologyHandler.hpp; sourceTree = "<group>"; };
 		4E065C1061BFE1DDEBFCEF3B /* ControllerStateMachine.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ControllerStateMachine.hpp; sourceTree = "<group>"; };
 		4EAC9531EBCD3BFCC5274B38 /* ATContextBase.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ATContextBase.hpp; sourceTree = "<group>"; };
@@ -1130,6 +1133,7 @@
 		F85F69E1C47968DBCD351C13 /* FocusriteSaffireProfile.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = FocusriteSaffireProfile.hpp; sourceTree = "<group>"; };
 		F8B5576036EFE84BD74E7EFA /* AddressSpaceManager.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = AddressSpaceManager.hpp; sourceTree = "<group>"; };
 		F9741333A3F544B641641494 /* SaffireMixerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaffireMixerViewModel.swift; sourceTree = "<group>"; };
+		FA0CE0102B0AEA2853C383FA /* DARTCandidateSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DARTCandidateSelectionTests.swift; sourceTree = "<group>"; };
 		FA21FB623DC8076A7D6A6ACE /* SessionRegistry.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = SessionRegistry.hpp; sourceTree = "<group>"; };
 		FB4F38B538B6F7A28F16625C /* SBP2ManagementORB.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SBP2ManagementORB.cpp; sourceTree = "<group>"; };
 		FC76D117C15153F78867F3A4 /* ASFWMCPSbp2Tools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASFWMCPSbp2Tools.swift; sourceTree = "<group>"; };
@@ -1643,6 +1647,7 @@
 				AB92C50A509F45F51EFD3F03 /* AVCNestedChannelTests.swift */,
 				8AC380D7BBAE68986EC3385C /* AVCSampleRateMappingTests.swift */,
 				DF378D7A8CBF72942CB67F13 /* AVCUnitWireParsingTests.swift */,
+				FA0CE0102B0AEA2853C383FA /* DARTCandidateSelectionTests.swift */,
 				C3C3C0A53557FD4630647F63 /* DuetCodecTests.swift */,
 				51751F4E2707BF3956287D1F /* DuetViewModelLogicTests.swift */,
 				AA63228416151FD72A8A9C49 /* MCP */,
@@ -1953,6 +1958,7 @@
 				6FA63624C10EEF4E28C60EB7 /* DriverConnector+LoggingConfig.swift */,
 				9D7C91E89F804C760390C3DA /* DriverConnector+LogRing.swift */,
 				6A816C540C2BEB377CE294ED /* DriverConnector+Saffire.swift */,
+				4DEF4DDB2D9566CAEAFFAAB7 /* DriverConnector+SCSIMapper.swift */,
 				264D4CD41FF948792F95E023 /* DriverConnector+Status.swift */,
 				487FFDBA8B98968F6A7E5DCB /* DriverConnectorLogStore.swift */,
 				3E3B0B43A80EA689D344C17A /* DriverConnectorTransport.swift */,
@@ -3208,6 +3214,7 @@
 				47C7D2797F3974490450A45A /* AVCNestedChannelTests.swift in Sources */,
 				BFA67B801CE2FD081CFA4BF5 /* AVCSampleRateMappingTests.swift in Sources */,
 				B48FA948465DEDE30BA18B47 /* AVCUnitWireParsingTests.swift in Sources */,
+				9C590D10F760AFC85C707998 /* DARTCandidateSelectionTests.swift in Sources */,
 				38FE60619DFBA6ECB035BE64 /* DuetCodecTests.swift in Sources */,
 				BBC4374CAF02DA7A26022E78 /* DuetViewModelLogicTests.swift in Sources */,
 				AB26C52B22F65434EA8E93A7 /* MCPAvcFcpToolsTests.swift in Sources */,
@@ -3301,6 +3308,7 @@
 				43E9F7DBC8C68F163661ABE3 /* DriverConnector+Lifecycle.swift in Sources */,
 				0AB0C833F3F66D9BAF12FEF4 /* DriverConnector+LogRing.swift in Sources */,
 				2B63AD73E9E124C02A392F9C /* DriverConnector+LoggingConfig.swift in Sources */,
+				9BD95333AF99D4D79CD5A3DF /* DriverConnector+SCSIMapper.swift in Sources */,
 				E07796C3FF28E4FF1CA3F467 /* DriverConnector+Saffire.swift in Sources */,
 				0267190E6597A8DA11482D7C /* DriverConnector+Status.swift in Sources */,
 				88663772C9C228C3DC7F6CBD /* DriverConnectorLogStore.swift in Sources */,

--- a/ASFW/ASFWDriverConnector.swift
+++ b/ASFW/ASFWDriverConnector.swift
@@ -60,6 +60,8 @@ final class ASFWDriverConnector: ObservableObject {
         case requestUserBusReset = 61
         case startAudioStreaming = 62
         case stopAudioStreaming = 63
+        // App-provisioned DART mapper id for the driver's SBP-2 nub (Apple Silicon).
+        case provisionSCSIMapperID = 64
     }
 
     // MARK: - Re-exported Models

--- a/ASFW/DriverConnector+Lifecycle.swift
+++ b/ASFW/DriverConnector+Lifecycle.swift
@@ -111,6 +111,12 @@ extension ASFWDriverConnector {
         DispatchQueue.main.async { [weak self] in
             self?.isConnected = true
         }
+
+        // Idempotent (the driver publishes its SBP-2 nub at most once), and
+        // repeated here on every connect so adapter re-plug — which restarts
+        // the dext with an unprovisioned nub — heals on reconnection.
+        provisionSCSIMapperID()
+
         log("Connection established", level: .success)
     }
 

--- a/ASFW/DriverConnector+SCSIMapper.swift
+++ b/ASFW/DriverConnector+SCSIMapper.swift
@@ -37,16 +37,18 @@ extension ASFWDriverConnector {
     }
 
     /// Pure selection logic, split out for testability: exact
-    /// `dart-<complex>-piodma` match first, then any DART in the same
-    /// complex, then any DART at all.
+    /// `mapper-<complex>-piodma` match first, then any mapper in the same
+    /// complex, then any mapper at all. The trailing hyphen in tier two
+    /// keeps `apciec1` from matching `mapper-apciec10-…`.
     static func selectDARTCandidate(
         complex: String?, candidates: [(name: String, id: UInt32)]
     ) -> UInt32? {
         if let complex {
-            if let exact = candidates.first(where: { $0.name == "dart-\(complex)-piodma" }) {
+            if let exact = candidates.first(where: { $0.name == "mapper-\(complex)-piodma" }) {
                 return exact.id
             }
-            if let sameComplex = candidates.first(where: { $0.name.hasPrefix("dart-\(complex)") }) {
+            if let sameComplex = candidates.first(where: { $0.name.hasPrefix("mapper-\(complex)-") })
+            {
                 return sameComplex.id
             }
         }
@@ -82,13 +84,14 @@ extension ASFWDriverConnector {
         }
     }
 
-    /// Every `dart-*`-named IOService-plane entry publishing an IOMapperID.
+    /// Every IODARTMapper publishing an IOMapperID, named by its
+    /// IODARTMapperNub parent (e.g. `mapper-apciec0-piodma`). No registry
+    /// entry named `dart-*` carries IOMapperID — the property lives on the
+    /// IODARTMapper child of the mapper nub.
     private static func dartMapperCandidates() -> [(name: String, id: UInt32)] {
         var iterator: io_iterator_t = 0
-        let root = IORegistryGetRootEntry(kIOMainPortDefault)
-        guard IORegistryEntryCreateIterator(
-            root, "IOService", IOOptionBits(kIORegistryIterateRecursively), &iterator)
-            == KERN_SUCCESS
+        guard IOServiceGetMatchingServices(
+            kIOMainPortDefault, IOServiceMatching("IODARTMapper"), &iterator) == KERN_SUCCESS
         else { return [] }
         defer { IOObjectRelease(iterator) }
 
@@ -98,11 +101,6 @@ extension ASFWDriverConnector {
             guard entry != 0 else { break }
             defer { IOObjectRelease(entry) }
 
-            var nameBuffer = [CChar](repeating: 0, count: 128)
-            guard IORegistryEntryGetName(entry, &nameBuffer) == KERN_SUCCESS else { continue }
-            let name = String(cString: nameBuffer)
-            guard name.hasPrefix("dart-") else { continue }
-
             guard
                 let data = IORegistryEntryCreateCFProperty(
                     entry, "IOMapperID" as CFString, kCFAllocatorDefault, 0)?
@@ -110,7 +108,14 @@ extension ASFWDriverConnector {
                 data.count >= 4
             else { continue }
             let id = data.withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }
-            candidates.append((name: name, id: UInt32(littleEndian: id)))
+
+            var parent: io_registry_entry_t = 0
+            guard IORegistryEntryGetParentEntry(entry, "IOService", &parent) == KERN_SUCCESS
+            else { continue }
+            defer { IOObjectRelease(parent) }
+            var nameBuffer = [CChar](repeating: 0, count: 128)
+            guard IORegistryEntryGetName(parent, &nameBuffer) == KERN_SUCCESS else { continue }
+            candidates.append((name: String(cString: nameBuffer), id: UInt32(littleEndian: id)))
         }
         return candidates
     }

--- a/ASFW/DriverConnector+SCSIMapper.swift
+++ b/ASFW/DriverConnector+SCSIMapper.swift
@@ -1,0 +1,117 @@
+import Foundation
+import IOKit
+
+extension ASFWDriverConnector {
+    /// On Apple Silicon the driver defers publishing its SBP-2 nub until it
+    /// knows which DART the SCSI kernel shim should resolve DMA mappings
+    /// through — the mapper id is only readable from user space (the live
+    /// IODARTMapper object does not serialize across the DriverKit boundary).
+    /// Look it up and hand it down. On Intel (no DART nodes) this finds
+    /// nothing and returns; VT-d's system mapper covers that case.
+    func provisionSCSIMapperID() {
+        guard connection != 0 else { return }
+        guard let mapperID = Self.fireWireDARTMapperID() else {
+            log("No DART mapper found for the FireWire controller — skipping SCSI mapper provisioning",
+                level: .info)
+            return
+        }
+        var input = UInt64(mapperID)
+        let kr = IOConnectCallScalarMethod(
+            connection, Method.provisionSCSIMapperID.rawValue, &input, 1, nil, nil)
+        if kr == KERN_SUCCESS {
+            log(String(format: "Provisioned SCSI DART mapper id 0x%08x", mapperID), level: .success)
+        } else {
+            log("SCSI mapper provisioning failed: \(interpretIOReturn(kr))", level: .error)
+        }
+    }
+
+    /// The IOMapperID of a DART serving the FireWire controller's PCIe
+    /// complex. The HBA copies payloads via UserGetDataBuffer and never
+    /// dereferences the IOVA, so any published DART satisfies the kernel
+    /// shim — the tiers below just prefer the controller's own complex.
+    static func fireWireDARTMapperID() -> UInt32? {
+        let complex = fireWireControllerPath().flatMap { path in
+            path.range(of: "apciec[0-9]+", options: .regularExpression).map { String(path[$0]) }
+        }
+        return selectDARTCandidate(complex: complex, candidates: dartMapperCandidates())
+    }
+
+    /// Pure selection logic, split out for testability: exact
+    /// `dart-<complex>-piodma` match first, then any DART in the same
+    /// complex, then any DART at all.
+    static func selectDARTCandidate(
+        complex: String?, candidates: [(name: String, id: UInt32)]
+    ) -> UInt32? {
+        if let complex {
+            if let exact = candidates.first(where: { $0.name == "dart-\(complex)-piodma" }) {
+                return exact.id
+            }
+            if let sameComplex = candidates.first(where: { $0.name.hasPrefix("dart-\(complex)") }) {
+                return sameComplex.id
+            }
+        }
+        return candidates.first?.id
+    }
+
+    /// IOService-plane path of the FireWire OHCI controller (PCI class-code
+    /// 0x0C0010), or nil if none is present.
+    private static func fireWireControllerPath() -> String? {
+        var iterator: io_iterator_t = 0
+        guard IOServiceGetMatchingServices(
+            kIOMainPortDefault, IOServiceMatching("IOPCIDevice"), &iterator) == KERN_SUCCESS
+        else { return nil }
+        defer { IOObjectRelease(iterator) }
+
+        while true {
+            let service = IOIteratorNext(iterator)
+            guard service != 0 else { return nil }
+            defer { IOObjectRelease(service) }
+
+            guard
+                let classCode = IORegistryEntryCreateCFProperty(
+                    service, "class-code" as CFString, kCFAllocatorDefault, 0)?
+                    .takeRetainedValue() as? Data,
+                classCode.count >= 3,
+                classCode[0] == 0x10, classCode[1] == 0x00, classCode[2] == 0x0C
+            else { continue }
+
+            var path = [CChar](repeating: 0, count: 512)
+            if IORegistryEntryGetPath(service, "IOService", &path) == KERN_SUCCESS {
+                return String(cString: path)
+            }
+        }
+    }
+
+    /// Every `dart-*`-named IOService-plane entry publishing an IOMapperID.
+    private static func dartMapperCandidates() -> [(name: String, id: UInt32)] {
+        var iterator: io_iterator_t = 0
+        let root = IORegistryGetRootEntry(kIOMainPortDefault)
+        guard IORegistryEntryCreateIterator(
+            root, "IOService", IOOptionBits(kIORegistryIterateRecursively), &iterator)
+            == KERN_SUCCESS
+        else { return [] }
+        defer { IOObjectRelease(iterator) }
+
+        var candidates: [(name: String, id: UInt32)] = []
+        while true {
+            let entry = IOIteratorNext(iterator)
+            guard entry != 0 else { break }
+            defer { IOObjectRelease(entry) }
+
+            var nameBuffer = [CChar](repeating: 0, count: 128)
+            guard IORegistryEntryGetName(entry, &nameBuffer) == KERN_SUCCESS else { continue }
+            let name = String(cString: nameBuffer)
+            guard name.hasPrefix("dart-") else { continue }
+
+            guard
+                let data = IORegistryEntryCreateCFProperty(
+                    entry, "IOMapperID" as CFString, kCFAllocatorDefault, 0)?
+                    .takeRetainedValue() as? Data,
+                data.count >= 4
+            else { continue }
+            let id = data.withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }
+            candidates.append((name: name, id: UInt32(littleEndian: id)))
+        }
+        return candidates
+    }
+}

--- a/ASFWDriver/ASFWDriver.cpp
+++ b/ASFWDriver/ASFWDriver.cpp
@@ -209,6 +209,73 @@ void ASFWDriver::free() {
     super::free();
 }
 
+// Give the SBP-2 nub a DMA mapper the SCSI HBA's kernel shim can resolve.
+//
+// The shim prepares an IODMACommand for every data-carrying task before calling
+// into the dext and requires ONE IOVM segment spanning the whole transfer. Its
+// mapper comes from IOMapper::copyMapperForDeviceWithIndex(getProvider(), 0),
+// which is a plain copyProperty("iommu-parent") on the nub (xnu
+// IOMapper.cpp:174-207). With no mapper there is no IOVA remapping, so only a
+// transfer that fits one physically contiguous page yields a single segment and
+// everything larger is failed in the kernel before UserProcessParallelTask runs
+// — HW-confirmed 2026-08-04: 519 KB reads died pre-dext until the nub carried
+// this property. An OSData value is matched against the IOMapperID each
+// IODARTMapper publishes; the HBA never dereferences the resulting address (all
+// payload moves by memcpy via UserGetDataBuffer), so the mapping only has to
+// exist. A board-specific fallback lives in ASFWSBP2NubProperties.
+static void PublishNubMapperID(IOService* provider, IOService* nub) {
+    if (provider == nullptr || nub == nullptr) {
+        return;
+    }
+
+    static constexpr struct {
+        const char* key;
+        const char* plane;
+    } kProbes[] = {
+        {"iommu-parent", "IOService"},
+        {"iommu-parent", "IODeviceTree"},
+        {"iommu-id", "IODeviceTree"},
+    };
+
+    OSData* discovered = nullptr;
+    for (const auto& probe : kProbes) {
+        OSContainer* raw = nullptr;
+        const kern_return_t kr = provider->SearchProperty(
+            probe.key, probe.plane, kIOServiceSearchPropertyParents, &raw);
+        auto value = OSSharedPtr(raw, OSNoRetain);
+        auto* data = OSDynamicCast(OSData, value.get());
+        uint32_t id = 0;
+        if (data != nullptr && data->getLength() >= sizeof(uint32_t)) {
+            const auto* bytes = static_cast<const uint8_t*>(data->getBytesNoCopy());
+            id = static_cast<uint32_t>(bytes[0]) | (static_cast<uint32_t>(bytes[1]) << 8) |
+                 (static_cast<uint32_t>(bytes[2]) << 16) | (static_cast<uint32_t>(bytes[3]) << 24);
+            if (discovered == nullptr) {
+                discovered = data;
+                discovered->retain();
+            }
+        }
+        ASFW_LOG(Controller,
+                 "[MapperDiag] SearchProperty(%{public}s, %{public}s) kr=0x%08x present=%u "
+                 "isData=%u len=%u id=0x%08x",
+                 probe.key, probe.plane, kr, value ? 1u : 0u, data != nullptr ? 1u : 0u,
+                 data != nullptr ? static_cast<unsigned>(data->getLength()) : 0u, id);
+    }
+
+    if (discovered == nullptr) {
+        ASFW_LOG(Controller, "[MapperDiag] no mapper id discovered — keeping plist fallback");
+        return;
+    }
+
+    OSDictionary* rawProps = nullptr;
+    if (nub->CopyProperties(&rawProps) == kIOReturnSuccess && rawProps != nullptr) {
+        auto props = OSSharedPtr(rawProps, OSNoRetain);
+        props->setObject("iommu-parent", discovered);
+        const kern_return_t kr = nub->SetProperties(props.get());
+        ASFW_LOG(Controller, "[MapperDiag] applied discovered mapper id to nub: kr=0x%08x", kr);
+    }
+    discovered->release();
+}
+
 kern_return_t IMPL(ASFWDriver, Start) {
     auto kr = Start(provider, SUPERDISPATCH);
     if (kr != kIOReturnSuccess)
@@ -381,6 +448,7 @@ kern_return_t ASFWDriver::StartRuntime(IOService* provider) {
         if (nubKr != kIOReturnSuccess || sbp2NubService == nullptr) {
             ASFW_LOG(Controller, "[SCSIHBA] Failed to create ASFWSBP2Nub: 0x%08x", nubKr);
         } else {
+            PublishNubMapperID(provider, sbp2NubService);
             // IOKit retains the nub as our child; the nub's Start() calls RegisterService().
             sbp2NubService->release();
         }

--- a/ASFWDriver/ASFWDriver.cpp
+++ b/ASFWDriver/ASFWDriver.cpp
@@ -209,71 +209,85 @@ void ASFWDriver::free() {
     super::free();
 }
 
-// Give the SBP-2 nub a DMA mapper the SCSI HBA's kernel shim can resolve.
+// SBP-2 nub publication and its DMA-mapper precondition.
 //
-// The shim prepares an IODMACommand for every data-carrying task before calling
-// into the dext and requires ONE IOVM segment spanning the whole transfer. Its
-// mapper comes from IOMapper::copyMapperForDeviceWithIndex(getProvider(), 0),
-// which is a plain copyProperty("iommu-parent") on the nub (xnu
-// IOMapper.cpp:174-207). With no mapper there is no IOVA remapping, so only a
-// transfer that fits one physically contiguous page yields a single segment and
-// everything larger is failed in the kernel before UserProcessParallelTask runs
-// — HW-confirmed 2026-08-04: 519 KB reads died pre-dext until the nub carried
-// this property. An OSData value is matched against the IOMapperID each
-// IODARTMapper publishes; the HBA never dereferences the resulting address (all
-// payload moves by memcpy via UserGetDataBuffer), so the mapping only has to
-// exist. A board-specific fallback lives in ASFWSBP2NubProperties.
-static void PublishNubMapperID(IOService* provider, IOService* nub) {
-    if (provider == nullptr || nub == nullptr) {
+// The SCSI kernel shim prepares an IODMACommand for every data-carrying task
+// before calling into the dext and requires ONE IOVM segment spanning the whole
+// transfer. Its mapper comes from IOMapper::copyMapperForDeviceWithIndex(
+// getProvider(), 0), which is a plain copyProperty("iommu-parent") on the nub
+// (xnu IOMapper.cpp:174-207). With no mapper there is no IOVA remapping, so
+// only a transfer that fits one physically contiguous page yields a single
+// segment and everything larger is failed in the kernel before
+// UserProcessParallelTask runs — HW-confirmed 2026-08-04: 519 KB reads died
+// pre-dext until the nub carried this property. An OSData value is matched
+// against the IOMapperID each IODARTMapper publishes; the HBA never
+// dereferences the resulting address (all payload moves by memcpy via
+// UserGetDataBuffer), so the mapping only has to exist — but a value with NO
+// matching IOMapperID hangs the shim's mapper wait, so guessing is not safe.
+//
+// The value is board/port-specific and unreadable from the dext (the live
+// IODARTMapper object does not serialize across the DriverKit boundary; every
+// SearchProperty path fails — HW-proven). The app looks it up and hands it down
+// via ProvisionSBP2MapperID; on Apple Silicon the nub is only published once
+// the value is staged on this service as kSBP2MapperIDStagingKey, which the
+// nub's Start() copies onto itself as iommu-parent BEFORE RegisterService().
+// Intel needs none of this (VT-d supplies a system mapper), and a developer can
+// still short-circuit via an iommu-parent entry in ASFWSBP2NubProperties.
+static constexpr const char* kSBP2MapperIDStagingKey = "ASFWSBP2MapperID";
+
+static bool PlistNubPropertiesCarryMapper(IOService* driver) {
+    OSDictionary* raw = nullptr;
+    if (driver->CopyProperties(&raw) != kIOReturnSuccess || raw == nullptr) {
+        return false;
+    }
+    auto props = OSSharedPtr(raw, OSNoRetain);
+    auto* nubProps = OSDynamicCast(OSDictionary, props->getObject("ASFWSBP2NubProperties"));
+    return nubProps != nullptr && nubProps->getObject("iommu-parent") != nullptr;
+}
+
+static void PublishSBP2Nub(ASFWDriver* driver) {
+    IOService* nub = nullptr;
+    const kern_return_t kr = driver->Create(driver, "ASFWSBP2NubProperties", &nub);
+    if (kr != kIOReturnSuccess || nub == nullptr) {
+        ASFW_LOG(Controller, "[SCSIHBA] Failed to create ASFWSBP2Nub: 0x%08x", kr);
         return;
     }
+    // IOKit retains the nub as our child; its Start() adopts any staged mapper
+    // id and calls RegisterService().
+    nub->release();
+}
 
-    static constexpr struct {
-        const char* key;
-        const char* plane;
-    } kProbes[] = {
-        {"iommu-parent", "IOService"},
-        {"iommu-parent", "IODeviceTree"},
-        {"iommu-id", "IODeviceTree"},
-    };
-
-    OSData* discovered = nullptr;
-    for (const auto& probe : kProbes) {
-        OSContainer* raw = nullptr;
-        const kern_return_t kr = provider->SearchProperty(
-            probe.key, probe.plane, kIOServiceSearchPropertyParents, &raw);
-        auto value = OSSharedPtr(raw, OSNoRetain);
-        auto* data = OSDynamicCast(OSData, value.get());
-        uint32_t id = 0;
-        if (data != nullptr && data->getLength() >= sizeof(uint32_t)) {
-            const auto* bytes = static_cast<const uint8_t*>(data->getBytesNoCopy());
-            id = static_cast<uint32_t>(bytes[0]) | (static_cast<uint32_t>(bytes[1]) << 8) |
-                 (static_cast<uint32_t>(bytes[2]) << 16) | (static_cast<uint32_t>(bytes[3]) << 24);
-            if (discovered == nullptr) {
-                discovered = data;
-                discovered->retain();
-            }
-        }
-        ASFW_LOG(Controller,
-                 "[MapperDiag] SearchProperty(%{public}s, %{public}s) kr=0x%08x present=%u "
-                 "isData=%u len=%u id=0x%08x",
-                 probe.key, probe.plane, kr, value ? 1u : 0u, data != nullptr ? 1u : 0u,
-                 data != nullptr ? static_cast<unsigned>(data->getLength()) : 0u, id);
+kern_return_t ASFWDriver::ProvisionSBP2MapperID(uint32_t mapperID) {
+    if (!ivars || mapperID == 0) {
+        return kIOReturnBadArgument;
+    }
+    std::atomic_ref<bool> claimed(ivars->sbp2NubClaimed);
+    if (claimed.exchange(true)) {
+        ASFW_LOG(Controller, "[SCSIHBA] mapper id 0x%08x ignored — SBP-2 nub already published",
+                 mapperID);
+        return kIOReturnSuccess;
     }
 
-    if (discovered == nullptr) {
-        ASFW_LOG(Controller, "[MapperDiag] no mapper id discovered — keeping plist fallback");
-        return;
+    const uint8_t le[4] = {static_cast<uint8_t>(mapperID), static_cast<uint8_t>(mapperID >> 8),
+                           static_cast<uint8_t>(mapperID >> 16),
+                           static_cast<uint8_t>(mapperID >> 24)};
+    auto data = OSSharedPtr(OSData::withBytes(le, sizeof(le)), OSNoRetain);
+    auto dict = OSSharedPtr(OSDictionary::withCapacity(1), OSNoRetain);
+    if (!data || !dict || !dict->setObject(kSBP2MapperIDStagingKey, data.get())) {
+        claimed.store(false);
+        return kIOReturnNoMemory;
+    }
+    const kern_return_t kr = SetProperties(dict.get());
+    if (kr != kIOReturnSuccess) {
+        claimed.store(false);
+        ASFW_LOG(Controller, "[SCSIHBA] failed to stage mapper id 0x%08x: 0x%08x", mapperID, kr);
+        return kr;
     }
 
-    OSDictionary* rawProps = nullptr;
-    if (nub->CopyProperties(&rawProps) == kIOReturnSuccess && rawProps != nullptr) {
-        auto props = OSSharedPtr(rawProps, OSNoRetain);
-        props->setObject("iommu-parent", discovered);
-        const kern_return_t kr = nub->SetProperties(props.get());
-        ASFW_LOG(Controller, "[MapperDiag] applied discovered mapper id to nub: kr=0x%08x", kr);
-    }
-    discovered->release();
+    ASFW_LOG(Controller, "[SCSIHBA] mapper id 0x%08x provisioned — publishing SBP-2 nub",
+             mapperID);
+    PublishSBP2Nub(this);
+    return kIOReturnSuccess;
 }
 
 kern_return_t IMPL(ASFWDriver, Start) {
@@ -443,14 +457,22 @@ kern_return_t ASFWDriver::StartRuntime(IOService* provider) {
         // provably alive — a dead-dext boot-time match stranded the registry busy
         // count and panicked (issue #54). A future per-unit nub will additionally
         // carry login/unit identity.
-        IOService* sbp2NubService = nullptr;
-        kern_return_t nubKr = Create(this, "ASFWSBP2NubProperties", &sbp2NubService);
-        if (nubKr != kIOReturnSuccess || sbp2NubService == nullptr) {
-            ASFW_LOG(Controller, "[SCSIHBA] Failed to create ASFWSBP2Nub: 0x%08x", nubKr);
-        } else {
-            PublishNubMapperID(provider, sbp2NubService);
-            // IOKit retains the nub as our child; the nub's Start() calls RegisterService().
-            sbp2NubService->release();
+        bool publishNow = true;
+#if defined(__arm64__)
+        // Apple Silicon: without a DART mapper id on the nub every transfer
+        // crossing a page run fails in-kernel, and a wrong id hangs the shim —
+        // wait for the app to provision one (ProvisionSBP2MapperID) unless the
+        // plist carries a developer override. See the comment block above
+        // PublishSBP2Nub().
+        publishNow = PlistNubPropertiesCarryMapper(this);
+        if (!publishNow) {
+            ASFW_LOG(Controller,
+                     "[SCSIHBA] SBP-2 nub deferred until the app provisions a DART mapper id");
+        }
+#endif
+        if (publishNow) {
+            ivars->sbp2NubClaimed = true;
+            PublishSBP2Nub(this);
         }
 
         RegisterService();

--- a/ASFWDriver/ASFWDriver.cpp
+++ b/ASFWDriver/ASFWDriver.cpp
@@ -370,10 +370,12 @@ kern_return_t ASFWDriver::StartRuntime(IOService* provider) {
     // Publish once per instance: StartRuntime() is re-entered on wake, and the
     // SBP-2 nub and RegisterService() must not repeat across sleep/wake cycles.
     if (!ivars->serviceRegistered) {
-        // Publish the SBP-2 nub. The SCSI HBA currently co-matches the PCI device
-        // directly (see Info.plist ASFWSCSIControllerService), so nothing matches on
-        // this nub yet — it is staged for a future per-unit personality carrying
-        // login/unit identity, and kept published now to reserve the discovery seam.
+        // Publish the SBP-2 nub. The SCSI HBA personality (Info.plist
+        // ASFWSCSIControllerService, --scsi builds) matches this nub instead of the
+        // PCI device, so its kernel stub can only instantiate once the dext is
+        // provably alive — a dead-dext boot-time match stranded the registry busy
+        // count and panicked (issue #54). A future per-unit nub will additionally
+        // carry login/unit identity.
         IOService* sbp2NubService = nullptr;
         kern_return_t nubKr = Create(this, "ASFWSBP2NubProperties", &sbp2NubService);
         if (nubKr != kIOReturnSuccess || sbp2NubService == nullptr) {

--- a/ASFWDriver/ASFWDriver.iig
+++ b/ASFWDriver/ASFWDriver.iig
@@ -111,6 +111,12 @@ public:
     kern_return_t StartAudioStreaming(uint64_t guid) LOCALONLY;
     kern_return_t StopAudioStreaming(uint64_t guid) LOCALONLY;
 
+    // App-provisioned DART mapper id for the SBP-2 nub (Apple Silicon). The
+    // SCSI kernel shim resolves its DMA mapper from iommu-parent on the HBA's
+    // provider node; the value is only readable from user space, so the app
+    // looks it up and the nub is published on receipt (see ASFWDriver.cpp).
+    kern_return_t ProvisionSBP2MapperID(uint32_t mapperID) LOCALONLY;
+
     // Isochronous Receive Control
     kern_return_t StartIsochReceive(uint8_t channel, uint32_t wireFormatRaw, uint32_t am824Slots) LOCALONLY;
     kern_return_t StopIsochReceive() LOCALONLY;
@@ -134,6 +140,7 @@ struct ASFWDriver_IVars {
     IOService* powerProvider;   // borrowed from Start; cleared in Stop
     bool runtimeSuspended;      // true between sleep quiesce and wake rebuild
     bool serviceRegistered;     // RegisterService() must run once per instance
+    bool sbp2NubClaimed;        // SBP-2 nub publication claimed (atomically, once)
 
     // Wake-verify timer. Lives on the default queue (stable for the service
     // lifetime, unlike per-rebuild runtime state); released in Stop, which also

--- a/ASFWDriver/Info.plist
+++ b/ASFWDriver/Info.plist
@@ -79,6 +79,8 @@
 				<string>IOUserService</string>
 				<key>IOUserClass</key>
 				<string>ASFWSBP2Nub</string>
+				<key>iommu-parent</key>
+				<data>VwAAAA==</data>
 			</dict>
 			<key>ASFWTraceDMACoherency</key>
 			<false/>

--- a/ASFWDriver/Info.plist
+++ b/ASFWDriver/Info.plist
@@ -79,8 +79,6 @@
 				<string>IOUserService</string>
 				<key>IOUserClass</key>
 				<string>ASFWSBP2Nub</string>
-				<key>iommu-parent</key>
-				<data>VwAAAA==</data>
 			</dict>
 			<key>ASFWTraceDMACoherency</key>
 			<false/>

--- a/ASFWDriver/Info.plist
+++ b/ASFWDriver/Info.plist
@@ -110,14 +110,13 @@
 			<string>com.apple.iokit.IOSCSIParallelFamily</string>
 			<key>IOClass</key>
 			<string>IOUserSCSIParallelInterfaceController</string>
-			<key>IOMatchCategory</key>
-			<string>ASFWSCSIController</string>
-			<key>IOPCIMatch</key>
-			<string>0x590111c1</string>
-			<key>IOPCITunnelCompatible</key>
-			<true/>
+			<key>IOPropertyMatch</key>
+			<dict>
+				<key>ASFWNubType</key>
+				<string>SBP2</string>
+			</dict>
 			<key>IOProviderClass</key>
-			<string>IOPCIDevice</string>
+			<string>IOUserService</string>
 			<key>IOUserClass</key>
 			<string>ASFWSCSIController</string>
 			<key>IOUserServerName</key>

--- a/ASFWDriver/SCSIController/ASFWSBP2Nub.cpp
+++ b/ASFWDriver/SCSIController/ASFWSBP2Nub.cpp
@@ -9,6 +9,9 @@
 
 #include <DriverKit/DriverKit.h>
 #include <DriverKit/IOLib.h>
+#include <DriverKit/OSData.h>
+#include <DriverKit/OSDictionary.h>
+#include <DriverKit/OSSharedPtr.h>
 
 #include "../Logging/Logging.hpp"
 
@@ -18,6 +21,27 @@ kern_return_t IMPL(ASFWSBP2Nub, Start)
     if (ret != kIOReturnSuccess) {
         return ret;
     }
+
+    // Adopt the app-provisioned DART mapper id staged on the parent driver as
+    // iommu-parent BEFORE registering: the SCSI kernel shim resolves its DMA
+    // mapper from this nub the moment the HBA personality matches, so the
+    // property must be in place first (see PublishSBP2Nub in ASFWDriver.cpp).
+    // Absent on Intel and when the plist dict already carries iommu-parent.
+    OSContainer* rawStaged = nullptr;
+    if (SearchProperty("ASFWSBP2MapperID", "IOService", kIOServiceSearchPropertyParents,
+                       &rawStaged) == kIOReturnSuccess) {
+        auto staged = OSSharedPtr(rawStaged, OSNoRetain);
+        if (auto* data = OSDynamicCast(OSData, staged.get()); data != nullptr) {
+            OSDictionary* rawProps = nullptr;
+            if (CopyProperties(&rawProps) == kIOReturnSuccess && rawProps != nullptr) {
+                auto props = OSSharedPtr(rawProps, OSNoRetain);
+                props->setObject("iommu-parent", data);
+                const kern_return_t pkr = SetProperties(props.get());
+                ASFW_LOG(Controller, "[SCSIHBA] nub adopted staged mapper id: 0x%08x", pkr);
+            }
+        }
+    }
+
     ASFW_LOG(Controller, "[SCSIHBA] ASFWSBP2Nub::Start — registering (phase-0)");
     ret = RegisterService();
     if (ret != kIOReturnSuccess) {

--- a/ASFWDriver/SCSIController/ASFWSCSIController.iig
+++ b/ASFWDriver/SCSIController/ASFWSCSIController.iig
@@ -27,11 +27,14 @@
 // device's real identity; in the suspended window (bus reset) commands answer
 // BUSY — nothing is ever held without a deadline.
 //
-// Matching: this HBA co-matches the OHCI PCI device directly (IOProviderClass
-// IOPCIDevice + IOPCIMatch, distinct IOMatchCategory), alongside the main
-// ASFWDriver. ASFWDriver also publishes an ASFWSBP2Nub, but nothing matches on
-// it yet — it is staged for a future per-unit personality, not the current
-// match path.
+// Matching: this HBA matches the ASFWSBP2Nub that ASFWDriver publishes after a
+// successful Start (IOProviderClass IOUserService + IOPropertyMatch
+// ASFWNubType=SBP2), never the PCI device. The nub only exists once the dext
+// process is alive, so the kernel-side IOUserSCSIParallelInterfaceController
+// stub can never be instantiated against a dead dext — a boot-time PCI match
+// with the dext killed at launch (e.g. AMFI) left the stub stranded holding
+// the registry busy count until watchdogd's 60 s panic (issue #54). A launch
+// failure now degrades to silent no-load, like the audio personalities.
 //
 
 #ifndef ASFWSCSIController_h

--- a/ASFWDriver/SCSIController/SBP2TargetBridge.cpp
+++ b/ASFWDriver/SCSIController/SBP2TargetBridge.cpp
@@ -110,6 +110,7 @@ void SBP2TargetBridge::Start() {
 
 void SBP2TargetBridge::Shutdown() {
     uint64_t handle = 0;
+    uint64_t guid = 0;
     std::deque<PendingTask> drained;
     {
         IOLockGuard g(lock_);
@@ -118,7 +119,9 @@ void SBP2TargetBridge::Shutdown() {
         }
         stopping_ = true;
         handle = sessionHandle_;
+        guid = sessionGuid_;
         sessionHandle_ = 0;
+        sessionGuid_ = 0;
         drained.swap(pending_);
     }
 
@@ -155,6 +158,19 @@ void SBP2TargetBridge::Shutdown() {
     }
     if (!drained.empty()) {
         ASFW_LOG(Controller, "[SBP2Bridge] shutdown drained %zu queued tasks", drained.size());
+    }
+
+    // Bridge teardown is a terminal down-edge for the HBA. The observer was
+    // detached above before ReleaseOwner, so the registry's own logout edge
+    // never reaches the hub — emit it here instead. Without this the kernel
+    // target survives runtime teardown (sleep quiesce), and a task queued
+    // behind the SAM LUN's device-sleep wedges target 0 until something
+    // destroys it (HW 2026-08-04: hang after wake, stuck SCSITaskUserClient).
+    // Destroying before sleep means wake's login-up edge rebuilds a fresh
+    // target with no LUN state to wedge. Redundant edges are safe: the HBA's
+    // down leg is a no-op when no target is attached.
+    if (handle != 0) {
+        SBP2BridgeHub::NotifyTargetState(guid, false);
     }
 }
 
@@ -268,6 +284,7 @@ void SBP2TargetBridge::OnUnitPublished(const std::shared_ptr<Discovery::FWUnit>&
             return;
         }
         sessionHandle_ = *handle;
+        sessionGuid_ = guid;
     }
     ASFW_LOG(Controller, "[SBP2Bridge] session %llu created for guid=0x%016llx — logging in",
              *handle, guid);

--- a/ASFWDriver/SCSIController/SBP2TargetBridge.hpp
+++ b/ASFWDriver/SCSIController/SBP2TargetBridge.hpp
@@ -111,6 +111,7 @@ private:
     bool pumpScheduled_{false};
     bool stopping_{false};
     uint64_t sessionHandle_{0};
+    uint64_t sessionGuid_{0};
 
     Discovery::IUnitRegistry::CallbackHandle unitCallbackHandle_{0};
     bool unitCallbackRegistered_{false};

--- a/ASFWDriver/UserClient/Core/ASFWDriverUserClient.cpp
+++ b/ASFWDriver/UserClient/Core/ASFWDriverUserClient.cpp
@@ -73,6 +73,7 @@ enum {
     kMethodRequestUserBusReset = 61,
     kMethodStartAudioStreaming = 62,
     kMethodStopAudioStreaming = 63,
+    kMethodProvisionSBP2MapperID = 64,
     // TODO(ASFW-IRM): Remove temporary IRM test method after dedicated validation tooling exists.
     kMethodTestIRMAllocation = 26,
     kMethodTestIRMRelease = 27,
@@ -339,6 +340,14 @@ MethodDispatchResult DispatchDriverControlMethods(ASFWDriver& driver,
         return MethodDispatchResult{selector == kMethodStartAudioStreaming
                                         ? driver.StartAudioStreaming(*guid)
                                         : driver.StopAudioStreaming(*guid)};
+    }
+    case kMethodProvisionSBP2MapperID: {
+        const auto mapperID = GetFirstScalarInput(arguments);
+        if (!mapperID.has_value() || *mapperID == 0 || *mapperID > UINT32_MAX) {
+            return MethodDispatchResult{kIOReturnBadArgument};
+        }
+        return MethodDispatchResult{
+            driver.ProvisionSBP2MapperID(static_cast<uint32_t>(*mapperID))};
     }
     case kMethodGetAudioAutoStart:
         return HandleGetAudioAutoStart(driver, arguments);

--- a/ASFWDriver/UserClient/Core/ASFWDriverUserClient.iig
+++ b/ASFWDriver/UserClient/Core/ASFWDriverUserClient.iig
@@ -74,6 +74,8 @@ public:
         // Developer-only complete audio lifecycle control, GUID scalar input.
         kMethodStartAudioStreaming     = 62,
         kMethodStopAudioStreaming      = 63,
+        // App-provisioned DART mapper id (uint32 scalar) for the SBP-2 nub.
+        kMethodProvisionSBP2MapperID   = 64,
         // TODO(ASFW-IRM): Remove temporary IRM test method after dedicated validation tooling exists.
         kMethodTestIRMAllocation       = 26,
         kMethodTestIRMRelease          = 27,

--- a/ASFWTests/DARTCandidateSelectionTests.swift
+++ b/ASFWTests/DARTCandidateSelectionTests.swift
@@ -3,10 +3,10 @@ import XCTest
 
 final class DARTCandidateSelectionTests: XCTestCase {
     private let candidates: [(name: String, id: UInt32)] = [
-        ("dart-apciec1-piodma", 0x61),
-        ("dart-apciec0", 0x55),
-        ("dart-apciec0-piodma", 0x57),
-        ("dart-disp0", 0x41),
+        ("mapper-apciec1-piodma", 0x61),
+        ("mapper-apciec0-3-0-0", 0x55),
+        ("mapper-apciec0-piodma", 0x57),
+        ("mapper-disp0-piodma", 0x41),
     ]
 
     func testPrefersExactPiodmaMatchForComplex() {
@@ -16,7 +16,7 @@ final class DARTCandidateSelectionTests: XCTestCase {
     }
 
     func testFallsBackToSameComplexPrefix() {
-        let withoutExact = candidates.filter { $0.name != "dart-apciec0-piodma" }
+        let withoutExact = candidates.filter { $0.name != "mapper-apciec0-piodma" }
         XCTAssertEqual(
             ASFWDriverConnector.selectDARTCandidate(complex: "apciec0", candidates: withoutExact),
             0x55)

--- a/ASFWTests/DARTCandidateSelectionTests.swift
+++ b/ASFWTests/DARTCandidateSelectionTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import ASFW
+
+final class DARTCandidateSelectionTests: XCTestCase {
+    private let candidates: [(name: String, id: UInt32)] = [
+        ("dart-apciec1-piodma", 0x61),
+        ("dart-apciec0", 0x55),
+        ("dart-apciec0-piodma", 0x57),
+        ("dart-disp0", 0x41),
+    ]
+
+    func testPrefersExactPiodmaMatchForComplex() {
+        XCTAssertEqual(
+            ASFWDriverConnector.selectDARTCandidate(complex: "apciec0", candidates: candidates),
+            0x57)
+    }
+
+    func testFallsBackToSameComplexPrefix() {
+        let withoutExact = candidates.filter { $0.name != "dart-apciec0-piodma" }
+        XCTAssertEqual(
+            ASFWDriverConnector.selectDARTCandidate(complex: "apciec0", candidates: withoutExact),
+            0x55)
+    }
+
+    func testFallsBackToAnyDARTWhenComplexUnknown() {
+        XCTAssertEqual(
+            ASFWDriverConnector.selectDARTCandidate(complex: nil, candidates: candidates),
+            0x61)
+    }
+
+    func testComplexPrefixDoesNotCrossNumberBoundary() {
+        // apciec1 must not match dart-apciec10-* style names by accident;
+        // exact piodma tier guards it.
+        XCTAssertEqual(
+            ASFWDriverConnector.selectDARTCandidate(complex: "apciec1", candidates: candidates),
+            0x61)
+    }
+
+    func testEmptyCandidatesYieldNil() {
+        XCTAssertNil(ASFWDriverConnector.selectDARTCandidate(complex: "apciec0", candidates: []))
+    }
+}


### PR DESCRIPTION
## What

Three commits that remove the *reason* the SCSI HBA is build-gated behind `--scsi`:

1. **`0d700f4`** — the HBA personality matches the already-published `ASFWSBP2Nub` instead of `IOPCIDevice`. A failed dext launch (e.g. AMFI) becomes a silent no-load instead of the #54 boot panic — the panic is impossible by construction.
2. **`7258268`** — publish `iommu-parent` (a DART mapper id) on the nub. Without it the kernel SCSI shim has no DMA mapper and fails every transfer larger than one contiguous page before the dext ever sees the task. The value ships in Info.plist and is machine-specific — see the open question.
3. **`d8fd558`** — emit the logout edge from `SBP2TargetBridge::Shutdown()` so target 0 is destroyed before system sleep. Fixes an unrecoverable post-wake LUN wedge; the wake login rebuilds the target fresh.

## HW validation

Full matrix green on M1 Pro / Tahoe / Nikon LS-9000 via TB→FW dock: large transfers (3× 519 KB READs, VueScan image), the #54 window, sleep/wake ×2, unplug + teardown under load, power-cycle re-login, and a port-swap.

<details><summary>Full matrix</summary>

- Match/launch on nub: `DK: using existing server … from provider ASFWSBP2Nub` — full HBA start, readiness gate, target create with real INQUIRY identity
- Large transfers: 3× 519 640 B READs full payload, 4× 32 KB SEND — VueScan preview produced an image (fails 100 % without the mapper property)
- Reboot with adapter present, scanner off: no panic, clean HBA start against the nub (the #54 window)
- Sleep/wake ×2: `target 0 destroyed` at quiesce → re-login → `target 0 created` after wake; no kernel-side accumulation (1 target, 1 user client after both cycles)
- Adapter unplug under worst case (wedged target + stale client + queued task, pre-fix build): clean cascade teardown ~1 ms, clean rebuild on re-plug
- Teardown under load: in-flight 508 944 B READ aborted cleanly, BUSY on retries, destroy → re-login → re-create → next scan ran
- Power-cycle re-login: no 5/26 regression (the #61 root-cause fix holds on this build)

**Known behavior:** a SCSITaskLib client running across a sleep (VueScan) hangs — its user client points at the destroyed target — and must be restarted after wake; the restarted app finds the device immediately. This is the deterministic, recoverable replacement for the previous unrecoverable LUN wedge.

**Port-swap result: the published DART mapper id is port-independent.** This settles the main open question for the plist path.

Test (MacBook Pro 16" M1, J316, 3 TB ports):

1. Reinstalled the plist variant (`iommu-parent = <57000000>` = `mapper-apciec0-piodma`, baked into `ASFWSBP2NubProperties`) + reboot. Nub published at boot with the property from birth — no app involvement. Baseline VueScan scan on the original port (card under `apciec0`): ✅
2. Moved the adapter to a different TB port, plist untouched. Card re-enumerated under **`apciec1`** (verified in ioreg), nub/HBA rebuilt cleanly, nub still carries the *apciec0* mapper id. Full VueScan preview incl. the ~519 KB READs: ✅

So the shim only needs *a* valid published system mapper to satisfy its DMA-prep path; the actual DMA runs through the PCI device's own mapper regardless of which id the nub advertises. The value is not port-bound.

Consequence for the portable-provisioning question: the "app patches the plist + re-sign + re-install" path (a) is now a **one-time per-machine calibration** at install time (which requires a reboot anyway) — moving the adapter between ports afterwards costs nothing. That removes the reboot-per-port objection. Runtime provisioning into the birth dict remains impossible on current xnu (see the `originalProperties` snapshot analysis above), so (a) looks like the pragmatic default while the DTS question / split-dext design is pending.
</details>

## The open question (why draft)

The mapper id only works from the nub's **birth** properties, and xnu snapshots those from the signed Info.plist when the driver attaches — so runtime provisioning is impossible (HW-falsified twice, root cause in xnu source). The plist value is port-independent (HW-proven), but machine-specific ⇒ per-machine re-signing at install ⇒ incompatible with Developer ID distribution.

<details><summary>Root cause + falsification evidence (xnu source refs)</summary>

**Update: app-assisted runtime provisioning is falsified — root cause found in the xnu source. The mapper id must be present in the dext's Info.plist; no runtime mechanism can deliver it.**

## What was tested (HW, reboot-verified)

Two variants of delivering the app-resolved mapper id to the SBP-2 nub, both on the deferred-publish build (nub only created after the app provisions via the new user-client selector):

1. **Adopt-in-Start:** nub's `Start()` copies the staged id onto itself via `SetProperties` before `RegisterService()`. Property verifiably lands top-level on the nub (`ioreg -d1`), synchronously, *before* the kernel stub is even matched. → **Large I/O still fails** (32 KB SEND / 519 KB READ → instant failure, nothing reaches the dext; threshold between 91 B and 32 KB = the no-mapper single-segment signature). Kernel log completely silent — no DART/prepare errors, i.e. the shim's silent no-mapper cold path.
2. **Bake-before-Create:** `ProvisionSBP2MapperID` patches `iommu-parent` into the `ASFWSBP2NubProperties` dictionary on the driver's own registry entry (verified present in ioreg) *before* calling `Create()`. → **Identical failure.**

Meanwhile the plist variant (value in `ASFWSBP2NubProperties` in Info.plist) remains the only configuration that has ever passed large I/O on the nub provider (519 640 B READs, image in VueScan — verified twice across reboots).

## Root cause (xnu, `iokit/Kernel/IOUserServer.cpp` @ main)

1. **`Create()` never reads the live property table.** `IOService::Create_Impl` fetches the properties dict from `reserved->uvars->originalProperties` — a snapshot taken in `IOUserServer::serviceAttach` (`dictionaryWithProperties()`) when the *driver* service attached at boot. A later `SetProperties` updates the live table (which is what ioreg shows) but never that snapshot. So a runtime-computed property can never enter a `Create()` birth dict — the snapshot chain always bottoms out in Info.plist content, at any nesting depth.
2. **The SCSI shim does not do a live `copyProperty` either.** In variant 1 the property was top-level on the nub before the stub matched (SetProperties_Impl applies synchronously inside the RPC; ring log proves the ordering), and the shim still ran mapperless. The consistent explanation is that the shim consumes the nub's *birth state* (its own `originalProperties` snapshot, taken during `serviceAttach` inside `Create_Impl`, i.e. before the nub's dext-side `Start()` ever runs). This matches all four data points: plist-at-birth works (×2), adopt-in-Start fails, bake-before-Create fails.

`IOMapper::copyMapperForDeviceWithIndex` itself (`iokit/Kernel/IOMapper.cpp`) is a plain `copyProperty("iommu-parent")` + `waitForMatchingService(IOMapperID)` — the caching/snapshotting is on the caller's side.

## Where this leaves the open question from the PR body

- The **mechanism** stands: `iommu-parent` (OSData `IOMapperID` of any published DART) on the nub satisfies the shim's DMA prep — but only when present in the nub's **birth dict**, which on current xnu means **present in Info.plist when the driver attaches**.
- **Portable delivery options:**
  - **(a) App-patches-the-plist:** the app already resolves the correct id portably (class `IODARTMapper`, named by its `IODARTMapperNub` parent `mapper-apciecN-piodma`; tiered fallback; committed with tests). Install flow: resolve → write into the dext copy's Info.plist → re-sign → install → reboot. Uses only the HW-proven mechanism; cost is one reboot when the adapter moves to a different Thunderbolt port. My candidate for the ad-hoc distribution tier.
  - **(b) DTS:** the question sharpens considerably with source line numbers — "what is the sanctioned way for an `IOUserService`-provided `IOUserSCSIParallelInterfaceController` to obtain a DMA mapper on Apple Silicon, given `Create_Impl`'s `originalProperties` snapshot?"
  - **(c)** (speculative, unverified) runtime `IOCatalogueSendData` of a patched driver personality + re-match — avoids the reboot but is AMFI-exposed.

The provisioning selector and deferred publish stay useful for (a)'s UX (the app knows whether the installed plist id matches the current port and can prompt for reinstall), but I've dropped the ineffective bake from the branch. The app-side resolution fix is committed.
</details>

**Direction needed — your call:**

1. **Split-dext** — does your HBA/ConfigROM split address this? Any dext-published nub hits the same birth-properties wall; it only helps if the HBA dext matches something with real PCI ancestry, which reopens the #54 gating question.
2. **DTS incident** — ask for the sanctioned way for an `IOUserService`-provided HBA to get a DMA mapper on Apple Silicon. We can draft it.
3. **Stay on PCI-match** (main's model, mapper for free) and keep #54 solved by gating alone.

Secondary, once direction is settled: default-on / removing the `--scsi` gate (no new regression path — under AMFI the whole dext dies silently either way), and Intel (VT-d publishes a system mapper; property likely unnecessary, untested).
