### PR TITLE
docs: sync CLAUDE.md and README with shipped SCSI HBA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) and other ai agents 
 
 ## Project Overview
 
-ASFW is a macOS DriverKit-based FireWire (IEEE 1394) driver restoring FireWire functionality removed in macOS Tahoe (26). It uses PCIDriverKit for user-space OHCI controller access and AudioDriverKit for CoreAudio integration. TODO: MIDIDriverKit and SCSIControllerDriverKit. 
+ASFW is a macOS DriverKit-based FireWire (IEEE 1394) driver restoring FireWire functionality removed in macOS Tahoe (26). It uses PCIDriverKit for user-space OHCI controller access, AudioDriverKit for CoreAudio integration, and SCSIControllerDriverKit for SBP-2 mass storage (SCSI HBA, in all builds since v0.3.0). TODO: MIDIDriverKit.
 
 Two components:
 - **ASFWDriver/** — C++23 DriverKit driver extension (dext)
@@ -99,6 +99,7 @@ CoreAudio / HAL
 | `Discovery/` | FireWire device + unit enumeration (`FWDevice`, `FWUnit`) |
 | `Controller/` | Controller state machine and lifecycle |
 | `Protocols/` | `AVC` (FCP, Music Subunit, stream formats, PCR), `SBP2`, `Ports` (register/PCR IO) |
+| `SCSIController/` | SCSI HBA (`IOUserSCSIParallelInterfaceController`): `ASFWSCSIController`, SBP-2 target bridge/nub publication, readiness gating |
 
 **Audio (AudioDriverKit stack)** — owns content format + CIP/61883 framing; must not reach into OHCI/transport mechanics:
 | Directory | Responsibility |
@@ -268,11 +269,9 @@ template the FireWire side.
 
 **Commit and git history.** Keep history traceable. If changes are getting large, warn the user that it is better to commit the current work first; otherwise unrelated logic shifts can become hard to repair or reason about.
 
-**DriverKit Architecture on Apple Silicon (arm64e requirement).** Xcode's default settings or `build.sh` might sometimes build the `ASFWDriver` target as standard `arm64`. However, on Apple Silicon, macOS strictly requires all System Extensions (DriverKit dexts) to be built for **`arm64e`** (Pointer Authentication ABI). If the driver is built as `arm64`, it will lack an `LC_MAIN` entry point and `kernelmanagerd` will instantly reject it on hardware attach with `OS_REASON_EXEC` / `ENOEXEC` (Exec format error). Always ensure `ARCHS = "x86_64 arm64e";` is explicitly set in the DriverKit target's `project.pbxproj` build settings!
+**DriverKit Architecture on Apple Silicon (arm64e requirement).** Xcode's default settings or `build.sh` might sometimes build the `ASFWDriver` target as standard `arm64`. However, on Apple Silicon, macOS strictly requires all System Extensions (DriverKit dexts) to be built for **`arm64e`** (Pointer Authentication ABI). If the driver is built as `arm64`, it will lack an `LC_MAIN` entry point and `kernelmanagerd` will instantly reject it on hardware attach with `OS_REASON_EXEC` / `ENOEXEC` (Exec format error). Always ensure `ARCHS: x86_64 arm64e` is explicitly set for the DriverKit target in `project.yml` (the pbxproj is generated and gitignored)!
 
 **Code Signing and Hardened Runtime.** If you use Ad-Hoc signing (`CODE_SIGN_IDENTITY="-"`) for local testing (with `amfi_get_out_of_my_way=1` in boot-args), you MUST ensure that `ENABLE_HARDENED_RUNTIME = NO` for the DriverKit target. If Hardened Runtime is enabled with an ad-hoc signature, `amfid` will kill the dext on launch (`OS_REASON_EXEC`).
-
-**DriverKit Architecture on Apple Silicon (arm64e requirement).** Xcode's default settings or `build.sh` might sometimes build the `ASFWDriver` target as standard `arm64`. However, on Apple Silicon, macOS strictly requires all System Extensions (DriverKit dexts) to be built for **`arm64e`** (Pointer Authentication ABI). If the driver is built as `arm64`, it will lack an `LC_MAIN` entry point and `kernelmanagerd` will instantly reject it on hardware attach with `OS_REASON_EXEC` / `ENOEXEC` (Exec format error). Always ensure `ARCHS = "x86_64 arm64e";` is explicitly set in the DriverKit target's `project.pbxproj` build settings!
 
 ## Code Patterns
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ This project is in active development. The following features are implemented:
 - Host-controlled sample-rate switching (44.1 kHz / 48 kHz) driven from the device's advertised clock capabilities, including live rate changes on CoreAudio aggregate devices clocked by the FireWire interface
 - DICE per-channel naming (device nickname plus TX/RX channel labels) surfaced to CoreAudio
 - DV (IEC 61883-2) capture from MiniDV camcorders to raw `.dv` files, with AV/C tape transport control (play/stop/rewind) from the app. DV capture and audio receive are mutually exclusive — both use IR context 0
+- SBP-2 mass storage through the built-in SCSI HBA (`ASFWSCSIControllerService`), exposing FireWire scanners and disks as regular SCSI devices (see [SCSI HBA](#scsi-hba-sbp-2-scannersdisks))
 
 ## Driver initialization (high level)
 
@@ -386,6 +387,10 @@ The driver is organized into functional subsystems:
 - **Protocols/SBP2/** — SBP-2 (storage) protocol: command ORBs, management ORBs, address space management, page tables.
 - **Protocols/Ports/** — Protocol port abstractions (FireWire bus port, RX port, register I/O).
 
+**SCSI HBA:**
+
+- **SCSIController/** — SCSI host adapter (`IOUserSCSIParallelInterfaceController`): controller service, SBP-2 target bridge and nub publication, target readiness gating.
+
 **Supporting subsystems:**
 
 - **DeviceProfiles/** — Device identity and audio profile registry. Vendor-specific profiles for Focusrite, Apogee, Alesis, PreSonus, and Midas.
@@ -541,8 +546,8 @@ You can reach me via:
 
 ## References
 
-- [Apple DriverKit Documentation](https://developer.apple.com/documentation/driverkit) - NB. Oficcial documentation on Apple Developer website is incomplete and sometimes outdated. Refer to header files in DriverKit SDK for more accurate information.
-- [Apple PCIDriverKit Documentation](https://developer.apple.com/documentation/pcidriverkit) s- Same as above
+- [Apple DriverKit Documentation](https://developer.apple.com/documentation/driverkit) - NB. Official documentation on Apple Developer website is incomplete and sometimes outdated. Refer to header files in DriverKit SDK for more accurate information.
+- [Apple PCIDriverKit Documentation](https://developer.apple.com/documentation/pcidriverkit) — Same as above
 - [System Extensions and DriverKit](https://developer.apple.com/videos/play/wwdc2019/702/) — WWDC 2019 session introducing DriverKit and system extensions.
 - [Modernize PCI and SCSI drivers with DriverKit](https://developer.apple.com/videos/play/wwdc2020/10670/) — Small but informative WWDC 2020 session about modernizing PCI and SCSI drivers.
 - [IEEE 1394-2008 Standard](https://standards.ieee.org/ieee/1394/4377/) — Latest edition. This is most complete reference about FireWire 


### PR DESCRIPTION
Documentation-only sync now that the SCSI HBA ships in every build (since #96 / v0.3.0):

**CLAUDE.md**
- SCSIControllerDriverKit is no longer listed as a TODO; `SCSIController/` added to the subsystem table
- Removed an accidentally duplicated paragraph (the arm64e requirement appeared twice)
- The arm64e ARCHS guidance now points at `project.yml` instead of the generated, gitignored pbxproj

**README**
- SBP-2 mass storage via the SCSI HBA added to *What currently works*
- `SCSIController/` added to the driver structure overview
- Two small typos fixed in *References*

No code changes.