### PR TITLE
fix(async): watchdog never starts, so transaction timeouts never fire

### DIFF
--- a/ASFWDriver/ASFWDriver.cpp
+++ b/ASFWDriver/ASFWDriver.cpp
@@ -930,7 +930,15 @@ void ASFWDriver::ScheduleAsyncWatchdog(uint64_t delayUsec) {
         return;
     }
     auto& ctx = *ivars->context;
-    if (!ctx.lifecycle || !ctx.lifecycle->AdmitsNormalWork()) {
+    // Gate on the alive states (kStarting/kRunning), NOT AdmitsNormalWork():
+    // the initial arm in StartRuntime happens before CompleteStart() flips the
+    // state to kRunning, so a kRunning-only gate silently no-ops it and the
+    // self-rearming tick chain never starts — no AT transaction timeout can
+    // ever fire (0.3.0 regression, 22c82112; observed as an unrecoverable
+    // SBP-2 wedge when a target stopped responding). Teardown still kills the
+    // chain authoritatively via watchdog.Stop()/Reset() (timer disable), and
+    // every return to kRunning re-enters StartRuntime, which re-arms.
+    if (!ctx.lifecycle || !ctx.lifecycle->AdmitsBringupInterrupts()) {
         return;
     }
     ctx.watchdog.Schedule(delayUsec);
@@ -942,12 +950,15 @@ void ASFWDriver::AsyncWatchdogTimerFired_Impl(ASFWDriver_AsyncWatchdogTimerFired
 
     if (ivars && ivars->context) {
         auto& ctx = *ivars->context;
-        if (!ctx.lifecycle || !ctx.lifecycle->AdmitsNormalWork()) {
-            return;
+        // Skip only the WORK when normal work is inadmissible — never the
+        // reschedule below. An early return here breaks the self-rearming
+        // chain permanently on a transient non-running state; the chain's
+        // real kill switch is the timer disable in watchdog.Stop()/Reset().
+        if (ctx.lifecycle && ctx.lifecycle->AdmitsNormalWork()) {
+            ctx.watchdog.HandleTick(ctx.controller.get(), ctx.deps.asyncController.get(),
+                                    ctx.isoch.ReceiveContext(), ctx.isoch.TransmitContext(),
+                                    ctx.statusPublisher);
         }
-        ctx.watchdog.HandleTick(ctx.controller.get(), ctx.deps.asyncController.get(),
-                                ctx.isoch.ReceiveContext(), ctx.isoch.TransmitContext(),
-                                ctx.statusPublisher);
     }
 
     ScheduleAsyncWatchdog(kAsyncWatchdogPeriodUsec);

--- a/ASFWDriver/Protocols/SBP2/SBP2ManagementORB.cpp
+++ b/ASFWDriver/Protocols/SBP2/SBP2ManagementORB.cpp
@@ -150,6 +150,24 @@ bool SBP2ManagementORB::Execute() noexcept {
 
     inProgress_.store(true, std::memory_order_relaxed);
 
+    // Arm the timeout BEFORE the write goes out so it covers the whole
+    // exchange (agent write + status block), not just the wait for status.
+    // Previously armed in OnWriteComplete: a write whose completion never
+    // arrived (wedged target — observed on LS-4000, LUN reset after ORB
+    // timeout) left the management ORB pending forever with no timer running.
+    if (scheduler_ != nullptr && timeoutMs_ > 0) {
+        const std::weak_ptr<int> weakLifetime = lifetimeToken_;
+        const uint64_t delayNs = static_cast<uint64_t>(timeoutMs_) * 1'000'000ULL;
+
+        timeoutToken_ = scheduler_->ScheduleAfter(delayNs, [this, weakLifetime]() {
+            if (weakLifetime.expired()) {
+                return;
+            }
+            timeoutToken_ = kInvalidSchedulerToken;
+            OnTimeout();
+        });
+    }
+
     // Write ORB address to management agent
     const FW::Generation gen{generation_};
     const FW::NodeId node{static_cast<uint8_t>(nodeID_ & 0x3Fu)};
@@ -172,6 +190,10 @@ bool SBP2ManagementORB::Execute() noexcept {
 
     if (!writeHandle_) {
         ASFW_LOG(Async, "SBP2ManagementORB::Execute: WriteBlock failed");
+        if (scheduler_ != nullptr && timeoutToken_ != kInvalidSchedulerToken) {
+            scheduler_->Cancel(timeoutToken_);
+            timeoutToken_ = kInvalidSchedulerToken;
+        }
         inProgress_.store(false, std::memory_order_relaxed);
         return false;
     }
@@ -193,22 +215,10 @@ void SBP2ManagementORB::OnWriteComplete(Async::AsyncStatus status,
         return;
     }
 
-    // Management agent write ACK'd. Start timeout, wait for status block.
+    // Management agent write ACK'd; the timeout armed in Execute() keeps
+    // running until the status block arrives.
     ASFW_LOG(Async, "SBP2ManagementORB: mgmt agent ACK'd, waiting for status block (timeout=%ums)",
              timeoutMs_);
-
-    if (scheduler_ != nullptr && timeoutMs_ > 0) {
-        const std::weak_ptr<int> weakLifetime = lifetimeToken_;
-        const uint64_t delayNs = static_cast<uint64_t>(timeoutMs_) * 1'000'000ULL;
-
-        timeoutToken_ = scheduler_->ScheduleAfter(delayNs, [this, weakLifetime]() {
-            if (weakLifetime.expired()) {
-                return;
-            }
-            timeoutToken_ = kInvalidSchedulerToken;
-            OnTimeout();
-        });
-    }
 }
 
 void SBP2ManagementORB::OnStatusBlockWrite(uint32_t offset,

--- a/ASFWDriver/Protocols/SBP2/SBP2ManagementORB.cpp
+++ b/ASFWDriver/Protocols/SBP2/SBP2ManagementORB.cpp
@@ -184,7 +184,14 @@ bool SBP2ManagementORB::Execute() noexcept {
         gen, node, mgmtAddr,
         std::span<const uint8_t>{orbAddressBE_.data(), orbAddressBE_.size()},
         speed,
-        [this](Async::AsyncStatus status, std::span<const uint8_t> response) {
+        [this, weak = std::weak_ptr<int>(lifetimeToken_)](
+            Async::AsyncStatus status, std::span<const uint8_t> response) {
+            // The timeout is armed before this write, so OnTimeout can fire —
+            // and Complete() can destroy the ORB — while the write is still
+            // in flight. Guard like the timer lambda above.
+            if (weak.expired()) {
+                return;
+            }
             OnWriteComplete(status, response);
         });
 

--- a/tests/protocols/SBP2ORBTests.cpp
+++ b/tests/protocols/SBP2ORBTests.cpp
@@ -201,6 +201,41 @@ TEST(SBP2ORBTests, ManagementORBTimesOutWhenAgentWriteNeverCompletes) {
     EXPECT_EQ(-2, completionStatus);
 }
 
+TEST(SBP2ORBTests, ManagementORBTimeoutWithWriteInFlightThenLateWriteCompletion) {
+    // With the timeout armed before the agent write (Execute, not
+    // OnWriteComplete), OnTimeout can fire while the write is still in
+    // flight. CommandExecutor destroys the ORB from the completion callback,
+    // so the late write completion must not touch the freed object.
+    // Run under ASan to make the use-after-free observable.
+    ORBTimerRig rig;
+
+    auto orb = std::make_unique<SBP2ManagementORB>(rig.bus, rig.bus, rig.addressManager,
+                                                   reinterpret_cast<void*>(0x8));
+    orb->SetFunction(SBP2ManagementORB::Function::LogicalUnitReset);
+    orb->SetLoginID(0x12);
+    orb->SetManagementAgentOffset(0x80);
+    orb->SetTargetNode(1, 0x3F);
+    orb->SetTimeout(5);
+    orb->SetScheduler(&rig.scheduler);
+
+    int completionStatus = 99;
+    orb->SetCompletionCallback([&](int status) {
+        completionStatus = status;
+        orb.reset();                  // what CommandExecutor.cpp does
+    });
+
+    ASSERT_TRUE(orb->Execute());
+    ASSERT_EQ(1u, rig.bus.PendingWriteCount());
+
+    rig.AdvanceMs(5);                 // timeout fires; ORB destroys itself
+    EXPECT_EQ(-2, completionStatus);
+    EXPECT_EQ(nullptr, orb.get());
+
+    // AT layer resolves the transaction afterwards — real late ACK, or
+    // kIOReturnTimeout from the AT watchdog.
+    EXPECT_TRUE(rig.bus.CompleteNextWrite(ASFW::Async::AsyncStatus::kTimeout));
+}
+
 TEST(SBP2ORBTests, ManagementORBUsesFullBusNodeIdInEmbeddedAddresses) {
     ORBTimerRig rig;
 

--- a/tests/protocols/SBP2ORBTests.cpp
+++ b/tests/protocols/SBP2ORBTests.cpp
@@ -175,6 +175,32 @@ TEST(SBP2ORBTests, ManagementORBStatusWriteCancelsTimeout) {
     EXPECT_EQ(0, completionStatus);
 }
 
+TEST(SBP2ORBTests, ManagementORBTimesOutWhenAgentWriteNeverCompletes) {
+    // Regression: a wedged target whose fetch/management engine stops ACKing
+    // can strand the agent write without a completion. The ORB timeout must
+    // cover that window too (armed in Execute, not OnWriteComplete) —
+    // otherwise the LUN-reset escalation hangs forever (observed: LS-4000).
+    ORBTimerRig rig;
+
+    SBP2ManagementORB orb(rig.bus, rig.bus, rig.addressManager, reinterpret_cast<void*>(0x8));
+    orb.SetFunction(SBP2ManagementORB::Function::LogicalUnitReset);
+    orb.SetLoginID(0x12);
+    orb.SetManagementAgentOffset(0x80);
+    orb.SetTargetNode(1, 0x3F);
+    orb.SetTimeout(5);
+    orb.SetScheduler(&rig.scheduler);
+
+    int completionStatus = 99;
+    orb.SetCompletionCallback([&completionStatus](int status) { completionStatus = status; });
+
+    ASSERT_TRUE(orb.Execute());
+    ASSERT_EQ(1u, rig.bus.PendingWriteCount());
+
+    // Never complete the write — the timer must still fire.
+    rig.AdvanceMs(5);
+    EXPECT_EQ(-2, completionStatus);
+}
+
 TEST(SBP2ORBTests, ManagementORBUsesFullBusNodeIdInEmbeddedAddresses) {
     ORBTimerRig rig;
 


### PR DESCRIPTION
## What's broken

The driver has an internal alarm clock (the async watchdog). Its one job: if a command never gets an answer, give up after a while and report an error.

Since `22c82112` (Aug 5, on main — also shipped in the 0.3.0 release), that clock is never started. The reason is a one-line startup-order bug: the clock refuses to start unless the driver is in the "running" state — but the clock is started *during* startup, before "running" is set (that commit changed the check; `ScheduleAsyncWatchdog` in `ASFWDriver.cpp`). The clock also only re-arms itself from its own tick, so if the first start is skipped, it never ticks at all. No error, no log line — it just silently isn't there.

## When it matters

As long as every device answers every command, the clock is never needed, so day-to-day use looks normal. It only matters when an answer goes missing — a sick device, a flaky cable, a lost interrupt. Then:

- the command waits **forever** instead of failing
- the app that sent it freezes (only force-quit helps)
- the driver's own recovery (reset, re-login) never runs
- each stuck command permanently eats a slice of the driver's resources — enough of them and FireWire stops working entirely until reinstall or reboot

## How we found it

A scanner's power supply died in the middle of a scan, in exactly the way where a timeout is the only possible rescue (the device stayed visible on the bus but stopped answering). VueScan froze permanently. Digging through the logs showed no timeout had fired in the entire session — and the code showed why.

## The fix

Three small changes:

1. Start the clock correctly during startup (allow starting while the driver is starting up, not just when fully running).
2. Make sure the clock can never accidentally stop itself again — a tick that has nothing to do still schedules the next tick. Shutdown stops it the proper way, as before.
3. One SBP-2 timer (management ORB) was started only *after* its command got a reply — so a command with no reply had no timer at all. It now starts before the command is sent.

## Testing

- All 1589 host tests green, plus a new test that fails on the old code.
- Real hardware (Nikon LS-9000, SBP-2): normal scanning works, and pulling the power mid-scan now gives the app an immediate error instead of a freeze.
